### PR TITLE
Optimize dev-server

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -77,7 +77,11 @@ devMiddleware.waitUntilValid(() => {
   console.log('> Listening at ' + uri + '\n')
   // when env is testing, don't need open it
   if (autoOpenBrowser && process.env.NODE_ENV !== 'testing') {
-    opn(uri)
+    var opnOpts = {};
+    if (config.dev.browser) {
+        opnOpts.app = [config.dev.browser];
+    }
+    opn(uri, opnOpts)
   }
   _resolve()
 })

--- a/config/index.js
+++ b/config/index.js
@@ -24,7 +24,10 @@ module.exports = {
   },
   dev: {
     env: require('./dev.env'),
-    port: 8080,
+    port: 8081,
+    // define a special browser to open the dev app (false = default browser)
+    // 'google chrome' on macOS, 'google-chrome' on Linux and 'chrome' on Win
+    browser: false,
     autoOpenBrowser: true,
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "karma-spec-reporter": "0.0.31",
     "karma-webpack": "^2.0.9",
     "mocha": "^3.5.3",
-    "opn": "^5.2.0",
+    "opn": "^5.3.0",
     "optimize-css-assets-webpack-plugin": "^2.0.0",
     "ora": "^1.2.0",
     "phantomjs-prebuilt": "^2.1.16",


### PR DESCRIPTION
  - Runs the dev-server per default on port 8081, because 8080 is often blocked by a Tomcat
  - Makes the automatically opened browser to show the dev-app configurable