### PR TITLE
Make window components draggable / moveable

### DIFF
--- a/src/components/FeatureInfoWindow.vue
+++ b/src/components/FeatureInfoWindow.vue
@@ -91,8 +91,4 @@ export default {
     background-color: white;
   }
 
-  .wgu-feature-infowindow > nav {
-    cursor: move;
-  }
-
 </style>

--- a/src/components/FeatureInfoWindow.vue
+++ b/src/components/FeatureInfoWindow.vue
@@ -2,7 +2,9 @@
 
     <v-card
       class="wgu-feature-infowindow info-card"
-      v-if="this.feature !== null" >
+      v-draggable-win
+      v-if="this.feature !== null"
+      v-bind:style="{ left: left, top: top }" >
 
         <v-toolbar class="red darken-3 white--text" dark>
           <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
@@ -25,10 +27,14 @@
 
 <script>
 
-import { WguEventBus } from '../WguEventBus.js'
+import { WguEventBus } from '../WguEventBus.js';
+import { DraggableWin } from '../directives/DraggableWin.js';
 
 export default {
   name: 'wgu-feature-info-window',
+  directives: {
+    DraggableWin
+  },
   props: {
     layerId: {type: String, required: true},
     imageProp: {type: String, required: false},
@@ -40,7 +46,9 @@ export default {
     return {
       // will be filled in mounted
       feature: null,
-      attributes: null
+      attributes: null,
+      left: '300px',
+      top: '200px'
     }
   },
   mounted () {
@@ -79,10 +87,12 @@ export default {
 
   .wgu-feature-infowindow.info-card {
     position: absolute;
-    bottom: 130px;
-    right: 10px;
     width: 300px;
     background-color: white;
+  }
+
+  .wgu-feature-infowindow > nav {
+    cursor: move;
   }
 
 </style>

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -57,8 +57,4 @@
       position: absolute;
   }
 
-  .wgu-helpwin.card > nav {
-    cursor: move;
-  }
-
 </style>

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="wgu-helpwin" v-if=show>
+  <v-card v-draggable-win class="wgu-helpwin" v-if=show v-bind:style="{ left: left, top: top }">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>help</v-icon></v-toolbar-side-icon>
       <v-toolbar-title>Help</v-toolbar-title>
@@ -22,12 +22,18 @@
 
 <script>
   // Import the EventBus
-  import { WguEventBus } from '../../WguEventBus.js'
+  import { WguEventBus } from '../../WguEventBus.js';
+  import { DraggableWin } from '../../directives/DraggableWin.js';
 
   export default {
+    directives: {
+      DraggableWin
+    },
     data () {
       return {
-        show: false
+        show: false,
+        left: '200px',
+        top: '200px'
       }
     },
     created () {
@@ -43,14 +49,16 @@
 <style>
 
   .wgu-helpwin {
-    bottom: 10px;
-    left: calc(50% - 150px);
     background-color: white;
     z-index: 2;
   }
 
   .wgu-helpwin.card {
       position: absolute;
+  }
+
+  .wgu-helpwin.card > nav {
+    cursor: move;
   }
 
 </style>

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -140,10 +140,6 @@
       position: absolute;
   }
 
-  .wgu-layerlist > nav {
-    cursor: move;
-  }
-
   .wgu-layerlist-item a.list__tile {
     padding-left: 0;
   }

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="wgu-layerlist" v-if=show>
+  <v-card v-draggable-win class="wgu-layerlist" v-if=show v-bind:style="{ left: left, top: top }">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>layers</v-icon></v-toolbar-side-icon>
       <v-toolbar-title>Layers</v-toolbar-title>
@@ -24,8 +24,12 @@
 <script>
   // Import the EventBus
   import { WguEventBus } from '../../WguEventBus.js'
+  import { DraggableWin } from '../../directives/DraggableWin.js';
 
   export default {
+    directives: {
+      DraggableWin
+    },
     data () {
       return {
         // will be filled in mounted
@@ -33,7 +37,10 @@
         // will be filled in mounted and adapted by the layer checkboxes
         visibleLayers: [],
 
-        show: false
+        show: false,
+
+        left: '300px',
+        top: '70px'
       }
     },
     created () {
@@ -126,13 +133,15 @@
 <style>
 
   .wgu-layerlist {
-    bottom: 130px;
-    left: 10px;
     background-color: white;
     z-index: 2;
   }
   .wgu-layerlist.card {
       position: absolute;
+  }
+
+  .wgu-layerlist > nav {
+    cursor: move;
   }
 
   .wgu-layerlist-item a.list__tile {

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -249,10 +249,6 @@
     z-index: 2;
   }
 
-  .vwg-measurewin > nav {
-    cursor: move;
-  }
-
   .measure-result {
     font-size: 14px;
     padding-left: 8px;

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="vwg-measurewin" v-if=show>
+  <v-card v-draggable-win class="vwg-measurewin" v-if=show v-bind:style="{ left: left, top: top }">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>photo_size_select_small</v-icon></v-toolbar-side-icon>
       <v-toolbar-title>Measure</v-toolbar-title>
@@ -37,6 +37,7 @@
 <script>
   // Import the EventBus
   import { WguEventBus } from '../../WguEventBus.js'
+  import { DraggableWin } from '../../directives/DraggableWin.js';
   import DrawInteraction from 'ol/interaction/draw'
   import LineStringGeom from 'ol/geom/linestring'
   import PolygonGeom from 'ol/geom/polygon'
@@ -50,12 +51,17 @@
   import Fill from 'ol/style/fill'
 
   export default {
+    directives: {
+      DraggableWin
+    },
     data () {
       return {
         area: ' -- ',
         distance: ' -- ',
         measureType: 'distance',
-        show: false
+        show: false,
+        left: '10px',
+        top: '130px'
       }
     },
     created () {
@@ -239,10 +245,12 @@
 
   .vwg-measurewin {
     position: absolute;
-    top: 130px;
-    right: 10px;
     background-color: white;
     z-index: 2;
+  }
+
+  .vwg-measurewin > nav {
+    cursor: move;
   }
 
   .measure-result {

--- a/src/directives/DraggableWin.js
+++ b/src/directives/DraggableWin.js
@@ -1,0 +1,53 @@
+import Vue from 'vue';
+
+/**
+ * Directive to make a window component draggable by dragging it's header.
+ * Proudly inspired by https://www.w3schools.com/howto/howto_js_draggable.asp
+ */
+export const DraggableWin = {
+  bind (elmnt, binding, vnode) {
+    var pos1 = 0;
+    var pos2 = 0;
+    var pos3 = 0;
+    var pos4 = 0;
+
+    // get the header element to bind the events on it
+    var header = elmnt.querySelector('nav');
+    if (!header) {
+      return;
+    }
+    header.onmousedown = dragMouseDown;
+
+    function dragMouseDown (e) {
+      e = e || window.event;
+      // get the mouse cursor position at startup:
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      document.onmouseup = closeDragElement;
+      // call a function whenever the cursor moves:
+      document.onmousemove = elementDrag;
+    }
+
+    function elementDrag (e) {
+      e = e || window.event;
+      // calculate the new cursor position:
+      pos1 = pos3 - e.clientX;
+      pos2 = pos4 - e.clientY;
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+
+      // set the Vue component's new position:
+      vnode.componentInstance.$parent.top = (elmnt.offsetTop - pos2) + 'px';
+      vnode.componentInstance.$parent.left = (elmnt.offsetLeft - pos1) + 'px';
+    }
+
+    function closeDragElement () {
+      // stop moving when mouse button is released
+      document.onmouseup = null;
+      document.onmousemove = null;
+    }
+  }
+};
+
+// Make directive available globally
+Vue.directive('draggable-win', DraggableWin);

--- a/src/directives/DraggableWin.js
+++ b/src/directives/DraggableWin.js
@@ -16,6 +16,10 @@ export const DraggableWin = {
     if (!header) {
       return;
     }
+
+    // set cursor so it's signal that the user can drag the window
+    header.style.cursor = 'move';
+
     header.onmousedown = dragMouseDown;
 
     function dragMouseDown (e) {


### PR DESCRIPTION
This PR improves the window components, so they can be dragged by the user to any position within the application.

The dragging behavior is implemented in a Vue directive, so it can be be added to any window by setting the tag ``v-draggable-win`` in the template. 