### PR TITLE
 Make WebGIS-Viewer embeddable

### DIFF
--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -30,6 +30,11 @@ module.exports = merge(baseWebpackConfig, {
       template: 'index.html',
       inject: true
     }),
+    new HtmlWebpackPlugin({
+      filename: 'embedded.html',
+      template: 'embedded.html',
+      inject: true
+    }),
     new FriendlyErrorsPlugin()
   ]
 })

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -67,6 +67,25 @@ var webpackConfig = merge(baseWebpackConfig, {
       // necessary to consistently work with multiple chunks via CommonsChunkPlugin
       chunksSortMode: 'dependency'
     }),
+    // generate dist embedded.html with correct asset hash for caching.
+    // you can customize output by editing /embedded.html
+    // see https://github.com/ampedandwired/html-webpack-plugin
+    new HtmlWebpackPlugin({
+      filename: process.env.NODE_ENV === 'testing'
+        ? 'embedded.html'
+        : config.build.embedded,
+      template: 'embedded.html',
+      inject: true,
+      minify: {
+        removeComments: true,
+        collapseWhitespace: true,
+        removeAttributeQuotes: true
+        // more options:
+        // https://github.com/kangax/html-minifier#options-quick-reference
+      },
+      // necessary to consistently work with multiple chunks via CommonsChunkPlugin
+      chunksSortMode: 'dependency'
+    }),
     // keep module.id stable when vender modules does not change
     new webpack.HashedModuleIdsPlugin(),
     // split vendor js into its own file

--- a/config/index.js
+++ b/config/index.js
@@ -5,6 +5,7 @@ module.exports = {
   build: {
     env: require('./prod.env'),
     index: path.resolve(__dirname, '../dist/index.html'),
+    embedded: path.resolve(__dirname, '../dist/embedded.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',

--- a/embedded.html
+++ b/embedded.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>Wegue WebGIS Embedded</title>
+
+    <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
+
+  </head>
+  <body>
+    <div id="container" class="" style="width: 800px; height: 600px; padding: 20px;">
+      <div id="app" embedded></div>
+    </div>
+    <!-- built files will be auto injected -->
+  </body>
+</html>

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="wgu-app" data-app>
+  <div id="app" data-app :class="{ 'wgu-app': true, 'wgu-app-embedded': isEmbedded }">
 
       <wgu-app-header
         title="Vue.js / OpenLayers WebGIS">
@@ -72,6 +72,7 @@
 </template>
 
 <script>
+
 import OlMap from './components/ol/Map'
 import OsmLayer from './components/ol/LayerOsm'
 import TileWmsLayer from './components/ol/LayerTileWms'
@@ -102,6 +103,15 @@ export default {
     'wgu-toggle-layerlist-button': LayerListToggleButton,
     'wgu-toggle-helpwin-button': HelpWinToggleButton,
     'wgu-toggle-measuretool-button': MeasureToolToggleButton
+  },
+  data () {
+    return {
+      isEmbedded: false
+    }
+  },
+  mounted () {
+    // apply the isEmbedded state to the member var
+    this.isEmbedded = this.$isEmbedded;
   }
 }
 </script>

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -6,18 +6,27 @@ html {
 
 .wgu-app {
   font-family: 'Avenir', Helvetica, Arial, sans-serif;
+  position: relative;
   width: 100vw;
   height: 100vh;
   display: flex;
   flex-direction: column;
+}
+.wgu-app-embedded {
+  width: 100%;
+  height: 100%;
+  border: 2px solid grey;
 }
 
 .wgu-app .wgu-map {
   /* temp. solution since flex: 1 doe not work as expected */
   height: calc(100vh - 56px);
 }
+.wgu-app-embedded .wgu-map {
+  height: calc(100% - 56px);
+}
 
 .wgu-top-logo {
   left: 25px;
-  top: 50px;
+  top: 45px;
 }

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="map wgu-map" id="map">
+    <div class="map wgu-map" id="ol-map">
       <!--This <slot> is going to be replaced by the map-layer configuration
           tags in the app (see App.vue) -->
       <slot name="map-layers">No map layers provided!</slot>
@@ -23,14 +23,18 @@ export default {
     collapsibleAttribution: {type: Boolean, default: false}
   },
   mounted () {
-    this.map.setTarget(document.getElementById('map'))
+    this.map.setTarget(document.getElementById('ol-map'))
 
     // Send the event 'ol-map-mounted' with the OL map as payload
     WguEventBus.$emit('ol-map-mounted', this.map)
+
+    // resize the map, so it fits to parent
+    window.setTimeout(() => {
+      this.map.updateSize();
+    }, 100);
   },
   created () {
     this.map = new Map({
-      target: 'map',
       layers: [
       ],
       controls: [
@@ -53,7 +57,7 @@ export default {
 <style>
   .wgu-map .ol-zoom {
     top: auto;
-    left:auto;
+    left: auto;
     bottom: 3em;
     right: 0.5em;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -13,9 +13,15 @@ require('./assets/css/wegue.css')
 
 Vue.config.productionTip = false
 
+// Detect isEmbedded state by attribute embedded and
+// make accessible for all components
+// recommended by https://vuejs.org/v2/cookbook/adding-instance-properties.html
+const appEl = document.querySelector('#app');
+Vue.prototype.$isEmbedded = appEl.hasAttribute('embedded');
+
 /* eslint-disable no-new */
 new Vue({
   el: '#app',
   template: '<wgu-app/>',
   components: { WguApp }
-})
+});


### PR DESCRIPTION
This reworks the viewer setup, so it is also possible to embed the WebGIS-viewer in an arbitrary sized parent element instead of 'just' acting as fullscreen application. So it becomes more easy to use Wegue based WebGIS-applications in "parent-applications", e.g. a CMS. 

To put the viewer in an 'embedded' state add the attribute ``embedded`` to the element with the ID ``app``.

```html
    <div id="container" style="width: 800px; height: 600px; padding: 20px;">
      <div id="app" embedded></div>
    </div>
```
This results in an embedded viewer setup, like this:

![image](https://user-images.githubusercontent.com/1185547/36855119-0e3c7f66-1d73-11e8-92ea-d278bf8885cc.png)

