### PR TITLE
Introduce util for OpenLayers layers

### DIFF
--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -27,6 +27,7 @@
 <script>
   import { DraggableWin } from '../../directives/DraggableWin.js';
   import { Mapable } from '../../mixins/Mapable';
+  import LayerUtil from '../../util/Layer';
 
   export default {
     name: 'wgu-layerlist-win',
@@ -115,30 +116,11 @@
         })
 
         me.visibleLayers.forEach(function (layerNode) {
-          var layer = me.getLayersBy('name', layerNode)[0]
+          const layer = LayerUtil.getLayersBy('name', layerNode, me.map)[0];
           if (layer) {
             layer.setVisible(true)
           }
         })
-      },
-
-      /**
-       * Returns a set of map layers which matches the given key value pair.
-       *
-       * @param {String} key - Key to filter layers
-       * @param {Object} value - Value to filter layers
-       * @return {ol.layer.Base[]} Array of matching layers
-       */
-      getLayersBy (key, value) {
-        var layerMatches = []
-        var allLayers = this.map.getLayers()
-        allLayers.forEach(function (layer) {
-          if (layer.get(key) === value) {
-            layerMatches.push(layer)
-          }
-        })
-
-        return layerMatches
       }
     }
   }

--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -1,0 +1,42 @@
+/**
+ * Util class for OL layers
+ */
+const LayerUtil = {
+  /**
+   * Returns a set of map layers which matches the given key value pair.
+   *
+   * @param {String} key - Key to filter layers
+   * @param {Object} value - Value to filter layers
+   * @param  {ol.Map} olMap  The OL map to search in
+   * @return {ol.layer.Base[]} Array of matching layers
+   */
+  getLayersBy (key, value, olMap) {
+    if (!olMap) {
+      console.warn('No OL map passed to LayerUtil.getLayersBy - ' +
+        'no layer detection possible!');
+      return [];
+    }
+
+    let layerMatches = [];
+    olMap.getLayers().forEach(function (layer) {
+      if (layer.get(key) === value) {
+        layerMatches.push(layer);
+      }
+    });
+
+    return layerMatches;
+  },
+
+  /**
+   * Returns a map layer with the given LID (Layer ID)
+   *
+   * @param  {String} lid    The LID of the layer to query
+   * @param  {ol.Map} olMap  The OL map to search in
+   * @return {ol.layer.Base} The OL layer instance or undefined
+   */
+  getLayerByLid (lid, olMap) {
+    return LayerUtil.getLayersBy('lid', lid, olMap)[0];
+  }
+}
+
+export default LayerUtil;

--- a/test/unit/specs/util/Layer.spec.js
+++ b/test/unit/specs/util/Layer.spec.js
@@ -1,0 +1,112 @@
+import LayerUtil from '@/util/Layer'
+import Map from 'ol/Map'
+import View from 'ol/View'
+import TileLayer from 'ol/layer/Tile'
+import OSM from 'ol/source/OSM'
+
+describe('LayerUtil', () => {
+  it('is defined', () => {
+    expect(typeof UrlUtil).to.not.equal(undefined);
+  });
+
+  it('has the correct functions', () => {
+    expect(typeof LayerUtil.getLayersBy).to.equal('function');
+    expect(typeof LayerUtil.getLayerByLid).to.equal('function');
+  });
+
+  it('getLayersBy returns correct layers wrapped as array', () => {
+    const olMap = new Map({
+      layers: [
+        new TileLayer({
+          foo: 'bar',
+          source: new OSM()
+        }),
+        new TileLayer({
+          foo: 'bar',
+          source: new OSM()
+        })
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    const layerArr = LayerUtil.getLayersBy('foo', 'bar', olMap);
+    expect(layerArr).to.be.an('array');
+    expect(layerArr.length).to.eql(2);
+  });
+
+  it('getLayersBy returns empty array for non matching input params', () => {
+    const olMap = new Map({
+      layers: [
+        new TileLayer({
+          source: new OSM()
+        })
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    const layerArr = LayerUtil.getLayersBy('foo', 'bar', olMap);
+    expect(layerArr).to.be.an('array');
+    expect(layerArr).to.eql([]);
+  });
+
+  it('getLayersBy returns empty array if no OL map is passed', () => {
+    const layerArr = LayerUtil.getLayersBy('foo', 'bar');
+    expect(layerArr).to.be.an('array');
+    expect(layerArr).to.eql([]);
+  });
+
+  it('getLayerByLid returns correct layer', () => {
+    const olMap = new Map({
+      layers: [
+        new TileLayer({
+          lid: 'bar',
+          name: 'Test',
+          source: new OSM()
+        }),
+        new TileLayer({
+          foo2: 'bar',
+          source: new OSM()
+        })
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    const layer = LayerUtil.getLayerByLid('bar', olMap);
+    expect(typeof layer).to.not.equal(undefined);
+    expect(layer).to.be.an('object');
+    expect(layer.get('name')).to.eql('Test')
+  });
+
+  it('getLayerByLid returns undefined for non existing layer', () => {
+    const olMap = new Map({
+      layers: [
+        new TileLayer({
+          lid: 'bar',
+          name: 'Test',
+          source: new OSM()
+        }),
+        new TileLayer({
+          foo2: 'bar',
+          source: new OSM()
+        })
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    const layer = LayerUtil.getLayerByLid('kalle', olMap);
+    expect(layer).to.equal(undefined);
+  });
+
+  it('getLayerByLid returns undefined if no OL map is passed', () => {
+    const layer = LayerUtil.getLayerByLid('kalle');
+    expect(layer).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
Adds a utility module in order to work with OL layer instances. Currently the following functions are introduced: 

* `getLayersBy` => Returns a set of map layers which matches the given key value pair
* `getLayerByLid` => Returns a map layer with the given LID (Layer ID)