### PR TITLE
Make rendering of AppLogo optional based on given logo source

### DIFF
--- a/src/components/AppLogo.vue
+++ b/src/components/AppLogo.vue
@@ -1,6 +1,7 @@
 <template>
 
   <v-avatar
+     v-if="!!logoSrc"
      :size="logoSize"
      :tile="true"
      class="wgu-app-logo"


### PR DESCRIPTION
This prevents the rendering of the `AppLogo` in case the given logo source is not present or empty.