### PR TITLE
Correct component CSS for production build

### DIFF
--- a/src/components/AppLogo.vue
+++ b/src/components/AppLogo.vue
@@ -26,7 +26,7 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
 
-  .wgu-app-logo {
+  .v-avatar.v-avatar--tile.wgu-app-logo {
     position: absolute;
     z-index: 1000;
     border: 2px solid white;

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -50,7 +50,7 @@
     z-index: 2;
   }
 
-  .wgu-helpwin {
+  .v-card.wgu-helpwin {
     position: absolute;
   }
 

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -151,7 +151,7 @@ export default {
     z-index: 2;
   }
 
-  .wgu-infoclick-win {
+  .v-card.wgu-infoclick-win {
       position: absolute;
   }
 

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -140,7 +140,7 @@
     background-color: white;
     z-index: 2;
   }
-  .wgu-layerlist {
+  .v-card.wgu-layerlist {
     position: absolute;
   }
 

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -243,7 +243,7 @@
     z-index: 2;
   }
 
-  .wgu-measurewin {
+  .v-card.wgu-measurewin {
     position: absolute;
   }
 


### PR DESCRIPTION
This makes the CSS selectors more precise so the declarations of the Wegue components are not overwritten by Vuetify declarations (only happened in production build).