### PR TITLE
Upgrade to OpenLayers v5.x

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -46,7 +46,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        include: [resolve('src'), resolve('test')]
+        include: [resolve('src'), resolve('test'), resolve('node_modules/ol')],
       },
       {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "ol": "5.0.0",
+    "ol": "5.1.3",
     "vue": "^2.5.16",
     "vuetify": "^1.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "ol": "^4.6.5",
+    "ol": "5.0.0",
     "vue": "^2.5.16",
     "vuetify": "^1.0.8"
   },

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -63,9 +63,9 @@
 
 <script>
 
-import { WguEventBus } from '../../WguEventBus.js'
-import olProj from 'ol/proj'
-import olCoordinate from 'ol/coordinate'
+import { WguEventBus } from '../../WguEventBus.js';
+import {transform} from 'ol/proj.js';
+import {toStringHDMS} from 'ol/coordinate';
 
 export default {
   name: 'wgu-infoclick-win',
@@ -118,8 +118,8 @@ export default {
         var coordinates = evt.coordinate;
         var mapProjCode = me.map.getView().getProjection().getCode();
         var coordinatesWgs84 =
-          olProj.transform(coordinates, mapProjCode, 'EPSG:4326')
-        var hdms = olCoordinate.toStringHDMS(coordinatesWgs84);
+            transform(coordinates, mapProjCode, 'EPSG:4326');
+        var hdms = toStringHDMS(coordinatesWgs84);
 
         me.coordsMapProj = coordinates[1].toFixed(2) + ' ' + coordinates[0].toFixed(2);
         me.coordsWgs84 = coordinatesWgs84[1].toFixed(7) + ' ' + coordinatesWgs84[0].toFixed(7);

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -38,19 +38,19 @@
 </template>
 
 <script>
+  import DrawInteraction from 'ol/interaction/Draw';
+  import LineStringGeom from 'ol/geom/LineString';
+  import PolygonGeom from 'ol/geom/Polygon';
+  import {unByKey} from 'ol/Observable.js';
+  import VectorSource from 'ol/source/Vector';
+  import VectorLayer from 'ol/layer/Vector';
+  import Style from 'ol/style/Style';
+  import Stroke from 'ol/style/Stroke';
+  import Circle from 'ol/style/Circle';
+  import Fill from 'ol/style/Fill';
+  import {getArea, getLength} from 'ol/sphere.js';
   import { DraggableWin } from '../../directives/DraggableWin';
   import { Mapable } from '../../mixins/Mapable';
-  import DrawInteraction from 'ol/interaction/draw'
-  import LineStringGeom from 'ol/geom/linestring'
-  import PolygonGeom from 'ol/geom/polygon'
-  import Sphere from 'ol/sphere'
-  import Observable from 'ol/observable'
-  import VectorSource from 'ol/source/vector'
-  import VectorLayer from 'ol/layer/vector'
-  import Style from 'ol/style/style'
-  import Stroke from 'ol/style/stroke'
-  import Circle from 'ol/style/circle'
-  import Fill from 'ol/style/fill'
 
   export default {
     directives: {
@@ -178,7 +178,7 @@
         draw.on('drawend', () => {
           // unset sketch
           sketch = null;
-          Observable.unByKey(listener);
+          unByKey(listener);
         }, this);
 
         // make draw interaction available as member
@@ -204,8 +204,8 @@
        * @param  {ol.geom.LineString} line The LineString object to calculate length for
        */
       formatLength (line) {
-        var length = Sphere.getLength(line);
-        var output;
+        const length = getLength(line);
+        let output;
         if (length > 100) {
           output = (Math.round(length / 1000 * 100) / 100) +
               ' ' + 'km';
@@ -221,8 +221,8 @@
        * @param  {ol.geom.Polygon} polygon The Polygon object to calculate area for
        */
       formatArea (polygon) {
-        var area = Sphere.getArea(polygon);
-        var output;
+        const area = getArea(polygon);
+        let output;
         if (area > 10000) {
           output = (Math.round(area / 1000000 * 100) / 100) +
               ' ' + 'km²';

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -4,14 +4,14 @@
 
 <script>
 
-import Map from 'ol/map'
-import View from 'ol/view'
-import Attribution from 'ol/control/attribution';
-import Zoom from 'ol/control/zoom';
+import Map from 'ol/Map'
+import View from 'ol/View'
+import Attribution from 'ol/control/Attribution';
+import Zoom from 'ol/control/Zoom';
+import SelectInteraction from 'ol/interaction/Select';
 // import the app-wide EventBus
-import { WguEventBus } from '../../WguEventBus.js'
-import { LayerFactory } from '../../factory/Layer.js'
-import SelectInteraction from 'ol/interaction/select'
+import { WguEventBus } from '../../WguEventBus.js';
+import { LayerFactory } from '../../factory/Layer.js';
 
 export default {
   name: 'wgu-map',

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -1,14 +1,14 @@
-import TileLayer from 'ol/layer/tile'
-import TileWmsSource from 'ol/source/tilewms'
-import OsmSource from 'ol/source/osm'
-import VectorTileLayer from 'ol/layer/vectortile'
-import VectorTileSource from 'ol/source/vectortile'
-import MvtFormat from 'ol/format/mvt'
-import GeoJsonFormat from 'ol/format/geojson'
-import TopoJsonFormat from 'ol/format/topojson'
-import KmlFormat from 'ol/format/kml'
-import VectorLayer from 'ol/layer/vector'
-import VectorSource from 'ol/source/vector'
+import TileLayer from 'ol/layer/Tile';
+import TileWmsSource from 'ol/source/TileWMS';
+import OsmSource from 'ol/source/OSM';
+import VectorTileLayer from 'ol/layer/VectorTile'
+import VectorTileSource from 'ol/source/VectorTile'
+import MvtFormat from 'ol/format/MVT'
+import GeoJsonFormat from 'ol/format/GeoJSON'
+import TopoJsonFormat from 'ol/format/TopoJSON'
+import KmlFormat from 'ol/format/KML'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
 import OlStyleDefs from '../style/OlStyleDefs'
 
 /**

--- a/src/style/OlStyleDefs.js
+++ b/src/style/OlStyleDefs.js
@@ -1,6 +1,6 @@
-import OlStyle from 'ol/style/style'
-import OlStroke from 'ol/style/stroke'
-import OlFill from 'ol/style/fill'
+import OlStyle from 'ol/style/Style';
+import OlStroke from 'ol/style/Stroke';
+import OlFill from 'ol/style/Fill';
 
 export default {
   shopStyle: new OlStyle({

--- a/test/unit/specs/maxextentbutton/ZoomToMaxExtentButton.spec.js
+++ b/test/unit/specs/maxextentbutton/ZoomToMaxExtentButton.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import ZoomToMaxExtentButton from '@/components/maxextentbutton/ZoomToMaxExtentButton'
-import OlMap from 'ol/map';
-import OlView from 'ol/view';
+import OlMap from 'ol/Map';
+import OlView from 'ol/View';
 
 describe('maxextentbutton/ZoomToMaxExtentButton.vue', () => {
   // Check methods


### PR DESCRIPTION
This upgrades the Wegue project, so it is compatible to OpenLayers v5.x (currently [OpenLayers v5.1.3](https://github.com/openlayers/openlayers/releases/tag/v5.1.3)).

In case you stuck to OpenLayers v4.x you have to use Wegue v0.3.x (Currently [v0.3.0](https://github.com/meggsimum/wegue/releases/tag/v0.3.0))