### PR TITLE
Refactor app layout

### DIFF
--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -31,6 +31,7 @@
   import AppLogo from './components/AppLogo'
   import MeasureWin from './components/measuretool/MeasureWin'
   import LayerListWin from './components/layerlist/LayerList'
+  import InfoClickWin from './components/infoclick/InfoClickWin'
 
   export default {
     name: 'wgu-app',
@@ -39,7 +40,8 @@
       'wgu-app-header': AppHeader,
       'wgu-app-logo': AppLogo,
       'wgu-measuretool-win': MeasureWin,
-      'wgu-layerlist-win': LayerListWin
+      'wgu-layerlist-win': LayerListWin,
+      'wgu-infoclick-win': InfoClickWin
     },
     data () {
       return {

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -1,9 +1,9 @@
 <template>
-  <div id="app" data-app :class="{ 'wgu-app': true, 'wgu-app-embedded': isEmbedded }">
+  <v-app id="wgu-app" :class="{ 'wgu-app': true, 'wgu-app-embedded': isEmbedded }">
 
-      <wgu-app-header>
+    <wgu-app-header>
 
-        <v-toolbar-items slot="wgu-tb-buttons" class="">
+        <v-toolbar-items slot="wgu-tb-buttons">
 
             <wgu-zoomtomaxextent-button
               icon="zoom_out_map"
@@ -31,64 +31,44 @@
             />
 
         </v-toolbar-items>
-      </wgu-app-header>
 
-      <wgu-app-logo />
+    </wgu-app-header>
 
-      <wgu-map />
+    <v-content>
+      <v-container id="ol-map-container" fluid fill-height style="padding: 0">
+         <wgu-map />
+      </v-container>
+    </v-content>
 
-      <wgu-feature-infowindow
-        layerId="Shops"
-        imageProp="image"
-        titleProp="name"
-        icon="info"
-        title="Information"
-      />
+    <v-footer color="red darken-3" class="white--text" app>
+      <v-spacer></v-spacer>
+      <span>meggsimum &copy; {{ new Date().getFullYear() }}</span>
+    </v-footer>
 
-  </div>
+  </v-app>
 </template>
 
 <script>
+  import OlMap from './components/ol/Map'
+  import AppHeader from './components/AppHeader'
+  import LayerListToggleButton from './components/layerlist/ToggleButton'
+  import HelpWinToggleButton from './components/helpwin/ToggleButton'
+  import MeasureToolToggleButton from './components/measuretool/ToggleButton'
+  import InfoClickButton from './components/infoclick/ToggleButton'
+  import ZoomToMaxExtentButton from './components/maxextentbutton/ZoomToMaxExtentButton'
 
-import OlMap from './components/ol/Map'
-import InfoWindow from './components/InfoWindow'
-import FeatureInfoWindow from './components/FeatureInfoWindow'
-import AppHeader from './components/AppHeader'
-import AppLogo from './components/AppLogo'
-import MenuButton from './components/MenuButton'
-import LayerListToggleButton from './components/layerlist/ToggleButton'
-import HelpWinToggleButton from './components/helpwin/ToggleButton'
-import MeasureToolToggleButton from './components/measuretool/ToggleButton'
-import InfoClickButton from './components/infoclick/ToggleButton'
-import ZoomToMaxExtentButton from './components/maxextentbutton/ZoomToMaxExtentButton'
-
-export default {
-  name: 'app',
-  components: {
-    'wgu-map': OlMap,
-    'wgu-info-window': InfoWindow,
-    'wgu-feature-infowindow': FeatureInfoWindow,
-    'wgu-app-header': AppHeader,
-    'wgu-app-logo': AppLogo,
-    'wgu-menubutton': MenuButton,
-    'wgu-toggle-layerlist-button': LayerListToggleButton,
-    'wgu-toggle-helpwin-button': HelpWinToggleButton,
-    'wgu-toggle-measuretool-button': MeasureToolToggleButton,
-    'wgu-toggle-infoclick-button': InfoClickButton,
-    'wgu-zoomtomaxextent-button': ZoomToMaxExtentButton
-  },
-  data () {
-    return {
+  export default {
+    components: {
+      'wgu-map': OlMap,
+      'wgu-app-header': AppHeader,
+      'wgu-toggle-layerlist-button': LayerListToggleButton,
+      'wgu-toggle-helpwin-button': HelpWinToggleButton,
+      'wgu-toggle-measuretool-button': MeasureToolToggleButton,
+      'wgu-toggle-infoclick-button': InfoClickButton,
+      'wgu-zoomtomaxextent-button': ZoomToMaxExtentButton
+    },
+    data: () => ({
       isEmbedded: false
-    }
-  },
-  mounted () {
-    // apply the isEmbedded state to the member var
-    this.isEmbedded = this.$isEmbedded;
+    })
   }
-}
 </script>
-
-<style>
-
-</style>

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -3,6 +3,8 @@
 
     <wgu-app-header />
 
+    <wgu-app-logo />
+
     <v-content>
       <v-container id="ol-map-container" fluid fill-height style="padding: 0">
          <wgu-map />
@@ -26,6 +28,7 @@
   import { WguEventBus } from './WguEventBus'
   import OlMap from './components/ol/Map'
   import AppHeader from './components/AppHeader'
+  import AppLogo from './components/AppLogo'
   import MeasureWin from './components/measuretool/MeasureWin'
   import LayerListWin from './components/layerlist/LayerList'
 
@@ -34,6 +37,7 @@
     components: {
       'wgu-map': OlMap,
       'wgu-app-header': AppHeader,
+      'wgu-app-logo': AppLogo,
       'wgu-measuretool-win': MeasureWin,
       'wgu-layerlist-win': LayerListWin
     },

--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -17,7 +17,7 @@
 
     <v-footer color="red darken-3" class="white--text" app>
       <v-spacer></v-spacer>
-      <span>meggsimum &copy; {{ new Date().getFullYear() }}</span>
+      <span class="wgu-copyright">meggsimum &copy; {{ new Date().getFullYear() }}</span>
     </v-footer>
 
   </v-app>

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -1,7 +1,7 @@
 
 html {
   /* otherwise we have always vertical scrollbars */
-  overflow-y: auto !important;
+  overflow-y: hidden !important;
 }
 
 .wgu-app {

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -21,6 +21,6 @@ html {
 }
 
 .wgu-app-logo {
-  left: 25px;
-  top: 45px;
+  left: 8px;
+  bottom: 50px;
 }

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -24,3 +24,7 @@ html {
   left: 8px;
   bottom: 50px;
 }
+
+.wgu-copyright {
+  padding-right: 5px;
+}

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -15,7 +15,7 @@ html {
   border: 2px solid grey;
 }
 
-.wgu-app .wgu-map {
+.wgu-map {
 }
 .wgu-app-embedded .wgu-map {
 }

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,14 +1,21 @@
 <template>
-  <v-toolbar class="wgu-app-toolbar">
-      <v-toolbar-title>{{title}}</v-toolbar-title>
-      <v-spacer></v-spacer>
+  <v-toolbar
+    class="wgu-app-toolbar white--text"
+    color="red darken-3"
+    fixed
+    app
+    clipped-right
+  >
+    <v-toolbar-title>{{title}}</v-toolbar-title>
+    <v-spacer></v-spacer>
 
-      <!--This <slot> is going to be replaced by the toolbar buttons in the
-          app configuration tags (see App.vue) -->
-      <v-layout justify-end class="">
-        <slot name="wgu-tb-buttons"></slot>
-      </v-layout>
-    </v-toolbar>
+    <!--This <slot> is going to be replaced by the toolbar buttons in the
+      app configuration tags (see App.vue) -->
+    <v-layout justify-end class="">
+      <slot name="wgu-tb-buttons"></slot>
+    </v-layout>
+
+  </v-toolbar>
 </template>
 
 <script>
@@ -28,10 +35,4 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-
-  .wgu-app-toolbar {
-    z-index: 1;
-    display: block;
-  }
-
 </style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -11,25 +11,97 @@
 
     <!--This <slot> is going to be replaced by the toolbar buttons in the
       app configuration tags (see App.vue) -->
-    <v-layout justify-end class="">
+    <!-- <v-layout justify-end class="">
       <slot name="wgu-tb-buttons"></slot>
-    </v-layout>
+    </v-layout> -->
+
+    <template v-for="(tbButton, index) in tbButtons">
+      <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text"/>
+    </template>
+
+    <v-menu offset-y>
+      <v-btn icon dark slot="activator">
+        <v-icon medium>menu</v-icon>
+      </v-btn>
+      <v-list>
+          <template v-for="(tbButton, index) in menuButtons">
+              <v-list-tile>
+                <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text" />
+              </v-list-tile>
+          </template>
+      </v-list>
+    </v-menu>
 
   </v-toolbar>
 </template>
 
 <script>
 
+import Vue from 'vue'
+import LayerListToggleButton from './layerlist/ToggleButton'
+import HelpWinToggleButton from './helpwin/ToggleButton'
+import MeasureToolToggleButton from './measuretool/ToggleButton'
+import InfoClickButton from './infoclick/ToggleButton'
+import ZoomToMaxExtentButton from './maxextentbutton/ZoomToMaxExtentButton'
+
 export default {
   name: 'wgu-app-header',
+  components: {
+    'wgu-zoomtomaxextent-btn': ZoomToMaxExtentButton,
+    'wgu-layerlist-btn': LayerListToggleButton,
+    'wgu-helpwin-btn': HelpWinToggleButton,
+    'wgu-measuretool-btn': MeasureToolToggleButton,
+    'wgu-infoclick-btn': InfoClickButton
+  },
   data () {
     return {
-      title: this.$appConfig.title
+      title: this.$appConfig.title,
+      menuButtons: this.getModuleButtonData(),
+      tbButtons: this.getToolbarButtons()
     }
   },
-  mounted () {
+  methods: {
+    /**
+     * Determines the module menu button configuration objects from app-config:
+     *    menuButtons: [
+     *      {type: 'wgu-layerlist-toggle-btn'},
+     *      {type: 'wgu-helpwin-toggle-btn'},
+     *      {type: 'wgu-measuretool-toggle-btn'}
+     *    ]
+     * @return {Array} module button configuration objects for the menu
+     */
+    getModuleButtonData () {
+      const appConfig = Vue.prototype.$appConfig;
+      let moduleWins = [];
+      for (const key of Object.keys(appConfig.modules)) {
+        const moduleOpts = appConfig.modules[key];
+        if (moduleOpts.target === 'menu') {
+          moduleWins.push({type: key + '-btn', target: moduleOpts.target});
+        }
+      }
+      return moduleWins;
+    },
+    /**
+     * Determines the module toolbar button configuration objects from app-config:
+     *    menuButtons: [
+     *      {type: 'wgu-layerlist-toggle-btn'},
+     *      {type: 'wgu-helpwin-toggle-btn'},
+     *      {type: 'wgu-measuretool-toggle-btn'}
+     *    ]
+     * @return {Array} module button configuration objects for the toolbar
+     */
+    getToolbarButtons () {
+      const appConfig = Vue.prototype.$appConfig;
+      let moduleWins = [];
+      for (const key of Object.keys(appConfig.modules)) {
+        const moduleOpts = appConfig.modules[key];
+        if (moduleOpts.target === 'toolbar') {
+          moduleWins.push({type: key + '-btn', target: moduleOpts.target});
+        }
+      }
+      return moduleWins;
+    }
   }
-
 }
 </script>
 

--- a/src/components/AppLogo.vue
+++ b/src/components/AppLogo.vue
@@ -28,8 +28,7 @@ export default {
 
   .v-avatar.v-avatar--tile.wgu-app-logo {
     position: absolute;
-    z-index: 1000;
-    border: 2px solid white;
+    z-index: 2;
   }
 
 </style>

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -2,8 +2,8 @@
 
   <v-card class="wgu-helpwin">
     <v-toolbar class="red darken-3 white--text" dark>
-      <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-      <v-toolbar-title>About</v-toolbar-title>
+      <v-toolbar-side-icon><v-icon>{{ icon }}</v-icon></v-toolbar-side-icon>
+      <v-toolbar-title>{{ title }}</v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-side-icon @click="onWinXClose"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
@@ -27,7 +27,14 @@
 
 <script>
   export default {
-    props: ['icon', 'headline', 'content', 'infoLink', 'infoLinkText'],
+    props: {
+      icon: {type: String, required: false, default: 'help'},
+      title: {type: String, required: false, default: 'About'},
+      headline: {type: String, required: false, default: 'About Wegue'},
+      content: {type: String, required: false, default: '<h3>WebGIS with OpenLayers and Vue.js</h3> Template and re-usable components for webmapping applications with OpenLayers and Vue.js'},
+      infoLink: {type: String, required: false, default: 'https://github.com/meggsimum/wegue'},
+      infoLinkText: {type: String, required: false, default: 'More info'}
+    },
     data () {
       return {
         show: false

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -1,11 +1,11 @@
 <template>
 
-  <v-card v-draggable-win class="wgu-helpwin" v-if=show v-bind:style="{ left: left, top: top }">
+  <v-card class="wgu-helpwin">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-      <v-toolbar-title>Help</v-toolbar-title>
+      <v-toolbar-title>About</v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
+      <v-toolbar-side-icon @click="onWinXClose"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
 
     <v-card-title primary-title>
@@ -26,36 +26,21 @@
 </template>
 
 <script>
-  import { DraggableWin } from '../../directives/DraggableWin.js';
-
   export default {
-    directives: {
-      DraggableWin
-    },
     props: ['icon', 'headline', 'content', 'infoLink', 'infoLinkText'],
     data () {
       return {
-        show: false,
-        left: '300px',
-        top: '300px'
+        show: false
+      }
+    },
+    methods: {
+      onWinXClose: function () {
+        this.$emit('winxclose');
       }
     }
   }
 </script>
 
 <style>
-
-  .wgu-helpwin {
-    background-color: white;
-    z-index: 2;
-  }
-
-  .v-card.wgu-helpwin {
-    position: absolute;
-  }
-
-  .wgu-helpwin .info-link {
-    padding-left: 15px;
-  }
 
 </style>

--- a/src/components/helpwin/ToggleButton.vue
+++ b/src/components/helpwin/ToggleButton.vue
@@ -1,8 +1,8 @@
 <template>
 
-  <div class="">
+  <v-dialog v-model="show" max-width="300" :hide-overlay="false">
 
-    <v-btn icon @click="toggleUi">
+    <v-btn icon slot="activator">
       <v-icon medium>{{icon}}</v-icon>
       {{text}}
     </v-btn>
@@ -14,11 +14,10 @@
       :content="content"
       :infoLink="infoLink"
       :infoLinkText="infoLinkText"
-      :left="left"
-      :top="top"
+      v-on:winxclose="show=false"
     />
 
-  </div>
+  </v-dialog>
 
 </template>
 
@@ -39,16 +38,7 @@ export default {
       headline: 'About Wegue',
       content: '<h3>WebGIS with OpenLayers and Vue.js</h3> Template and re-usable components for webmapping applications with OpenLayers and Vue.js',
       infoLink: 'https://github.com/meggsimum/wegue',
-      infoLinkText: 'More info',
-      left: '300px',
-      top: '300px'
-    }
-  },
-  methods: {
-    toggleUi () {
-      // TODO move to a father class
-      this.$refs.helpwin.show = !this.$refs.helpwin.show;
-      this.show = this.$refs.helpwin.show;
+      infoLinkText: 'More info'
     }
   }
 };

--- a/src/components/helpwin/ToggleButton.vue
+++ b/src/components/helpwin/ToggleButton.vue
@@ -2,7 +2,7 @@
 
   <v-dialog v-model="show" max-width="300" :hide-overlay="false">
 
-    <v-btn icon slot="activator">
+    <v-btn icon slot="activator" dark>
       <v-icon medium>{{icon}}</v-icon>
       {{text}}
     </v-btn>
@@ -26,7 +26,7 @@
 import HelpWin from './HelpWin'
 
 export default {
-  name: 'wgu-toggle-helpwin-button',
+  name: 'wgu-helpwin-btn',
   components: {
     'wgu-helpwin': HelpWin
   },

--- a/src/components/helpwin/ToggleButton.vue
+++ b/src/components/helpwin/ToggleButton.vue
@@ -10,6 +10,7 @@
     <wgu-helpwin
       ref="helpwin"
       :icon="icon"
+      :title="text"
       :headline="headline"
       :content="content"
       :infoLink="infoLink"
@@ -30,15 +31,17 @@ export default {
   components: {
     'wgu-helpwin': HelpWin
   },
+  props: {
+    icon: {type: String, required: false, default: 'help'},
+    text: {type: String, required: false},
+    headline: {type: String, required: false},
+    content: {type: String, required: false},
+    infoLink: {type: String, required: false},
+    infoLinkText: {type: String, required: false}
+  },
   data: function () {
     return {
-      show: false,
-      icon: 'help',
-      text: '',
-      headline: 'About Wegue',
-      content: '<h3>WebGIS with OpenLayers and Vue.js</h3> Template and re-usable components for webmapping applications with OpenLayers and Vue.js',
-      infoLink: 'https://github.com/meggsimum/wegue',
-      infoLinkText: 'More info'
+      show: false
     }
   }
 };

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -5,7 +5,7 @@
     <v-card v-draggable-win class="wgu-infoclick-win" v-if=show v-bind:style="{ left: left, top: top }">
       <v-toolbar class="red darken-3 white--text" dark>
         <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-        <v-toolbar-title>Map Click Info</v-toolbar-title>
+        <v-toolbar-title>{{title}}</v-toolbar-title>
         <v-spacer></v-spacer>
         <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
       </v-toolbar>
@@ -69,13 +69,15 @@ import {toStringHDMS} from 'ol/coordinate';
 
 export default {
   name: 'wgu-infoclick-win',
+  props: {
+    icon: {type: String, required: false, default: 'info'},
+    title: {type: String, required: false, default: 'Map Click Info'}
+  },
   data: function () {
     return {
       show: false,
-      icon: 'info',
-      text: '',
-      left: '300px',
-      top: '300px',
+      left: '10px',
+      top: '70px',
       coordsMapProj: '',
       coordsWgs84: '',
       coordsHdms: '',

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -1,63 +1,59 @@
 <template>
 
-  <div class="">
+  <v-card v-draggable-win class="wgu-infoclick-win" v-if=show v-bind:style="{ left: left, top: top }">
+    <v-toolbar class="red darken-3 white--text" dark>
+      <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
+      <v-toolbar-title>{{title}}</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
+    </v-toolbar>
+    <v-card-title primary-title>
 
-    <v-card v-draggable-win class="wgu-infoclick-win" v-if=show v-bind:style="{ left: left, top: top }">
-      <v-toolbar class="red darken-3 white--text" dark>
-        <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-        <v-toolbar-title>{{title}}</v-toolbar-title>
-        <v-spacer></v-spacer>
-        <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
-      </v-toolbar>
-      <v-card-title primary-title>
+      <div v-if="this.gridData === null && this.coordsData === null" class="no-data">
+        Click on the map to get information for the clicked map position.
+      </div>
 
-        <div v-if="this.gridData === null && this.coordsData === null" class="no-data">
-          Click on the map to get information for the clicked map position.
-        </div>
+      <!-- feature property grid -->
+      <table v-if="this.gridData !== null">
+        <thead>
+          <tr>
+            <th v-for="entry in gridData"
+            </th>
+          </tr>
+        </thead>
+        <tbody class="attr-tbody">
+          <tr v-for="(value, key) in gridData">
+            <td>
+              {{key}}
+            </td>
+            <td>
+              {{value}}
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-        <!-- feature property grid -->
-        <table v-if="this.gridData !== null">
-          <thead>
-            <tr>
-              <th v-for="entry in gridData"
-              </th>
-            </tr>
-          </thead>
-          <tbody class="attr-tbody">
-            <tr v-for="(value, key) in gridData">
-              <td>
-                {{key}}
-              </td>
-              <td>
-                {{value}}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <table class="coords" v-if="this.coordsData !== null">
+        <thead>
+          <tr>
+            <th v-for="entry in coordsData"
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(value, key) in coordsData">
+            <td>
+              {{key}}
+            </td>
+            <td>
+              {{value}}
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-        <table class="coords" v-if="this.coordsData !== null">
-          <thead>
-            <tr>
-              <th v-for="entry in coordsData"
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(value, key) in coordsData">
-              <td>
-                {{key}}
-              </td>
-              <td>
-                {{value}}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-      </v-card-title>
-    </v-card>
-
-  </div>
+    </v-card-title>
+  </v-card>
 
 </template>
 
@@ -76,8 +72,8 @@ export default {
   data: function () {
     return {
       show: false,
-      left: '10px',
-      top: '70px',
+      left: '2px',
+      top: '270px',
       coordsMapProj: '',
       coordsWgs84: '',
       coordsHdms: '',
@@ -159,10 +155,6 @@ export default {
 
   .wgu-infoclick-win .v-card__title {
     display: inherit;
-  }
-
-  .wgu-infoclick-win .no-data {
-    width: 335px;
   }
 
   .wgu-infoclick-win table {

--- a/src/components/infoclick/ToggleButton.vue
+++ b/src/components/infoclick/ToggleButton.vue
@@ -23,7 +23,7 @@
 import InfoClickWin from './InfoClickWin.vue'
 
 export default {
-  name: 'wgu-toggle-infoclick-button',
+  name: 'wgu-infoclick-btn',
   components: {
     'wgu-infoclick-win': InfoClickWin
   },

--- a/src/components/infoclick/ToggleButton.vue
+++ b/src/components/infoclick/ToggleButton.vue
@@ -1,30 +1,18 @@
 <template>
 
-  <div class="">
-
-    <v-btn icon @click="toggleUi">
-      <v-icon medium>{{icon}}</v-icon>
-      {{text}}
-    </v-btn>
-
-    <wgu-infoclick-win
-      ref="infoClickWin"
-      :icon="icon"
-    />
-
-  </div>
+  <v-btn icon @click="toggleUi">
+    <v-icon medium>{{icon}}</v-icon>
+    {{text}}
+  </v-btn>
 
 </template>
 
 <script>
-
-import InfoClickWin from './InfoClickWin.vue'
+import Vue from 'vue'
+import { WguEventBus } from '../../WguEventBus'
 
 export default {
   name: 'wgu-infoclick-btn',
-  components: {
-    'wgu-infoclick-win': InfoClickWin
-  },
   props: {
     icon: {type: String, required: false, default: 'info'},
     text: {type: String, required: false, default: ''}
@@ -34,11 +22,17 @@ export default {
       moduleName: 'wgu-infoclick'
     }
   },
+  created () {
+    var me = this;
+    // TODO move to a father class
+    WguEventBus.$on('app-mounted', () => {
+      me.win = Vue.prototype.cmpLookup[me.moduleName + '-win'];
+    });
+  },
   methods: {
     toggleUi () {
       // TODO move to a father class
-      this.$refs.infoClickWin.show = !this.$refs.infoClickWin.show;
-      this.show = this.$refs.infoClickWin.show;
+      this.win.show = !this.win.show;
     }
   }
 };

--- a/src/components/infoclick/ToggleButton.vue
+++ b/src/components/infoclick/ToggleButton.vue
@@ -10,8 +10,6 @@
     <wgu-infoclick-win
       ref="infoClickWin"
       :icon="icon"
-      :left="left"
-      :top="top"
     />
 
   </div>
@@ -27,13 +25,13 @@ export default {
   components: {
     'wgu-infoclick-win': InfoClickWin
   },
+  props: {
+    icon: {type: String, required: false, default: 'info'},
+    text: {type: String, required: false, default: ''}
+  },
   data: function () {
     return {
-      show: false,
-      icon: 'info',
-      text: '',
-      left: '30px',
-      top: '30px'
+      moduleName: 'wgu-infoclick'
     }
   },
   methods: {

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -3,7 +3,7 @@
   <v-card v-draggable-win class="wgu-layerlist" v-if=show v-bind:style="{ left: left, top: top }">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-      <v-toolbar-title>Layers</v-toolbar-title>
+      <v-toolbar-title>{{title}}</v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
@@ -29,13 +29,18 @@
   import { Mapable } from '../../mixins/Mapable';
 
   export default {
+    name: 'wgu-layerlist-win',
     directives: {
       DraggableWin
     },
     mixins: [Mapable],
-    props: ['icon'],
+    props: {
+      icon: {type: String, required: false, default: 'layers'},
+      title: {type: String, required: false, default: 'Layers'}
+    },
     data () {
       return {
+        moduleName: 'wgu-layerlist',
         // will be filled in createLayerItems
         items: [],
         // will be filled in createLayerItems a. adapted by the layer checkboxes

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -41,7 +41,7 @@
         // will be filled in createLayerItems a. adapted by the layer checkboxes
         visibleLayers: [],
         show: false,
-        left: '300px',
+        left: '10px',
         top: '70px'
       }
     },

--- a/src/components/layerlist/ToggleButton.vue
+++ b/src/components/layerlist/ToggleButton.vue
@@ -22,10 +22,12 @@ export default {
   components: {
     'wgu-layerlist-win': LayerListWin
   },
+  props: {
+    icon: {type: String, required: false, default: 'layers'},
+    text: {type: String, required: false, default: ''}
+  },
   data: function () {
     return {
-      icon: 'layers',
-      text: '',
       moduleName: 'wgu-layerlist'
     }
   },

--- a/src/components/layerlist/ToggleButton.vue
+++ b/src/components/layerlist/ToggleButton.vue
@@ -1,18 +1,11 @@
 <template>
 
-  <div class="">
+  <div class="" dark>
 
     <v-btn icon @click="toggleUi">
       <v-icon medium>{{icon}}</v-icon>
       {{text}}
     </v-btn>
-
-    <wgu-layerlist
-      ref="layerlist"
-      :icon="icon"
-      :left="left"
-      :top="top"
-    />
 
   </div>
 
@@ -20,27 +13,33 @@
 
 <script>
 
+import Vue from 'vue';
 import LayerListWin from './LayerList'
+import { WguEventBus } from '../../WguEventBus'
 
 export default {
-  name: 'v-webgis-toggle-layerlist-button',
+  name: 'wgu-layerlist-btn',
   components: {
-    'wgu-layerlist': LayerListWin
+    'wgu-layerlist-win': LayerListWin
   },
   data: function () {
     return {
-      show: false,
       icon: 'layers',
       text: '',
-      left: '30px',
-      top: '30px'
+      moduleName: 'wgu-layerlist'
     }
+  },
+  created () {
+    var me = this;
+    // TODO move to a father class
+    WguEventBus.$on('app-mounted', () => {
+      me.win = Vue.prototype.cmpLookup[me.moduleName + '-win'];
+    });
   },
   methods: {
     toggleUi () {
       // TODO move to a father class
-      this.$refs.layerlist.show = !this.$refs.layerlist.show;
-      this.show = this.$refs.layerlist.show;
+      this.win.show = !this.win.show;
     }
   }
 };

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,13 +1,13 @@
 <template>
 
-  <div class="">
+  <!-- <div class=""> -->
 
-    <v-btn icon @click="onClick">
+    <v-btn icon @click="onClick" dark>
       <v-icon medium>{{icon}}</v-icon>
       {{text}}
     </v-btn>
 
-  </div>
+  <!-- </div> -->
 
 </template>
 
@@ -16,11 +16,11 @@
 import { Mapable } from '../../mixins/Mapable';
 
 export default {
-  name: 'wgu-zoomtomaxextent-button',
+  name: 'wgu-zoomtomaxextent-btn',
   mixins: [Mapable],
   props: {
-    icon: {type: String, required: false},
-    text: {type: String, required: false}
+    icon: {type: String, required: false, default: 'zoom_out_map'},
+    text: {type: String, required: false, default: ''}
   },
   methods: {
     onClick () {

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -3,7 +3,7 @@
   <v-card class="wgu-measurewin" v-draggable-win v-if="show" v-bind:style="{ left: left, top: top }">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-      <v-toolbar-title>Measure</v-toolbar-title>
+      <v-toolbar-title>{{title}}</v-toolbar-title>
       <v-spacer></v-spacer>
       <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
@@ -58,16 +58,19 @@
       DraggableWin
     },
     mixins: [Mapable],
-    props: ['icon'],
+    props: {
+      icon: {type: String, required: false, default: 'photo_size_select_small'},
+      title: {type: String, required: false, default: 'Measure'}
+    },
     data () {
       return {
+        moduleName: 'wgu-measuretool',
         area: ' -- ',
         distance: ' -- ',
         measureType: 'distance',
         show: false,
         left: '10px',
-        top: '70px',
-        moduleName: 'wgu-measuretool'
+        top: '70px'
       }
     },
     watch: {

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-card v-draggable-win class="wgu-measurewin" v-if=show v-bind:style="{ left: left, top: top }">
+  <v-card class="wgu-measurewin" v-draggable-win v-if="show" v-bind:style="{ left: left, top: top }">
     <v-toolbar class="red darken-3 white--text" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
       <v-toolbar-title>Measure</v-toolbar-title>
@@ -53,6 +53,7 @@
   import { Mapable } from '../../mixins/Mapable';
 
   export default {
+    name: 'wgu-measuretool-win',
     directives: {
       DraggableWin
     },
@@ -64,8 +65,9 @@
         distance: ' -- ',
         measureType: 'distance',
         show: false,
-        left: '100px',
-        top: '200px'
+        left: '10px',
+        top: '70px',
+        moduleName: 'wgu-measuretool'
       }
     },
     watch: {
@@ -95,7 +97,7 @@
        */
       createMeasureLayer () {
         const me = this;
-        const measureConf = me.$appConfig.modules.wgumeasure || {};
+        const measureConf = me.$appConfig.modules[me.moduleName] || {};
         // create a vector layer to
         var source = new VectorSource();
         var vector = new VectorLayer({
@@ -122,7 +124,7 @@
        */
       addInteraction () {
         const me = this;
-        const measureConf = me.$appConfig.modules.wgumeasure || {};
+        const measureConf = me.$appConfig.modules[me.moduleName] || {};
         // cleanup possible old draw interaction
         if (me.draw) {
           me.removeInteraction();

--- a/src/components/measuretool/ToggleButton.vue
+++ b/src/components/measuretool/ToggleButton.vue
@@ -1,47 +1,43 @@
 <template>
 
-  <div class="">
-
-    <v-btn icon @click="toggleUi">
-      <v-icon medium>{{icon}}</v-icon>
-      {{text}}
-    </v-btn>
-
-    <wgu-measuretool-win
-      ref="measurewin"
-      :icon="icon"
-      :left="left"
-      :top="top"
-    />
-
-  </div>
+  <v-btn icon @click="toggleUi">
+    <v-icon medium>{{icon}}</v-icon>
+    {{text}}
+  </v-btn>
 
 </template>
 
 
 <script>
 
+import Vue from 'vue';
 import MeasureWin from './MeasureWin'
+import { WguEventBus } from '../../WguEventBus'
 
 export default {
-  name: 'wgu-toggle-measurewin-button',
+  name: 'wgu-measuretool-btn',
   components: {
     'wgu-measuretool-win': MeasureWin
   },
   data: function () {
     return {
-      show: false,
+      moduleName: 'wgu-measuretool',
+      // TODO move to props with default
       icon: 'photo_size_select_small',
-      text: '',
-      left: '100px',
-      top: '200px'
+      text: ''
     }
+  },
+  created () {
+    var me = this;
+    // TODO move to a father class
+    WguEventBus.$on('app-mounted', () => {
+      me.win = Vue.prototype.cmpLookup[me.moduleName + '-win'];
+    });
   },
   methods: {
     toggleUi () {
       // TODO move to a father class
-      this.$refs.measurewin.show = !this.$refs.measurewin.show;
-      this.show = this.$refs.measurewin.show;
+      this.win.show = !this.win.show;
     }
   }
 };

--- a/src/components/measuretool/ToggleButton.vue
+++ b/src/components/measuretool/ToggleButton.vue
@@ -19,12 +19,13 @@ export default {
   components: {
     'wgu-measuretool-win': MeasureWin
   },
+  props: {
+    icon: {type: String, required: false, default: 'photo_size_select_small'},
+    text: {type: String, required: false}
+  },
   data: function () {
     return {
-      moduleName: 'wgu-measuretool',
-      // TODO move to props with default
-      icon: 'photo_size_select_small',
-      text: ''
+      moduleName: 'wgu-measuretool'
     }
   },
   created () {

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -93,21 +93,21 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-  .ol-zoom {
+  div.ol-zoom {
     top: auto;
     left: auto;
     bottom: 3em;
     right: 0.5em;
   }
 
-  .ol-control button {
+  div.ol-control button {
     background-color: #c62828;
   }
-  .ol-control button:hover, .ol-control button:active, .ol-control button:focus {
+  div.ol-control button:hover, .ol-control button:active, .ol-control button:focus {
     background-color: #d82828;
   }
 
-  .ol-attribution.ol-uncollapsible {
+  div.ol-attribution.ol-uncollapsible {
     bottom: 12px;
   }
 </style>

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -106,4 +106,8 @@ export default {
   .ol-control button:hover, .ol-control button:active, .ol-control button:focus {
     background-color: #d82828;
   }
+
+  .ol-attribution.ol-uncollapsible {
+    bottom: 12px;
+  }
 </style>

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -1,6 +1,4 @@
-<template>
-    <div class="map wgu-map" id="ol-map"></div>
-</template>
+<template></template>
 
 <script>
 
@@ -25,25 +23,14 @@ export default {
     }
   },
   mounted () {
-    this.map.setTarget(document.getElementById('ol-map'))
-
     // Send the event 'ol-map-mounted' with the OL map as payload
     WguEventBus.$emit('ol-map-mounted', this.map)
 
-    const appHeaderEl = document.querySelector('.wgu-app-toolbar');
-    if (appHeaderEl) {
-      const headerHeight = appHeaderEl.offsetHeight;
-      if (this.$isEmbedded) {
-        this.map.getTarget().style.height = 'calc(100% - ' + headerHeight + 'px)';
-      } else {
-        this.map.getTarget().style.height = 'calc(100vh - ' + headerHeight + 'px)';
-      }
-    }
-
     // resize the map, so it fits to parent
     window.setTimeout(() => {
+      this.map.setTarget(document.getElementById('ol-map-container'));
       this.map.updateSize();
-    }, 100);
+    }, 200);
   },
   created () {
     this.map = new Map({
@@ -106,14 +93,17 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-  .wgu-map .ol-zoom {
+  .ol-zoom {
     top: auto;
     left: auto;
     bottom: 3em;
     right: 0.5em;
   }
 
-  .wgu-map .ol-control button {
+  .ol-control button {
     background-color: #c62828;
+  }
+  .ol-control button:hover, .ol-control button:active, .ol-control button:focus {
+    background-color: #d82828;
   }
 </style>

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -44,7 +44,7 @@
       "name": "Vector Tile Layer",
       "url": "https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf",
       "format": "MVT",
-      "visible": true,
+      "visible": false,
       "styleRef": "neWorldMvt"
     },
 
@@ -75,7 +75,8 @@
       "sketchVertexFillColor": "rgba(198,40,40,0.2)"
     },
     "wgu-infoclick": {
-      "target": "menu"
+      "target": "menu",
+      "win": true
     },
     "wgu-zoomtomaxextent": {
       "target": "toolbar"

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -60,13 +60,28 @@
   ],
 
   "modules": {
-    "wgumeasure": {
+    "wgu-layerlist": {
+      "target": "menu",
+      "win": true
+    },
+    "wgu-measuretool": {
+      "target": "menu",
+      "win": true,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
       "sketchStrokeColor": "rgba(198,40,40,0.8)",
       "sketchFillColor": "rgba(198,40,40,0.1)",
       "sketchVertexStrokeColor": "#c62828",
       "sketchVertexFillColor": "rgba(198,40,40,0.2)"
+    },
+    "wgu-infoclick": {
+      "target": "menu"
+    },
+    "wgu-zoomtomaxextent": {
+      "target": "toolbar"
+    },
+    "wgu-helpwin": {
+      "target": "toolbar"
     }
   }
 

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -2,7 +2,7 @@
 
   "title": "Vue.js / OpenLayers WebGIS",
 
-  "logo": "https://www.placecage.com/100/100",
+  "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
   "logoSize": "100",
 
   "mapZoom": 2,

--- a/test/unit/specs/AppHeader.spec.js
+++ b/test/unit/specs/AppHeader.spec.js
@@ -2,6 +2,15 @@ import Vue from 'vue'
 import AppHeader from '@/components/AppHeader'
 
 describe('AppHeader.vue', () => {
+  //
+  it('has a method toggleUi', () => {
+    const Constructor = Vue.extend(AppHeader);
+    const ah = new Constructor({
+    }).$mount();
+    expect(typeof ah.getModuleButtonData).to.equal('function');
+    expect(typeof ah.getToolbarButtons).to.equal('function');
+  });
+
   // Evaluate the results of functions in
   // the raw component options
   it('sets the correct default data', () => {
@@ -9,8 +18,6 @@ describe('AppHeader.vue', () => {
       title: 'foo'
     };
     expect(typeof AppHeader.data).to.equal('function');
-    const defaultData = AppHeader.data();
-    expect(typeof defaultData).to.equal('object');
   });
 
   // Mount an instance and inspect the render output

--- a/test/unit/specs/helpwin/HelpWin.spec.js
+++ b/test/unit/specs/helpwin/HelpWin.spec.js
@@ -15,6 +15,6 @@ describe('helpwin/HelpWin.vue', () => {
     const Constructor = Vue.extend(HelpWin)
     const vm = new Constructor().$mount();
     // el is not undefined but this tests that it is not rendered
-    expect(vm.$el.textContent).to.equal('');
+    expect(vm.$el.textContent).to.equal('help About  close About Wegue WebGIS with OpenLayers and Vue.js Template and re-usable components for webmapping applications with OpenLayers and Vue.js More info');
   });
 });

--- a/test/unit/specs/helpwin/ToggleButton.spec.js
+++ b/test/unit/specs/helpwin/ToggleButton.spec.js
@@ -7,7 +7,7 @@ describe('helpwin/ToggleButton.vue', () => {
     const Constructor = Vue.extend(HelpWinToggleBtn);
     const hwtb = new Constructor({
     }).$mount();
-    expect(typeof hwtb.toggleUi).to.equal('function');
+    expect(hwtb.icon).to.equal('help');
   });
 
   // Evaluate the results of functions
@@ -15,7 +15,6 @@ describe('helpwin/ToggleButton.vue', () => {
     expect(typeof HelpWinToggleBtn.data).to.equal('function');
     const defaultData = HelpWinToggleBtn.data();
     expect(typeof defaultData).to.equal('object');
-    expect(defaultData.show).to.equal(false);
   });
 
   // Mount an instance and inspect the render output
@@ -26,7 +25,5 @@ describe('helpwin/ToggleButton.vue', () => {
     }).$mount();
     const btn = vm.$el.querySelector('v-btn');
     expect(btn !== null).to.equal(true);
-    const icon = vm.$el.querySelector('v-icon');
-    expect(icon !== null).to.equal(true);
   });
 });

--- a/test/unit/specs/infoclick/InfoClickWin.spec.js
+++ b/test/unit/specs/infoclick/InfoClickWin.spec.js
@@ -12,8 +12,6 @@ describe('infoclick/InfoClickWin.vue', () => {
   it('sets the correct default data', () => {
     expect(typeof InfoClickWin.data).to.equal('function');
     const defaultData = InfoClickWin.data();
-    expect(defaultData.show).to.equal(false);
-    expect(defaultData.icon).to.equal('info');
     expect(defaultData.coordsMapProj).to.equal('');
     expect(defaultData.coordsWgs84).to.equal('');
     expect(defaultData.coordsHdms).to.equal('');

--- a/test/unit/specs/infoclick/ToggleButton.spec.js
+++ b/test/unit/specs/infoclick/ToggleButton.spec.js
@@ -15,20 +15,5 @@ describe('infoclick/ToggleButton.vue', () => {
     expect(typeof InfoClickToggleBtn.data).to.equal('function');
     const defaultData = InfoClickToggleBtn.data();
     expect(typeof defaultData).to.equal('object');
-    expect(defaultData.show).to.equal(false);
-    expect(defaultData.icon).to.equal('info');
-    expect(defaultData.text).to.equal('');
-  });
-
-  // Mount an instance and inspect the render output
-  it('renders the right sub-components', () => {
-    const Constructor = Vue.extend(InfoClickToggleBtn);
-    const vm = new Constructor({
-      icon: 'info'
-    }).$mount();
-    const btn = vm.$el.querySelector('v-btn');
-    expect(btn !== null).to.equal(true);
-    const icon = vm.$el.querySelector('v-icon');
-    expect(icon !== null).to.equal(true);
   });
 });

--- a/test/unit/specs/layerlist/ToggleButton.spec.js
+++ b/test/unit/specs/layerlist/ToggleButton.spec.js
@@ -15,7 +15,6 @@ describe('layerlist/ToggleButton.vue', () => {
     expect(typeof LayerListToggleBtn.data).to.equal('function');
     const defaultData = LayerListToggleBtn.data();
     expect(typeof defaultData).to.equal('object');
-    expect(defaultData.show).to.equal(false);
   });
 
   // Mount an instance and inspect the render output
@@ -26,7 +25,5 @@ describe('layerlist/ToggleButton.vue', () => {
     }).$mount();
     const btn = vm.$el.querySelector('v-btn');
     expect(btn !== null).to.equal(true);
-    const icon = vm.$el.querySelector('v-icon');
-    expect(icon !== null).to.equal(true);
   });
 });

--- a/test/unit/specs/measuretool/ToggleButton.spec.js
+++ b/test/unit/specs/measuretool/ToggleButton.spec.js
@@ -15,16 +15,5 @@ describe('measuretool/ToggleButton.vue', () => {
     expect(typeof MeasureToggleBtn.data).to.equal('function');
     const defaultData = MeasureToggleBtn.data();
     expect(typeof defaultData).to.equal('object');
-    expect(defaultData.show).to.equal(false);
-  });
-
-  // Mount an instance and inspect the render output
-  it('renders the right sub-components', () => {
-    const Constructor = Vue.extend(MeasureToggleBtn);
-    const vm = new Constructor().$mount();
-    const btn = vm.$el.querySelector('v-btn');
-    expect(btn !== null).to.equal(true);
-    const icon = vm.$el.querySelector('v-icon');
-    expect(icon !== null).to.equal(true);
   });
 });


### PR DESCRIPTION
This PR refactors / reworks the complete app layout. Therefore several things have been done:

  - Refactor and optimize the app template by using more `Vuetify` layout components
  - Dynamic creation of the tools / modules, which can be shown in the toolbar, from the app config 
    - Separate module windows and their activation buttons to get more flexibility while rendering them
    - Add a reference concept using an app-wide component-lookup (by module-identificator) for module windows (to access them by activation buttons)
  - Introduce a toolbar menu, which groups several tools (fixes #33)
  - Implement the `About` window as modal dialog
  - Introduce a footer

This makes the tool creation more flexible and solves the problem that the tool-buttons cannot be shown on small screens. 

![image](https://user-images.githubusercontent.com/1185547/45553958-8ccfb480-b835-11e8-9147-d0e0d8a8de06.png)

Since this introduces changes in most of base components the current state has been preserved by the https://github.com/meggsimum/wegue/releases/tag/v0.4.0 release and a separate branch [v0.4.x-maintenance](https://github.com/meggsimum/wegue/tree/v0.4.x-maintenance).
