### PR TITLE
LayerList refactoring / optimization

### DIFF
--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -30,7 +30,7 @@
   import AppHeader from './components/AppHeader'
   import AppLogo from './components/AppLogo'
   import MeasureWin from './components/measuretool/MeasureWin'
-  import LayerListWin from './components/layerlist/LayerList'
+  import LayerListWin from './components/layerlist/LayerListWin'
   import InfoClickWin from './components/infoclick/InfoClickWin'
 
   export default {

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -5,20 +5,15 @@
       <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
       <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
+      <v-toolbar-side-icon @click="show=false"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
     <v-list>
-      <v-list-group v-for="item in items" :value="item.active" v-bind:key="item.title">
-        <v-list-tile class="wgu-layerlist-item" v-for="subItem in item.items" v-bind:key="subItem.title">
-          <input type="checkbox" class="wgu-layer-viz-cb" v-bind:value="subItem.title" v-model="visibleLayers" @change="layerVizChanged">
-          <v-list-tile-content class="black--text">
-              <v-list-tile-title>{{ subItem.title }}</v-list-tile-title>
-          </v-list-tile-content>
-          <v-list-tile-action>
-            <v-icon>{{ subItem.action }}</v-icon>
-          </v-list-tile-action>
-        </v-list-tile>
-      </v-list-group>
+      <v-list-tile class="wgu-layerlist-item" v-for="layerItem in layerItems" v-bind:key="layerItem.lid">
+        <input type="checkbox" :key="layerItem.lid" class="wgu-layer-viz-cb" v-model="layerItem.visible" @change="layerVizChanged">
+        <v-list-tile-content class="black--text">
+            <v-list-tile-title>{{ layerItem.title }}</v-list-tile-title>
+        </v-list-tile-content>
+      </v-list-tile>
     </v-list>
   </v-card>
 
@@ -44,9 +39,7 @@
       return {
         moduleName: 'wgu-layerlist',
         // will be filled in createLayerItems
-        items: [],
-        // will be filled in createLayerItems a. adapted by the layer checkboxes
-        visibleLayers: [],
+        layerItems: [],
         show: false,
         left: '10px',
         top: '70px'
@@ -75,52 +68,35 @@
         var layerArrClone = layers.getArray().slice(0);
         layers = layerArrClone.reverse();
 
-        var layerItems = []
-        var visibleLayers = []
+        var layerItems = [];
         layers.forEach(function (layer) {
           // skip if layer should not be listed
           if (layer.get('displayInLayerList') === false) {
             return;
           }
-          var visible = layer.getVisible();
-          var name = layer.get('name');
           layerItems.push({
-            title: name,
-            visible: visible
+            title: layer.get('name'),
+            lid: layer.get('lid'),
+            visible: layer.getVisible()
           })
+        });
 
-          if (visible) {
-            visibleLayers.push(name);
-          }
-        })
-
-        // set the initial state of visible layers
-        this.visibleLayers = visibleLayers
-
-        // set the layer list
-        this.items = [{
-          title: '',
-          items: layerItems,
-          active: true
-        }]
+        this.layerItems = layerItems;
       },
 
       /**
-       * Handles the 'change' event of the visibility checkboxes of the layers
+       * Handles the 'change' event of the visibility checkboxes in order to
+       * apply the current visibility state in 'data' to the OL layers.
        */
       layerVizChanged () {
-        var me = this
+        var me = this;
 
-        me.map.getLayers().forEach(function (layer) {
-          layer.setVisible(false)
-        })
-
-        me.visibleLayers.forEach(function (layerNode) {
-          const layer = LayerUtil.getLayersBy('name', layerNode, me.map)[0];
+        me.layerItems.forEach(function (layerItem, idx) {
+          const layer = LayerUtil.getLayerByLid(layerItem.lid, me.map);
           if (layer) {
-            layer.setVisible(true)
+            layer.setVisible(layerItem.visible);
           }
-        })
+        });
       }
     }
   }
@@ -128,24 +104,12 @@
 
 <style>
 
-  .wgu-layerlist {
-    background-color: white;
-    z-index: 2;
-  }
   .v-card.wgu-layerlist {
     position: absolute;
   }
 
-  .wgu-layerlist-item a.v-list__tile {
-    padding-left: 0;
-  }
-
   .wgu-layer-viz-cb {
     width: 45px;
-  }
-
-  .wgu-layerlist .v-list__group__header {
-    display: none;
   }
 
 </style>

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -8,7 +8,7 @@
       <v-toolbar-side-icon @click="show=false"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
     <v-list>
-      <v-list-tile class="wgu-layerlist-item" v-for="layerItem in layerItems" v-bind:key="layerItem.lid">
+      <v-list-tile class="wgu-layerlist-item" v-for="layerItem in layerItems" v-bind:key="layerItem.lid" @click="onItemClick($event, layerItem)">
         <input type="checkbox" :key="layerItem.lid" class="wgu-layer-viz-cb" v-model="layerItem.visible" @change="layerVizChanged">
         <v-list-tile-content class="black--text">
             <v-list-tile-title>{{ layerItem.title }}</v-list-tile-title>
@@ -82,6 +82,19 @@
         });
 
         this.layerItems = layerItems;
+      },
+
+      /**
+       * Handler for click on item in layer list:
+       * Toggles the corresponding visibility and calls this.layerVizChanged.
+       *
+       * @param  {Object} ect       Original vue click event
+       * @param  {Object} layerItem Layer item data object
+       */
+      onItemClick (evt, layerItem) {
+        layerItem.visible = !layerItem.visible;
+
+        this.layerVizChanged();
       },
 
       /**

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -1,48 +1,28 @@
 <template>
 
-  <v-card v-draggable-win class="wgu-layerlist" v-if=show v-bind:style="{ left: left, top: top }">
-    <v-toolbar :color="color" class="" dark>
-      <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-      <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
-      <v-spacer></v-spacer>
-      <v-toolbar-side-icon @click="show=false"><v-icon>close</v-icon></v-toolbar-side-icon>
-    </v-toolbar>
-    <v-list>
-      <v-list-tile class="wgu-layerlist-item" v-for="layerItem in layerItems" v-bind:key="layerItem.lid" @click="onItemClick($event, layerItem)">
-        <input type="checkbox" :key="layerItem.lid" class="wgu-layer-viz-cb" v-model="layerItem.visible" @change="layerVizChanged">
-        <v-list-tile-content class="black--text">
-            <v-list-tile-title>{{ layerItem.title }}</v-list-tile-title>
-        </v-list-tile-content>
-      </v-list-tile>
-    </v-list>
-  </v-card>
+  <v-list>
+    <v-list-tile class="wgu-layerlist-item" v-for="layerItem in layerItems" v-bind:key="layerItem.lid" @click="onItemClick($event, layerItem)">
+      <input type="checkbox" :key="layerItem.lid" class="wgu-layer-viz-cb" v-model="layerItem.visible" @change="layerVizChanged">
+      <v-list-tile-content class="black--text">
+          <v-list-tile-title>{{ layerItem.title }}</v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+  </v-list>
 
 </template>
 
 <script>
-  import { DraggableWin } from '../../directives/DraggableWin.js';
   import { Mapable } from '../../mixins/Mapable';
   import LayerUtil from '../../util/Layer';
 
   export default {
-    name: 'wgu-layerlist-win',
-    directives: {
-      DraggableWin
-    },
+    name: 'wgu-layerlist',
     mixins: [Mapable],
     props: {
-      color: {type: String, required: false, default: 'red darken-3'},
-      icon: {type: String, required: false, default: 'layers'},
-      title: {type: String, required: false, default: 'Layers'}
     },
     data () {
       return {
-        moduleName: 'wgu-layerlist',
-        // will be filled in createLayerItems
-        layerItems: [],
-        show: false,
-        left: '10px',
-        top: '70px'
+        layerItems: []
       }
     },
     methods: {
@@ -116,10 +96,6 @@
 </script>
 
 <style>
-
-  .v-card.wgu-layerlist {
-    position: absolute;
-  }
 
   .wgu-layer-viz-cb {
     width: 45px;

--- a/src/components/layerlist/LayerListWin.vue
+++ b/src/components/layerlist/LayerListWin.vue
@@ -1,0 +1,51 @@
+<template>
+
+  <v-card v-draggable-win class="wgu-layerlist" v-if=show v-bind:style="{ left: left, top: top }">
+    <v-toolbar :color="color" class="" dark>
+      <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
+      <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-toolbar-side-icon @click="show=false"><v-icon>close</v-icon></v-toolbar-side-icon>
+    </v-toolbar>
+
+    <wgu-layerlist />
+
+  </v-card>
+
+</template>
+
+<script>
+  import { DraggableWin } from '../../directives/DraggableWin.js';
+  import LayerList from './LayerList';
+
+  export default {
+    name: 'wgu-layerlist-win',
+    directives: {
+      DraggableWin
+    },
+    components: {
+      'wgu-layerlist': LayerList
+    },
+    props: {
+      color: {type: String, required: false, default: 'red darken-3'},
+      icon: {type: String, required: false, default: 'layers'},
+      title: {type: String, required: false, default: 'Layers'}
+    },
+    data () {
+      return {
+        moduleName: 'wgu-layerlist',
+        show: false,
+        left: '10px',
+        top: '70px'
+      }
+    }
+  }
+</script>
+
+<style>
+
+  .v-card.wgu-layerlist {
+    position: absolute;
+  }
+
+</style>

--- a/src/components/layerlist/ToggleButton.vue
+++ b/src/components/layerlist/ToggleButton.vue
@@ -14,7 +14,7 @@
 <script>
 
 import Vue from 'vue';
-import LayerListWin from './LayerList'
+import LayerListWin from './LayerListWin'
 import { WguEventBus } from '../../WguEventBus'
 
 export default {

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -6,6 +6,8 @@ function isCssColor (color) {
   return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
 }
 
+import Vue from 'vue';
+
 import Map from 'ol/Map'
 import View from 'ol/View'
 import Attribution from 'ol/control/Attribution';
@@ -29,6 +31,9 @@ export default {
   },
   mounted () {
     var me = this;
+    // Make the OL map accessible for Mapable mixin even 'ol-map-mounted' has
+    // already been fired. Don not use directly in cmps, use Mapable instead.
+    Vue.prototype.$map = me.map;
     // Send the event 'ol-map-mounted' with the OL map as payload
     WguEventBus.$emit('ol-map-mounted', me.map);
 

--- a/src/mixins/Mapable.js
+++ b/src/mixins/Mapable.js
@@ -1,5 +1,3 @@
-// import Vue from 'vue';
-
 import { WguEventBus } from '../WguEventBus.js'
 
 /**
@@ -7,14 +5,25 @@ import { WguEventBus } from '../WguEventBus.js'
  * Executes the onMapBound function of the target component, if available.
  */
 export const Mapable = {
-  created: function () {
-    WguEventBus.$on('ol-map-mounted', (olMap) => {
-      // make the OL map accesible in this component
-      this.map = olMap;
+  created () {
+    // if the OL map is not present in the vue prototype we have to wait until
+    // it is mounted. Otherwise apply OL map as member var.
+    if (!this.$map) {
+      // apply OL map once OL map is mounted
+      WguEventBus.$on('ol-map-mounted', (olMap) => {
+        // make the OL map accesible in this component
+        this.map = olMap;
 
+        if (this.onMapBound) {
+          this.onMapBound();
+        }
+      });
+    } else {
+      // OL map is already mounted --> directly apply as member
+      this.map = this.$map;
       if (this.onMapBound) {
         this.onMapBound();
       }
-    });
+    }
   }
 };

--- a/test/unit/specs/layerlist/LayerList.spec.js
+++ b/test/unit/specs/layerlist/LayerList.spec.js
@@ -7,14 +7,17 @@ describe('layerlist/LayerList.vue', () => {
   it('sets the correct default data', () => {
     expect(typeof LayerList.data).to.equal('function');
     const defaultData = LayerList.data();
-    expect(defaultData.show).to.equal(false);
+    expect(defaultData.layerItems).to.be.an('array');
+    expect(defaultData.layerItems.length).to.eql(0);
   });
 
   // Mount an instance and inspect the render output
   it('does not render on startup', () => {
     const Constructor = Vue.extend(LayerList)
     const vm = new Constructor().$mount();
-    // el is not undefined but this tests that it is not rendered
-    expect(vm.$el.textContent).to.equal('');
+
+    // no layers should bring up no list entries
+    const layerListDomItems = vm.$el.querySelector('.wgu-layerlist-item');
+    expect(layerListDomItems).to.equal(null);
   });
 });

--- a/test/unit/specs/layerlist/LayerListWin.spec.js
+++ b/test/unit/specs/layerlist/LayerListWin.spec.js
@@ -1,0 +1,23 @@
+import Vue from 'vue'
+import LayerListWin from '@/components/layerlist/LayerListWin'
+
+describe('layerlist/LayerListWin.vue', () => {
+  // Evaluate the results of functions in
+  // the raw component options
+  it('sets the correct default data', () => {
+    expect(typeof LayerListWin.data).to.equal('function');
+    const defaultData = LayerListWin.data();
+    expect(defaultData.show).to.equal(false);
+    expect(defaultData.left).to.equal('10px');
+    expect(defaultData.top).to.equal('70px');
+  });
+
+  // Mount an instance and inspect the render output
+  it('does not render on startup', () => {
+    const Constructor = Vue.extend(LayerListWin);
+    const vm = new Constructor().$mount();
+
+    // el is not undefined but this tests that it is not rendered
+    expect(vm.$el.textContent).to.equal('');
+  });
+});


### PR DESCRIPTION
This PR optimizes the `LayerList` component:

- Simplify UI template and data handling
- Add click handler for layer items in `LayerList`, so the user can toggle the layer visibility by clicking the whole item (instead of just clicking the checkbox) 
- Separate `LayerList` and `LayerListWin` components