### PR TITLE
Fix missing color modifier for InfoClick table border

### DIFF
--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -96,7 +96,7 @@ export default {
         borderColor = vColors[colorName];
         if (colorModifier) {
           colorModifier = colorModifier.replace('-', '');
-          borderColor = vColors[colorName];
+          borderColor = vColors[colorName][colorModifier];
         }
       }
       return {
@@ -181,7 +181,6 @@ export default {
   }
 
   .wgu-infoclick-win table {
-    border: 2px solid #c62828;
     border-radius: 3px;
     background-color: #fff;
   }

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -59,11 +59,13 @@
 
 <script>
 // helper function to detect a CSS color
+// Taken from Vuetify sources
+// https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/colorable.ts
 function isCssColor (color) {
   return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
 }
-import vColors from 'vuetify/es5/util/colors';
 
+import vColors from 'vuetify/es5/util/colors';
 import { WguEventBus } from '../../WguEventBus.js';
 import {transform} from 'ol/proj.js';
 import {toStringHDMS} from 'ol/coordinate';

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -2,12 +2,13 @@
 
 <script>
 // helper function to detect a CSS color
+// Taken from Vuetify sources
+// https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/colorable.ts
 function isCssColor (color) {
   return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
 }
 
 import Vue from 'vue';
-
 import Map from 'ol/Map'
 import View from 'ol/View'
 import Attribution from 'ol/control/Attribution';


### PR DESCRIPTION
This fixes the missing color modifier for the border color when a [Vuetify Material Color](https://vuetifyjs.com/en/framework/colors) is passed in.