### PR TITLE
Remove empty click handler for Layerist item

### DIFF
--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -9,7 +9,7 @@
     </v-toolbar>
     <v-list>
       <v-list-group v-for="item in items" :value="item.active" v-bind:key="item.title">
-        <v-list-tile class="wgu-layerlist-item" v-for="subItem in item.items" v-bind:key="subItem.title" @click="">
+        <v-list-tile class="wgu-layerlist-item" v-for="subItem in item.items" v-bind:key="subItem.title">
           <input type="checkbox" class="wgu-layer-viz-cb" v-bind:value="subItem.title" v-model="visibleLayers" @change="layerVizChanged">
           <v-list-tile-content class="black--text">
               <v-list-tile-title>{{ subItem.title }}</v-list-tile-title>


### PR DESCRIPTION
This removes the empty click handler for the layer items in the `LayerList` component. This avoids the pointer symbol for the mouse cursor, which was misleading for the users that there is something happening when clicking.