### PR TITLE
 Configure app with JSON based config

### DIFF
--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -23,7 +23,7 @@
         </v-toolbar-items>
       </wgu-app-header>
 
-      <wgu-top-logo logoSrc="https://www.placecage.com/100/100" />
+      <wgu-top-logo />
 
       <wgu-map :zoom="2" />
 

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -25,7 +25,7 @@
 
       <wgu-top-logo />
 
-      <wgu-map :zoom="2" />
+      <wgu-map />
 
       <wgu-feature-infowindow
         layerId="Shops"

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -26,34 +26,7 @@
 
       <wgu-top-logo logoSrc="https://www.placecage.com/100/100" />
 
-      <wgu-map :zoom="2">
-
-        <wgu-layer-osm slot="map-layers" :opacity="1.0" name="OSM"/>
-
-        <wgu-layer-vectortiles slot="map-layers"
-          name="Vector Tile Layer"
-          url="https://basemaps.arcgis.com/v1/arcgis/rest/services/World_Basemap/VectorTileServer/tile/{z}/{y}/{x}.pbf"
-          format="MVT"
-          hidden
-        />
-
-        <wgu-layer-tilewms slot="map-layers"
-          name="WMS (ahocevar)"
-          url="https://ahocevar.com/geoserver/wms"
-          layers="topp:states"
-          tiled
-        />
-
-        <wgu-layer-vector slot="map-layers"
-          name="Shops"
-          url="./static/data/shops-dannstadt.geojson"
-          format="GeoJSON"
-          :formatConfig="{}"
-          selectable
-          styleRef="shopStyle"
-        />
-
-      </wgu-map>
+      <wgu-map :zoom="2" />
 
       <wgu-feature-infowindow
         layerId="Shops"
@@ -69,10 +42,6 @@
 <script>
 
 import OlMap from './components/ol/Map'
-import OsmLayer from './components/ol/LayerOsm'
-import TileWmsLayer from './components/ol/LayerTileWms'
-import VectorLayer from './components/ol/LayerVector'
-import VectorTileLayer from './components/ol/LayerVectorTiles'
 import InfoWindow from './components/InfoWindow'
 import FeatureInfoWindow from './components/FeatureInfoWindow'
 import AppHeader from './components/AppHeader'
@@ -86,10 +55,6 @@ export default {
   name: 'app',
   components: {
     'wgu-map': OlMap,
-    'wgu-layer-osm': OsmLayer,
-    'wgu-layer-tilewms': TileWmsLayer,
-    'wgu-layer-vector': VectorLayer,
-    'wgu-layer-vectortiles': VectorTileLayer,
     'wgu-info-window': InfoWindow,
     'wgu-feature-infowindow': FeatureInfoWindow,
     'wgu-app-header': AppHeader,

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -1,8 +1,7 @@
 <template>
   <div id="app" data-app :class="{ 'wgu-app': true, 'wgu-app-embedded': isEmbedded }">
 
-      <wgu-app-header
-        title="Vue.js / OpenLayers WebGIS">
+      <wgu-app-header>
 
         <v-toolbar-items slot="wgu-tb-buttons" class="">
 

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -15,11 +15,9 @@
 
 export default {
   name: 'wgu-app-header',
-  props: {
-    title: {type: String, required: false, default: ''}
-  },
   data () {
     return {
+      title: this.$appConfig.title
     }
   },
   mounted () {

--- a/src/components/FeatureInfoWindow.vue
+++ b/src/components/FeatureInfoWindow.vue
@@ -55,8 +55,8 @@ export default {
     var me = this;
 
     // listen to selection events of connected layer and apply attributes
-    WguEventBus.$on('map-selectionchange', function (layerName, selected, deselected) {
-      if (me.layerId === layerName) {
+    WguEventBus.$on('map-selectionchange', function (layerId, selected, deselected) {
+      if (me.layerId === layerId) {
         me.setFeature(selected[0]);
       }
     });

--- a/src/components/TopLogo.vue
+++ b/src/components/TopLogo.vue
@@ -14,9 +14,11 @@
 
 export default {
   name: 'wgu-top-logo',
-  props: {
-    logoSrc: {type: String, required: true},
-    logoSize: {type: Number, required: false, default: 100}
+  data () {
+    return {
+      logoSrc: this.$appConfig.logo,
+      logoSize: this.$appConfig.logoSize
+    }
   }
 }
 </script>

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -15,9 +15,13 @@ import { LayerFactory } from '../../factory/Layer.js'
 export default {
   name: 'wgu-map',
   props: {
-    zoom: {type: Number, default: 0},
-    center: {type: Array},
     collapsibleAttribution: {type: Boolean, default: false}
+  },
+  data () {
+    return {
+      zoom: this.$appConfig.mapZoom,
+      center: this.$appConfig.mapCenter
+    }
   },
   mounted () {
     this.map.setTarget(document.getElementById('ol-map'))

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -1,9 +1,5 @@
 <template>
-    <div class="map wgu-map" id="ol-map">
-      <!--This <slot> is going to be replaced by the map-layer configuration
-          tags in the app (see App.vue) -->
-      <slot name="map-layers">No map layers provided!</slot>
-    </div>
+    <div class="map wgu-map" id="ol-map"></div>
 </template>
 
 <script>
@@ -14,6 +10,7 @@ import Attribution from 'ol/control/attribution';
 import Zoom from 'ol/control/zoom';
 // import the app-wide EventBus
 import { WguEventBus } from '../../WguEventBus.js'
+import { LayerFactory } from '../../factory/Layer.js'
 
 export default {
   name: 'wgu-map',
@@ -34,9 +31,10 @@ export default {
     }, 100);
   },
   created () {
+    const layers = this.createLayers();
+
     this.map = new Map({
-      layers: [
-      ],
+      layers: layers,
       controls: [
         new Zoom(),
         new Attribution({
@@ -48,6 +46,22 @@ export default {
         zoom: this.zoom
       })
     });
+  },
+
+  methods: {
+    /**
+     * Creates the OL layers due to the "mapLayers" array in app config.
+     * @return {ol.layer.Base[]} Array of OL layer instances
+     */
+    createLayers () {
+      let layers = [];
+      this.$appConfig.mapLayers.reverse().forEach(function (lConf) {
+        let layer = LayerFactory.getInstance(lConf);
+        layers.push(layer);
+      });
+
+      return layers;
+    }
   }
 
 }

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -43,6 +43,8 @@ export const LayerFactory = {
     // create correct layer type
     if (lConf.type === 'WMS') {
       return this.createWmsLayer(lConf);
+    } else if (lConf.type === 'XYZ') {
+      return this.createXyzLayer(lConf);
     } else if (lConf.type === 'OSM') {
       return this.createOsmLayer(lConf);
     } else if (lConf.type === 'VECTOR') {
@@ -79,6 +81,24 @@ export const LayerFactory = {
     });
 
     return layer;
+  },
+
+  /**
+   * Returns an OpenLayers XYZ layer instance due to given config.
+   *
+   * @param  {Object} lConf  Layer config object
+   * @return {ol.layer.Tile} OL XYZ layer instance
+   */
+  createXyzLayer (lConf) {
+    const xyzLayer = new TileLayer({
+      extent: lConf.extent,
+      source: new TileWmsSource({
+        url: lConf.url,
+        attributions: lConf.attributions
+      })
+    });
+
+    return xyzLayer;
   },
 
   /**

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -1,0 +1,147 @@
+import TileLayer from 'ol/layer/tile'
+import TileWmsSource from 'ol/source/tilewms'
+import OsmSource from 'ol/source/osm'
+import VectorTileLayer from 'ol/layer/vectortile'
+import VectorTileSource from 'ol/source/vectortile'
+import MvtFormat from 'ol/format/mvt'
+import GeoJsonFormat from 'ol/format/geojson'
+import TopoJsonFormat from 'ol/format/topojson'
+import KmlFormat from 'ol/format/kml'
+import VectorLayer from 'ol/layer/vector'
+import VectorSource from 'ol/source/vector'
+
+/**
+ * Factory, which creates OpenLayers layer instances according to a given config
+ * object.
+ */
+export const LayerFactory = {
+
+  /**
+   * Maps the format literal of the config to the corresponding OL module.
+   * @type {Object}
+   */
+  formatMapping: {
+    'MVT': MvtFormat,
+    'GeoJSON': GeoJsonFormat,
+    'TopoJSON': TopoJsonFormat,
+    'KML': KmlFormat
+  },
+
+  /**
+   * Returns an OpenLayers layer instance due to given config.
+   *
+   * @param  {Object} lConf  Layer config object
+   * @return {ol.layer.Base} OL layer instance
+   */
+  getInstance (lConf) {
+    // apply LID (Layer ID) if not existant
+    if (!lConf.lid) {
+      var now = new Date();
+      lConf.lid = now.getTime();
+    }
+
+    // create correct layer type
+    if (lConf.type === 'WMS') {
+      return this.createWmsLayer(lConf);
+    } else if (lConf.type === 'OSM') {
+      return this.createOsmLayer(lConf);
+    } else if (lConf.type === 'VECTOR') {
+      return this.createVectorLayer(lConf);
+    } else if (lConf.type === 'VECTORTILE') {
+      return this.createVectorTileLayer(lConf);
+    } else {
+      return null;
+    }
+  },
+
+  /**
+   * Returns an OpenLayers WMS layer instance due to given config.
+   *
+   * @param  {Object} lConf  Layer config object
+   * @return {ol.layer.Tile} OL WMS layer instance
+   */
+  createWmsLayer (lConf) {
+    const layer = new TileLayer({
+      name: lConf.name,
+      lid: lConf.lid,
+      extent: lConf.extent,
+      visible: lConf.visible,
+      opacity: lConf.opacity,
+      source: new TileWmsSource({
+        url: lConf.url,
+        params: {
+          'LAYERS': lConf.layers,
+          'TILED': lConf.tiled
+        },
+        serverType: lConf.serverType,
+        attributions: lConf.attributions
+      })
+    });
+
+    return layer;
+  },
+
+  /**
+   * Returns an OpenLayers OSM layer instance due to given config.
+   *
+   * @param  {Object} lConf  Layer config object
+   * @return {ol.layer.Tile} OL OSM layer instance
+   */
+  createOsmLayer (lConf) {
+    const layer = new TileLayer({
+      name: lConf.name,
+      lid: lConf.lid,
+      visible: lConf.visible,
+      opacity: lConf.opacity,
+      source: new OsmSource()
+    });
+
+    return layer;
+  },
+
+  /**
+   * Returns an OpenLayers vector layer instance due to given config.
+   *
+   * @param  {Object} lConf  Layer config object
+   * @return {ol.layer.Vector} OL vector layer instance
+   */
+  createVectorLayer (lConf) {
+    var vectorLayer = new VectorLayer({
+      name: lConf.name,
+      lid: lConf.lid,
+      extent: lConf.extent,
+      visible: lConf.visible,
+      opacity: lConf.opacity,
+      source: new VectorSource({
+        url: lConf.url,
+        format: new this.formatMapping[lConf.format](lConf.formatConfig),
+        attributions: lConf.attributions
+      })
+    });
+
+    return vectorLayer;
+  },
+
+  /**
+   * Returns an OpenLayers vector tile layer instance due to given config.
+   *
+   * @param  {Object} lConf  Layer config object
+   * @return {ol.layer.VectorTile} OL vector tile layer instance
+   */
+  createVectorTileLayer (lConf) {
+    const vtLayer = new VectorTileLayer({
+      name: lConf.name,
+      lid: lConf.lid,
+      visible: lConf.visible,
+      opacity: lConf.opacity,
+      source: new VectorTileSource({
+        url: lConf.url,
+        format: new this.formatMapping[lConf.format](),
+        attributions: lConf.attributions
+      })
+    });
+
+    return vtLayer;
+  }
+
+}

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -9,6 +9,7 @@ import TopoJsonFormat from 'ol/format/topojson'
 import KmlFormat from 'ol/format/kml'
 import VectorLayer from 'ol/layer/vector'
 import VectorSource from 'ol/source/vector'
+import OlStyleDefs from '../style/OlStyleDefs'
 
 /**
  * Factory, which creates OpenLayers layer instances according to a given config
@@ -126,7 +127,7 @@ export const LayerFactory = {
    * @return {ol.layer.Vector} OL vector layer instance
    */
   createVectorLayer (lConf) {
-    var vectorLayer = new VectorLayer({
+    const vectorLayer = new VectorLayer({
       name: lConf.name,
       lid: lConf.lid,
       extent: lConf.extent,
@@ -136,7 +137,8 @@ export const LayerFactory = {
         url: lConf.url,
         format: new this.formatMapping[lConf.format](lConf.formatConfig),
         attributions: lConf.attributions
-      })
+      }),
+      style: OlStyleDefs[lConf.styleRef]
     });
 
     return vectorLayer;

--- a/src/main.js
+++ b/src/main.js
@@ -8,11 +8,11 @@ import 'vuetify/dist/vuetify.min.css'
 
 Vue.use(Vuetify)
 
-require('../node_modules/ol/ol.css')
+require('../node_modules/ol/ol.css');
 
-require('./assets/css/wegue.css')
+require('./assets/css/wegue.css');
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
 // Detect isEmbedded state by attribute embedded and
 // make accessible for all components
@@ -20,9 +20,18 @@ Vue.config.productionTip = false
 const appEl = document.querySelector('#app');
 Vue.prototype.$isEmbedded = appEl.hasAttribute('embedded');
 
-/* eslint-disable no-new */
-new Vue({
-  el: '#app',
-  template: '<wgu-app/>',
-  components: { WguApp }
-});
+fetch('static/app-conf.json')
+  .then(function (response) {
+    return response.json();
+  })
+  .then(function (appConfig) {
+    // make app config accessible for all components
+    Vue.prototype.$appConfig = appConfig;
+
+    /* eslint-disable no-new */
+    new Vue({
+      el: '#app',
+      template: '<wgu-app/>',
+      components: { WguApp }
+    });
+  });

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -12,6 +12,7 @@
 
     {
       "type": "VECTOR",
+      "lid": "Shops",
       "name": "Shops DaSchau",
       "url": "./static/data/shops-dannstadt.geojson",
       "formatConfig": {

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -2,6 +2,9 @@
 
   "title": "Vue.js / OpenLayers WebGIS",
 
+  "logo": "https://www.placecage.com/100/100",
+  "logoSize": "200",
+
   "mapZoom": 2,
   "mapCenter": [0, 0],
 

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -1,5 +1,8 @@
 {
 
+  "mapZoom": 2,
+  "mapCenter": [0, 0],
+
   "mapLayers": [
 
     {

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -1,5 +1,7 @@
 {
 
+  "title": "Vue.js / OpenLayers WebGIS",
+
   "mapZoom": 2,
   "mapCenter": [0, 0],
 

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -1,0 +1,52 @@
+{
+
+  "mapLayers": [
+
+    {
+      "type": "VECTOR",
+      "name": "Shops DaSchau",
+      "url": "./static/data/shops-dannstadt.geojson",
+      "formatConfig": {
+      },
+      "format": "GeoJSON",
+      "visible": true,
+      "selectable": true,
+      "styleRef": "shopStyle"
+    },
+
+    {
+      "type": "VECTORTILE",
+      "name": "Vector Tile Layer",
+      "url": "https://basemaps.arcgis.com/v1/arcgis/rest/services/World_Basemap/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+      "format": "MVT",
+      "visible": false
+    },
+
+    {
+      "type": "WMS",
+      "lid": "ahocevar-wms",
+      "name": "WMS (ahocevar)",
+      "format": "image/png",
+      "layers": "topp:states",
+      "url": "https://ahocevar.com/geoserver/wms",
+      "transparent": true,
+      "singleTile": false,
+      "projection": "EPSG:3857",
+      "attribution": "",
+      "isBaseLayer": false,
+      "visibility": false,
+      "displayInLayerList": true
+    },
+
+    {
+      "type": "OSM",
+      "lid": "osm-bg",
+      "name": "OSM",
+      "isBaseLayer": false,
+      "visibility": true,
+      "displayInLayerList": true
+    }
+
+  ]
+
+}


### PR DESCRIPTION
This reworks the application creation in a way that at the startup an application configuration is loaded. The app config is a JSON document, which holds information to influence the initial state of the application, e.g.:

  - Map Center
  - Map Zoom
  - Layers and their Properties
  - Application Title
  - Application Logo URL and Size

This has the advantage that the initial state of the application can be changed without building and deploying the app.

The JSON looks like:

```javascript
{

  "title": "Vue.js / OpenLayers WebGIS",

  "logo": "https://www.placecage.com/100/100",
  "logoSize": "200",

  "mapZoom": 2,
  "mapCenter": [0, 0],

  "mapLayers": [
    {
      "type": "WMS",
      "lid": "ahocevar-wms",
      "name": "WMS (ahocevar)",
      "format": "image/png",
      "layers": "topp:states",
      "url": "https://ahocevar.com/geoserver/wms",
      "transparent": true,
      "singleTile": false,
      "projection": "EPSG:3857",
      "attribution": "",
      "isBaseLayer": false,
      "visibility": false,
      "displayInLayerList": true
    }
    //...
  ]
}
```

