### PR TITLE
Add "Map Info Click" component

### DIFF
--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -15,6 +15,11 @@
               text=""
             />
 
+            <wgu-toggle-infoclick-button
+              icon="info"
+              text=""
+            />
+
             <wgu-toggle-helpwin-button
               icon="help"
               text=""
@@ -49,6 +54,7 @@ import MenuButton from './components/MenuButton'
 import LayerListToggleButton from './components/layerlist/ToggleButton'
 import HelpWinToggleButton from './components/helpwin/ToggleButton'
 import MeasureToolToggleButton from './components/measuretool/ToggleButton'
+import InfoClickButton from './components/infoclick/ToggleButton'
 
 export default {
   name: 'app',
@@ -61,7 +67,8 @@ export default {
     'wgu-menubutton': MenuButton,
     'wgu-toggle-layerlist-button': LayerListToggleButton,
     'wgu-toggle-helpwin-button': HelpWinToggleButton,
-    'wgu-toggle-measuretool-button': MeasureToolToggleButton
+    'wgu-toggle-measuretool-button': MeasureToolToggleButton,
+    'wgu-toggle-infoclick-button': InfoClickButton
   },
   data () {
     return {

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -1,0 +1,195 @@
+<template>
+
+  <div class="">
+
+    <v-card v-draggable-win class="wgu-infoclick-win" v-if=show v-bind:style="{ left: left, top: top }">
+      <v-toolbar class="red darken-3 white--text" dark>
+        <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
+        <v-toolbar-title>Map Click Info</v-toolbar-title>
+        <v-spacer></v-spacer>
+      </v-toolbar>
+      <v-card-title primary-title>
+
+        <div v-if="this.gridData === null && this.coordsData === null" class="no-data">
+          Click on the map to get information for the clicked map position.
+        </div>
+
+        <!-- feature property grid -->
+        <table v-if="this.gridData !== null">
+          <thead>
+            <tr>
+              <th v-for="entry in gridData"
+              </th>
+            </tr>
+          </thead>
+          <tbody class="attr-tbody">
+            <tr v-for="(value, key) in gridData">
+              <td>
+                {{key}}
+              </td>
+              <td>
+                {{value}}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table class="coords" v-if="this.coordsData !== null">
+          <thead>
+            <tr>
+              <th v-for="entry in coordsData"
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(value, key) in coordsData">
+              <td>
+                {{key}}
+              </td>
+              <td>
+                {{value}}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </v-card-title>
+    </v-card>
+
+  </div>
+
+</template>
+
+<script>
+
+import { WguEventBus } from '../../WguEventBus.js'
+import olProj from 'ol/proj'
+import olCoordinate from 'ol/coordinate'
+
+export default {
+  name: 'wgu-infoclick-win',
+  data: function () {
+    return {
+      show: false,
+      icon: 'info',
+      text: '',
+      left: '300px',
+      top: '300px',
+      coordsMapProj: '',
+      coordsWgs84: '',
+      coordsHdms: '',
+      gridData: null,
+      coordsData: null
+    }
+  },
+  created () {
+    var me = this;
+    // Listen to the ol-map-mounted event and receive the OL map instance
+    WguEventBus.$on('ol-map-mounted', (olMap) => {
+      // make the OL map accesible in this component
+      me.map = olMap;
+    });
+  },
+  methods: {
+    toggleUi () {
+      this.show = !this.show;
+    },
+    registerMapClick () {
+      var me = this;
+
+      me.map.on('singleclick', (evt) => {
+        var featureLayer = me.map.forEachFeatureAtPixel(evt.pixel,
+          function (feature, layer) {
+            return [feature, layer];
+          });
+
+        if (featureLayer) {
+          var feat = featureLayer[0];
+          var props = feat.getProperties();
+
+          delete props.geometry;
+
+          me.gridData = props;
+        } else {
+          me.gridData = null;
+        }
+
+        var coordinates = evt.coordinate;
+        var mapProjCode = me.map.getView().getProjection().getCode();
+        var coordinatesWgs84 =
+          olProj.transform(coordinates, mapProjCode, 'EPSG:4326')
+        var hdms = olCoordinate.toStringHDMS(coordinatesWgs84);
+
+        me.coordsMapProj = coordinates[1].toFixed(2) + ' ' + coordinates[0].toFixed(2);
+        me.coordsWgs84 = coordinatesWgs84[1].toFixed(7) + ' ' + coordinatesWgs84[0].toFixed(7);
+        me.coordsHdms = hdms;
+
+        me.coordsData = {
+          'POS': coordinates[1].toFixed(2) + ' ' + coordinates[0].toFixed(2),
+          'WGS 84': coordinatesWgs84[1].toFixed(7) + ' ' + coordinatesWgs84[0].toFixed(7),
+          'HDMS': hdms
+        }
+      });
+    }
+  },
+  watch: {
+    show () {
+      if (this.show === true) {
+        this.registerMapClick();
+      }
+    }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+
+  .wgu-infoclick-win {
+    background-color: white;
+    z-index: 2;
+  }
+
+  .wgu-infoclick-win.card {
+      position: absolute;
+  }
+
+  .wgu-infoclick-win .card__title {
+    display: inherit;
+  }
+
+  .wgu-infoclick-win .no-data {
+    width: 335px;
+  }
+
+  .wgu-infoclick-win table {
+    border: 2px solid #c62828;
+    border-radius: 3px;
+    background-color: #fff;
+  }
+
+  .wgu-infoclick-win .attr-tbody {
+    display: block;
+    max-height: 300px;
+    overflow-y: scroll;
+  }
+
+  .wgu-infoclick-win table.coords {
+    margin-top: 12px;
+    width: 100%;
+  }
+
+  .wgu-infoclick-win td {
+    background-color: #f9f9f9;
+  }
+
+  .wgu-infoclick-win th, .wgu-infoclick-win td {
+    width: 200px;
+    padding: 10px 20px;
+  }
+
+  .wgu-infoclick-win th.active {
+    color: #fff;
+  }
+
+</style>

--- a/src/components/infoclick/ToggleButton.vue
+++ b/src/components/infoclick/ToggleButton.vue
@@ -1,0 +1,52 @@
+<template>
+
+  <div class="">
+
+    <v-btn icon @click="toggleUi">
+      <v-icon medium>{{icon}}</v-icon>
+      {{text}}
+    </v-btn>
+
+    <wgu-infoclick-win
+      ref="infoClickWin"
+      :icon="icon"
+      :left="left"
+      :top="top"
+    />
+
+  </div>
+
+</template>
+
+<script>
+
+import InfoClickWin from './InfoClickWin.vue'
+
+export default {
+  name: 'wgu-toggle-infoclick-button',
+  components: {
+    'wgu-infoclick-win': InfoClickWin
+  },
+  data: function () {
+    return {
+      show: false,
+      icon: 'info',
+      text: '',
+      left: '30px',
+      top: '30px'
+    }
+  },
+  methods: {
+    toggleUi () {
+      // TODO check how to call the super method
+      this.show = !this.show;
+      // forward property 'show' to window child componnet
+      this.$refs.infoClickWin.show = this.show;
+    }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+</style>

--- a/test/unit/specs/infoclick/InfoClickWin.spec.js
+++ b/test/unit/specs/infoclick/InfoClickWin.spec.js
@@ -1,0 +1,31 @@
+import Vue from 'vue'
+import InfoClickWin from '@/components/infoclick/InfoClickWin'
+
+describe('infoclick/InfoClickWin.vue', () => {
+  // Inspect the raw component options
+  it('has a created hook', () => {
+    expect(typeof InfoClickWin.created).to.equal('function');
+  });
+
+  // Evaluate the results of functions in
+  // the raw component options
+  it('sets the correct default data', () => {
+    expect(typeof InfoClickWin.data).to.equal('function');
+    const defaultData = InfoClickWin.data();
+    expect(defaultData.show).to.equal(false);
+    expect(defaultData.icon).to.equal('info');
+    expect(defaultData.coordsMapProj).to.equal('');
+    expect(defaultData.coordsWgs84).to.equal('');
+    expect(defaultData.coordsHdms).to.equal('');
+    expect(defaultData.gridData).to.equal(null);
+    expect(defaultData.coordsData).to.equal(null);
+  });
+
+  // Mount an instance and inspect the render output
+  it('does not render on startup', () => {
+    const Constructor = Vue.extend(InfoClickWin)
+    const vm = new Constructor().$mount();
+    // el is not undefined but this tests that it is not rendered
+    expect(vm.$el.textContent).to.equal('');
+  });
+});

--- a/test/unit/specs/infoclick/ToggleButton.spec.js
+++ b/test/unit/specs/infoclick/ToggleButton.spec.js
@@ -1,0 +1,34 @@
+import Vue from 'vue'
+import InfoClickToggleBtn from '@/components/infoclick/ToggleButton'
+
+describe('infoclick/ToggleButton.vue', () => {
+  // Check methods
+  it('has a method toggleUi', () => {
+    const Constructor = Vue.extend(InfoClickToggleBtn);
+    const ictb = new Constructor({
+    }).$mount();
+    expect(typeof ictb.toggleUi).to.equal('function');
+  });
+
+  // Evaluate the results of functions
+  it('sets the correct default data', () => {
+    expect(typeof InfoClickToggleBtn.data).to.equal('function');
+    const defaultData = InfoClickToggleBtn.data();
+    expect(typeof defaultData).to.equal('object');
+    expect(defaultData.show).to.equal(false);
+    expect(defaultData.icon).to.equal('info');
+    expect(defaultData.text).to.equal('');
+  });
+
+  // Mount an instance and inspect the render output
+  it('renders the right sub-components', () => {
+    const Constructor = Vue.extend(InfoClickToggleBtn);
+    const vm = new Constructor({
+      icon: 'info'
+    }).$mount();
+    const btn = vm.$el.querySelector('v-btn');
+    expect(btn !== null).to.equal(true);
+    const icon = vm.$el.querySelector('v-icon');
+    expect(icon !== null).to.equal(true);
+  });
+});


### PR DESCRIPTION
This adds a component which enables a generic map-click functionality and shows either the feature attributes (if a feature was hit) or the clicked coordinates (in case there is no feature at the clicked position).
The Information is shown in a floating window.

![image](https://user-images.githubusercontent.com/1185547/39230760-fbfeb524-4867-11e8-81ae-763de2f571cb.png)

