### PR TITLE
Make colors of measure features configurable

### DIFF
--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -94,7 +94,8 @@
        * map.
        */
       createMeasureLayer () {
-        var me = this;
+        const me = this;
+        const measureConf = me.$appConfig.modules.wgumeasure || {};
         // create a vector layer to
         var source = new VectorSource();
         var vector = new VectorLayer({
@@ -102,17 +103,11 @@
           source: source,
           style: new Style({
             fill: new Fill({
-              color: 'rgba(255, 255, 255, 0.2)'
+              color: measureConf.fillColor || 'rgba(255, 255, 255, 0.2)'
             }),
             stroke: new Stroke({
-              color: 'rgba(0, 0, 0, 0.7)',
+              color: measureConf.strokeColor || 'rgba(0, 0, 0, 0.5)',
               width: 2
-            }),
-            image: new Circle({
-              radius: 7,
-              fill: new Fill({
-                color: 'rgba(0, 0, 0, 0.7)'
-              })
             })
           })
         });
@@ -126,7 +121,8 @@
        * Creates and adds the necessary draw interaction and adds it to the map.
        */
       addInteraction () {
-        var me = this;
+        const me = this;
+        const measureConf = me.$appConfig.modules.wgumeasure || {};
         // cleanup possible old draw interaction
         if (me.draw) {
           me.removeInteraction();
@@ -138,20 +134,20 @@
           type: type,
           style: new Style({
             fill: new Fill({
-              color: 'rgba(255, 255, 255, 0.2)'
+              color: measureConf.sketchFillColor || 'rgba(255, 255, 255, 0.2)'
             }),
             stroke: new Stroke({
-              color: 'rgba(0, 0, 0, 0.5)',
+              color: measureConf.sketchStrokeColor || 'rgba(0, 0, 0, 0.5)',
               lineDash: [10, 10],
               width: 2
             }),
             image: new Circle({
               radius: 5,
               stroke: new Stroke({
-                color: 'rgba(0, 0, 0, 0.7)'
+                color: measureConf.sketchVertexStrokeColor || 'rgba(0, 0, 0, 0.7)'
               }),
               fill: new Fill({
-                color: 'rgba(255, 255, 255, 0.2)'
+                color: measureConf.sketchVertexFillColor || 'rgba(255, 255, 255, 0.2)'
               })
             })
           })

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -57,6 +57,17 @@
       "displayInLayerList": true
     }
 
-  ]
+  ],
+
+  "modules": {
+    "wgumeasure": {
+      "strokeColor": "#c62828",
+      "fillColor": "rgba(198,40,40,0.2)",
+      "sketchStrokeColor": "rgba(198,40,40,0.8)",
+      "sketchFillColor": "rgba(198,40,40,0.1)",
+      "sketchVertexStrokeColor": "#c62828",
+      "sketchVertexFillColor": "rgba(198,40,40,0.2)"
+    }
+  }
 
 }


### PR DESCRIPTION
This makes the colors of the feature style for the measure features configurable. By adding a config section like

```
    "wgumeasure": {
      "strokeColor": "#c62828",
      "fillColor": "rgba(198,40,40,0.2)",
      "sketchStrokeColor": "rgba(198,40,40,0.8)",
      "sketchFillColor": "rgba(198,40,40,0.1)",
      "sketchVertexStrokeColor": "#c62828",
      "sketchVertexFillColor": "rgba(198,40,40,0.2)"
    }
```

one can change the different colors. The previous values are used as fallback. So if one does not specify a color the app would look like before.

 