### PR TITLE
Make base color of application configurable

### DIFF
--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -1,21 +1,21 @@
 <template>
   <v-app id="wgu-app" data-app :class="{ 'wgu-app': true, 'wgu-app-embedded': isEmbedded }">
 
-    <wgu-app-header />
+    <wgu-app-header :color="baseColor" />
 
     <wgu-app-logo />
 
     <v-content>
       <v-container id="ol-map-container" fluid fill-height style="padding: 0">
-         <wgu-map />
+         <wgu-map :color="baseColor" />
       </v-container>
     </v-content>
 
     <template v-for="(moduleWin, index) in moduleWins">
-      <component :is="moduleWin.type" :key="index" :ref="moduleWin.type" />
+      <component :is="moduleWin.type" :key="index" :ref="moduleWin.type" :color="baseColor" />
     </template>
 
-    <v-footer color="red darken-3" class="white--text" app>
+    <v-footer :color="baseColor" class="white--text" app>
       <v-spacer></v-spacer>
       <span class="wgu-copyright">{{footerText}} <span v-if="showCopyrightYear" >&copy; {{ new Date().getFullYear() }}</span></span>
     </v-footer>
@@ -48,7 +48,8 @@
         isEmbedded: false,
         moduleWins: this.getModuleWinData(),
         footerText: Vue.prototype.$appConfig.footerText,
-        showCopyrightYear: Vue.prototype.$appConfig.showCopyrightYear
+        showCopyrightYear: Vue.prototype.$appConfig.showCopyrightYear,
+        baseColor: Vue.prototype.$appConfig.baseColor
       }
     },
     mounted () {

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <v-toolbar
     class="wgu-app-toolbar white--text"
-    color="red darken-3"
+    :color="color"
     fixed
     app
     clipped-right
@@ -16,7 +16,7 @@
     </v-layout> -->
 
     <template v-for="(tbButton, index) in tbButtons">
-      <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text"/>
+      <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text" :color="color" />
     </template>
 
     <v-menu offset-y>
@@ -26,7 +26,7 @@
       <v-list>
           <template v-for="(tbButton, index) in menuButtons">
               <v-list-tile>
-                <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text" />
+                <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text" :color="color" />
               </v-list-tile>
           </template>
       </v-list>
@@ -52,6 +52,9 @@ export default {
     'wgu-helpwin-btn': HelpWinToggleButton,
     'wgu-measuretool-btn': MeasureToolToggleButton,
     'wgu-infoclick-btn': InfoClickButton
+  },
+  props: {
+    color: {type: String, required: false, default: 'red darken-3'}
   },
   data () {
     return {

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -1,7 +1,7 @@
 <template>
 
   <v-card class="wgu-helpwin">
-    <v-toolbar class="red darken-3 white--text" dark>
+    <v-toolbar :color="color" class="" dark>
       <v-toolbar-side-icon><v-icon>{{ icon }}</v-icon></v-toolbar-side-icon>
       <v-toolbar-title>{{ title }}</v-toolbar-title>
       <v-spacer></v-spacer>
@@ -28,6 +28,7 @@
 <script>
   export default {
     props: {
+      color: {type: String, required: false, default: 'red darken-3'},
       icon: {type: String, required: false, default: 'help'},
       title: {type: String, required: false, default: 'About'},
       headline: {type: String, required: false, default: 'About Wegue'},

--- a/src/components/helpwin/ToggleButton.vue
+++ b/src/components/helpwin/ToggleButton.vue
@@ -9,6 +9,7 @@
 
     <wgu-helpwin
       ref="helpwin"
+      :color="color"
       :icon="icon"
       :title="text"
       :headline="headline"
@@ -32,6 +33,7 @@ export default {
     'wgu-helpwin': HelpWin
   },
   props: {
+    color: {type: String, required: false, default: 'red darken-3'},
     icon: {type: String, required: false, default: 'help'},
     text: {type: String, required: false},
     headline: {type: String, required: false},

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -1,7 +1,7 @@
 <template>
 
   <v-card v-draggable-win class="wgu-infoclick-win" v-if=show v-bind:style="{ left: left, top: top }">
-    <v-toolbar class="red darken-3 white--text" dark>
+    <v-toolbar :color="color" class="" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
       <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
       <v-spacer></v-spacer>
@@ -14,7 +14,7 @@
       </div>
 
       <!-- feature property grid -->
-      <table v-if="this.gridData !== null">
+      <table v-if="this.gridData !== null" :style="tableStyles">
         <thead>
           <tr>
             <th v-for="entry in gridData"
@@ -33,7 +33,7 @@
         </tbody>
       </table>
 
-      <table class="coords" v-if="this.coordsData !== null">
+      <table class="coords" v-if="this.coordsData !== null" :style="tableStyles">
         <thead>
           <tr>
             <th v-for="entry in coordsData"
@@ -58,6 +58,11 @@
 </template>
 
 <script>
+// helper function to detect a CSS color
+function isCssColor (color) {
+  return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
+}
+import vColors from 'vuetify/es5/util/colors';
 
 import { WguEventBus } from '../../WguEventBus.js';
 import {transform} from 'ol/proj.js';
@@ -66,6 +71,7 @@ import {toStringHDMS} from 'ol/coordinate';
 export default {
   name: 'wgu-infoclick-win',
   props: {
+    color: {type: String, required: false, default: 'red darken-3'},
     icon: {type: String, required: false, default: 'info'},
     title: {type: String, required: false, default: 'Map Click Info'}
   },
@@ -79,6 +85,23 @@ export default {
       coordsHdms: '',
       gridData: null,
       coordsData: null
+    }
+  },
+  computed: {
+    tableStyles () {
+      // calculate border color of tables due to current color property
+      let borderColor = this.color;
+      if (!isCssColor(this.color)) {
+        let [colorName, colorModifier] = this.color.toString().trim().split(' ', 2);
+        borderColor = vColors[colorName];
+        if (colorModifier) {
+          colorModifier = colorModifier.replace('-', '');
+          borderColor = vColors[colorName];
+        }
+      }
+      return {
+        'border': '2px solid ' + borderColor
+      };
     }
   },
   created () {

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -1,7 +1,7 @@
 <template>
 
   <v-card v-draggable-win class="wgu-layerlist" v-if=show v-bind:style="{ left: left, top: top }">
-    <v-toolbar class="red darken-3 white--text" dark>
+    <v-toolbar :color="color" class="" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
       <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
       <v-spacer></v-spacer>
@@ -35,6 +35,7 @@
     },
     mixins: [Mapable],
     props: {
+      color: {type: String, required: false, default: 'red darken-3'},
       icon: {type: String, required: false, default: 'layers'},
       title: {type: String, required: false, default: 'Layers'}
     },

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -1,7 +1,7 @@
 <template>
 
   <v-card class="wgu-measurewin" v-draggable-win v-if="show" v-bind:style="{ left: left, top: top }">
-    <v-toolbar class="red darken-3 white--text" dark>
+    <v-toolbar :color="color" class="" dark>
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
       <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
       <v-spacer></v-spacer>
@@ -59,6 +59,7 @@
     },
     mixins: [Mapable],
     props: {
+      color: {type: String, required: false, default: 'red darken-3'},
       icon: {type: String, required: false, default: 'photo_size_select_small'},
       title: {type: String, required: false, default: 'Measure'}
     },

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -2,6 +2,8 @@
 
   "title": "Vue.js / OpenLayers WebGIS",
 
+  "baseColor": "red darken-3",
+
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
   "logoSize": "100",
 


### PR DESCRIPTION
This allows to change the base color of the application (used in header, footer, window-title, etc.) by a configuration property. The old (hard-coded) color (`red darken-3` => `#C62828`) is set as default due to legacy reasons.

Every CSS color or [Vuetify Material Color](https://vuetifyjs.com/en/framework/colors) can be used.

```JSON
{

  "title": "Vue.js / OpenLayers WebGIS",

  "baseColor": "red darken-3"

  ...
}
```


```JSON
{

  "title": "Vue.js / OpenLayers WebGIS",

  "baseColor": "#ff0000"

  ...
}
```