### PR TITLE
Add property to ignore layers in LayerList

### DIFF
--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -77,6 +77,10 @@
         var layerItems = []
         var visibleLayers = []
         layers.forEach(function (layer) {
+          // skip if layer should not be listed
+          if (layer.get('displayInLayerList') === false) {
+            return;
+          }
           var visible = layer.getVisible();
           var name = layer.get('name');
           layerItems.push({

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -67,6 +67,7 @@ export const LayerFactory = {
     const layer = new TileLayer({
       name: lConf.name,
       lid: lConf.lid,
+      displayInLayerList: lConf.displayInLayerList,
       extent: lConf.extent,
       visible: lConf.visible,
       opacity: lConf.opacity,
@@ -92,6 +93,7 @@ export const LayerFactory = {
    */
   createXyzLayer (lConf) {
     const xyzLayer = new TileLayer({
+      displayInLayerList: lConf.displayInLayerList,
       extent: lConf.extent,
       source: new TileWmsSource({
         url: lConf.url,
@@ -112,6 +114,7 @@ export const LayerFactory = {
     const layer = new TileLayer({
       name: lConf.name,
       lid: lConf.lid,
+      displayInLayerList: lConf.displayInLayerList,
       visible: lConf.visible,
       opacity: lConf.opacity,
       source: new OsmSource()
@@ -130,6 +133,7 @@ export const LayerFactory = {
     const vectorLayer = new VectorLayer({
       name: lConf.name,
       lid: lConf.lid,
+      displayInLayerList: lConf.displayInLayerList,
       extent: lConf.extent,
       visible: lConf.visible,
       opacity: lConf.opacity,
@@ -154,6 +158,7 @@ export const LayerFactory = {
     const vtLayer = new VectorTileLayer({
       name: lConf.name,
       lid: lConf.lid,
+      displayInLayerList: lConf.displayInLayerList,
       visible: lConf.visible,
       opacity: lConf.opacity,
       source: new VectorTileSource({


### PR DESCRIPTION
This introduces a Boolean property `displayInLayerList` in order to exclude map layers from the `LayerList` component. The property has to be set to the corresponding OL layer object.

Closes #43.