### PR TITLE
Do not show layer with measure geoms in LayerList

### DIFF
--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -106,6 +106,7 @@
         var source = new VectorSource();
         var vector = new VectorLayer({
           name: 'Measure Layer',
+          displayInLayerList: false,
           source: source,
           style: new Style({
             fill: new Fill({


### PR DESCRIPTION
This avoids that the map layer with the measure geometries is shown in the `LayerList` component. The visibility management of this layer is done by the `Measure` component itself.