### PR TITLE
Refactor InfoClickWin

### DIFF
--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -37,7 +37,10 @@ export default {
   name: 'wgu-coords-table',
   props: {
     color: {type: String, required: false, default: 'red darken-3'},
-    coordsData: {type: Object}
+    coordsData: {type: Object},
+    showMapPos: {type: Boolean, required: false, default: true},
+    showWgsPos: {type: Boolean, required: false, default: true},
+    showHdms: {type: Boolean, required: false, default: true}
   },
   data: function () {
     return {
@@ -68,16 +71,27 @@ export default {
       const me = this;
       const coordinate = me.coordsData.coordinate;
       const projection = me.coordsData.projection;
+      const coordinateWgs84 = transform(coordinate, projection, 'EPSG:4326');
+      let coordRows = {};
 
-      var coordinateWgs84 =
-          transform(coordinate, projection, 'EPSG:4326');
-      var hdms = toStringHDMS(coordinateWgs84);
-
-      me.coordRows = {
-        'POS': coordinate[1].toFixed(2) + ' ' + coordinate[0].toFixed(2),
-        'WGS 84': coordinateWgs84[1].toFixed(7) + ' ' + coordinateWgs84[0].toFixed(7),
-        'HDMS': hdms
+      if (me.showMapPos) {
+        // show coordinate in map' SRS
+        coordRows['MAP PROJ'] =
+          coordinate[1].toFixed(2) + ' ' + coordinate[0].toFixed(2);
       }
+      if (me.showWgsPos) {
+        // show coordinate in WGS 84
+        const coordinateWgs84 = transform(coordinate, projection, 'EPSG:4326');
+        coordRows['WGS 84'] =
+          coordinateWgs84[1].toFixed(7) + '° ' + coordinateWgs84[0].toFixed(7) + '°'
+      }
+      if (me.showHdms) {
+        // show coordinate in WGS 84 as formatted deegree / min / secs
+        const hdms = toStringHDMS(coordinateWgs84);
+        coordRows['HDMS'] = hdms
+      }
+
+      me.coordRows = coordRows;
     }
   }
 };

--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -1,0 +1,94 @@
+<template>
+
+  <table class="coords" v-if="coordRows" :style="tableStyles">
+    <thead>
+      <tr>
+        <th v-for="entry in coordRows"
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(value, key) in coordRows">
+        <td class="key-td">
+          {{key}}
+        </td>
+        <td class="val-td">
+          {{value}}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+</template>
+
+<script>
+// helper function to detect a CSS color
+// Taken from Vuetify sources
+// https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/colorable.ts
+function isCssColor (color) {
+  return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
+}
+
+import vColors from 'vuetify/es5/util/colors';
+import {transform} from 'ol/proj.js';
+import {toStringHDMS} from 'ol/coordinate';
+
+export default {
+  name: 'wgu-coords-table',
+  props: {
+    color: {type: String, required: false, default: 'red darken-3'},
+    coordsData: {type: Object}
+  },
+  data: function () {
+    return {
+      coordRows: null
+    }
+  },
+  computed: {
+    tableStyles () {
+      // calculate border color of tables due to current color property
+      let borderColor = this.color;
+      if (!isCssColor(this.color)) {
+        let [colorName, colorModifier] = this.color.toString().trim().split(' ', 2);
+        borderColor = vColors[colorName];
+        if (colorModifier) {
+          colorModifier = colorModifier.replace('-', '');
+          borderColor = vColors[colorName][colorModifier];
+        }
+      }
+      return {
+        'border': '2px solid ' + borderColor
+      };
+    }
+  },
+  methods: {
+  },
+  watch: {
+    coordsData () {
+      const me = this;
+      const coordinate = me.coordsData.coordinate;
+      const projection = me.coordsData.projection;
+
+      var coordinateWgs84 =
+          transform(coordinate, projection, 'EPSG:4326');
+      var hdms = toStringHDMS(coordinateWgs84);
+
+      me.coordRows = {
+        'POS': coordinate[1].toFixed(2) + ' ' + coordinate[0].toFixed(2),
+        'WGS 84': coordinateWgs84[1].toFixed(7) + ' ' + coordinateWgs84[0].toFixed(7),
+        'HDMS': hdms
+      }
+    }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+
+.wgu-infoclick-win table.coords {
+  margin-top: 12px;
+  width: 100%;
+}
+
+</style>

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -33,29 +33,8 @@
         </tbody>
       </table>
 
-<<<<<<< HEAD
-      <table class="coords" v-if="this.coordsData !== null" :style="tableStyles">
-        <thead>
-          <tr>
-            <th v-for="entry in coordsData"
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(value, key) in coordsData">
-            <td>
-              {{key}}
-            </td>
-            <td>
-              {{value}}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-=======
       <!-- click coodinate info grid -->
       <wgu-coords-table :coordsData="coordsData" :color="color" />
->>>>>>> 08eed3b... Separate CoordsTable into own component
 
     </v-card-title>
   </v-card>

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -9,29 +9,12 @@
     </v-toolbar>
     <v-card-title primary-title>
 
-      <div v-if="this.gridData === null && this.coordsData === null" class="no-data">
+      <div v-if="!this.attributeData && !this.coordsData" class="no-data">
         Click on the map to get information for the clicked map position.
       </div>
 
       <!-- feature property grid -->
-      <table v-if="this.gridData !== null" :style="tableStyles">
-        <thead>
-          <tr>
-            <th v-for="entry in gridData"
-            </th>
-          </tr>
-        </thead>
-        <tbody class="attr-tbody">
-          <tr v-for="(value, key) in gridData">
-            <td>
-              {{key}}
-            </td>
-            <td>
-              {{value}}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <wgu-property-table :properties="attributeData" :color="color" />
 
       <!-- click coodinate info grid -->
       <wgu-coords-table :coordsData="coordsData" :color="color" />
@@ -42,20 +25,15 @@
 </template>
 
 <script>
-// helper function to detect a CSS color
-// Taken from Vuetify sources
-// https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/colorable.ts
-function isCssColor (color) {
-  return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
-}
 
-import vColors from 'vuetify/es5/util/colors';
 import { WguEventBus } from '../../WguEventBus.js';
+import PropertyTable from './PropertyTable';
 import CoordsTable from './CoordsTable';
 
 export default {
   name: 'wgu-infoclick-win',
   components: {
+    'wgu-property-table': PropertyTable,
     'wgu-coords-table': CoordsTable
   },
   props: {
@@ -68,25 +46,8 @@ export default {
       show: false,
       left: '2px',
       top: '270px',
-      gridData: null,
+      attributeData: null,
       coordsData: null
-    }
-  },
-  computed: {
-    tableStyles () {
-      // calculate border color of tables due to current color property
-      let borderColor = this.color;
-      if (!isCssColor(this.color)) {
-        let [colorName, colorModifier] = this.color.toString().trim().split(' ', 2);
-        borderColor = vColors[colorName];
-        if (colorModifier) {
-          colorModifier = colorModifier.replace('-', '');
-          borderColor = vColors[colorName][colorModifier];
-        }
-      }
-      return {
-        'border': '2px solid ' + borderColor
-      };
     }
   },
   created () {
@@ -144,11 +105,10 @@ export default {
   },
   watch: {
     show () {
+      const me = this;
       if (this.show === true) {
         me.registerMapClick();
       } else {
-        // unregister map click
-        me.registerMapClick(true);
         // cleanup old data
         me.attributeData = null;
         me.coordsData = null;

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -33,6 +33,7 @@
         </tbody>
       </table>
 
+<<<<<<< HEAD
       <table class="coords" v-if="this.coordsData !== null" :style="tableStyles">
         <thead>
           <tr>
@@ -51,6 +52,10 @@
           </tr>
         </tbody>
       </table>
+=======
+      <!-- click coodinate info grid -->
+      <wgu-coords-table :coordsData="coordsData" :color="color" />
+>>>>>>> 08eed3b... Separate CoordsTable into own component
 
     </v-card-title>
   </v-card>
@@ -67,11 +72,13 @@ function isCssColor (color) {
 
 import vColors from 'vuetify/es5/util/colors';
 import { WguEventBus } from '../../WguEventBus.js';
-import {transform} from 'ol/proj.js';
-import {toStringHDMS} from 'ol/coordinate';
+import CoordsTable from './CoordsTable';
 
 export default {
   name: 'wgu-infoclick-win',
+  components: {
+    'wgu-coords-table': CoordsTable
+  },
   props: {
     color: {type: String, required: false, default: 'red darken-3'},
     icon: {type: String, required: false, default: 'info'},
@@ -82,9 +89,6 @@ export default {
       show: false,
       left: '2px',
       top: '270px',
-      coordsMapProj: '',
-      coordsWgs84: '',
-      coordsHdms: '',
       gridData: null,
       coordsData: null
     }
@@ -138,21 +142,11 @@ export default {
           me.gridData = null;
         }
 
-        var coordinates = evt.coordinate;
-        var mapProjCode = me.map.getView().getProjection().getCode();
-        var coordinatesWgs84 =
-            transform(coordinates, mapProjCode, 'EPSG:4326');
-        var hdms = toStringHDMS(coordinatesWgs84);
-
-        me.coordsMapProj = coordinates[1].toFixed(2) + ' ' + coordinates[0].toFixed(2);
-        me.coordsWgs84 = coordinatesWgs84[1].toFixed(7) + ' ' + coordinatesWgs84[0].toFixed(7);
-        me.coordsHdms = hdms;
-
+        // collect click coordinate + projection --> CoordsTable
         me.coordsData = {
-          'POS': coordinates[1].toFixed(2) + ' ' + coordinates[0].toFixed(2),
-          'WGS 84': coordinatesWgs84[1].toFixed(7) + ' ' + coordinatesWgs84[0].toFixed(7),
-          'HDMS': hdms
-        }
+          coordinate: evt.coordinate,
+          projection: me.map.getView().getProjection().getCode()
+        };
       });
     }
   },
@@ -191,11 +185,6 @@ export default {
     display: block;
     max-height: 300px;
     overflow-y: scroll;
-  }
-
-  .wgu-infoclick-win table.coords {
-    margin-top: 12px;
-    width: 100%;
   }
 
   .wgu-infoclick-win td {

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -1,0 +1,63 @@
+<template>
+
+  <table v-if="this.properties" :style="tableStyles">
+    <thead>
+      <tr>
+        <th v-for="entry in properties"
+        </th>
+      </tr>
+    </thead>
+    <tbody class="attr-tbody">
+      <tr v-for="(value, key) in properties">
+        <td class="key-td">
+          {{key}}
+        </td>
+        <td class="val-td">
+          {{value}}
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+</template>
+
+<script>
+// helper function to detect a CSS color
+// Taken from Vuetify sources
+// https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/colorable.ts
+function isCssColor (color) {
+  return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/)
+}
+
+import vColors from 'vuetify/es5/util/colors';
+
+export default {
+  name: 'wgu-property-table',
+  props: {
+    color: {type: String, required: false, default: 'red darken-3'},
+    properties: {type: Object}
+  },
+  computed: {
+    tableStyles () {
+      // calculate border color of tables due to current color property
+      let borderColor = this.color;
+      if (!isCssColor(this.color)) {
+        let [colorName, colorModifier] = this.color.toString().trim().split(' ', 2);
+        borderColor = vColors[colorName];
+        if (colorModifier) {
+          colorModifier = colorModifier.replace('-', '');
+          borderColor = vColors[colorName][colorModifier];
+        }
+      }
+      return {
+        'border': '2px solid ' + borderColor
+      };
+    }
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+
+</style>

--- a/test/unit/specs/infoclick/CoordsTable.spec.js
+++ b/test/unit/specs/infoclick/CoordsTable.spec.js
@@ -1,0 +1,33 @@
+import Vue from 'vue'
+import CoordsTable from '@/components/infoclick/CoordsTable'
+
+describe('infoclick/CoordsTable.vue', () => {
+  // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof CoordsTable).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(CoordsTable);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
+    }).$mount();
+
+    expect(comp.color).to.equal('red darken-3');
+    expect(comp.coordsData).to.equal(undefined);
+    expect(comp.showMapPos).to.equal(true);
+    expect(comp.showWgsPos).to.equal(true);
+    expect(comp.showHdms).to.equal(true);
+  });
+
+  // Evaluate the results of functions in
+  // the raw component options
+  it('sets the correct default data', () => {
+    expect(typeof CoordsTable.data).to.equal('function');
+    const defaultData = CoordsTable.data();
+    expect(defaultData.coordRows).to.equal(null);
+  });
+});

--- a/test/unit/specs/infoclick/InfoClickWin.spec.js
+++ b/test/unit/specs/infoclick/InfoClickWin.spec.js
@@ -3,6 +3,10 @@ import InfoClickWin from '@/components/infoclick/InfoClickWin'
 
 describe('infoclick/InfoClickWin.vue', () => {
   // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof InfoClickWin).to.not.equal('undefined');
+  });
+
   it('has a created hook', () => {
     expect(typeof InfoClickWin.created).to.equal('function');
   });
@@ -12,16 +16,16 @@ describe('infoclick/InfoClickWin.vue', () => {
   it('sets the correct default data', () => {
     expect(typeof InfoClickWin.data).to.equal('function');
     const defaultData = InfoClickWin.data();
-    expect(defaultData.coordsMapProj).to.equal('');
-    expect(defaultData.coordsWgs84).to.equal('');
-    expect(defaultData.coordsHdms).to.equal('');
-    expect(defaultData.gridData).to.equal(null);
+    expect(defaultData.show).to.equal(false);
+    expect(defaultData.left).to.equal('2px');
+    expect(defaultData.top).to.equal('270px');
+    expect(defaultData.attributeData).to.equal(null);
     expect(defaultData.coordsData).to.equal(null);
   });
 
   // Mount an instance and inspect the render output
   it('does not render on startup', () => {
-    const Constructor = Vue.extend(InfoClickWin)
+    const Constructor = Vue.extend(InfoClickWin);
     const vm = new Constructor().$mount();
     // el is not undefined but this tests that it is not rendered
     expect(vm.$el.textContent).to.equal('');

--- a/test/unit/specs/infoclick/PropertyTable.spec.js
+++ b/test/unit/specs/infoclick/PropertyTable.spec.js
@@ -1,0 +1,24 @@
+import Vue from 'vue'
+import PropertyTable from '@/components/infoclick/PropertyTable'
+
+describe('infoclick/PropertyTable.vue', () => {
+  // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof PropertyTable).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(PropertyTable);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {
+        properties: null
+      }
+    }).$mount();
+
+    expect(comp.color).to.equal('red darken-3');
+    expect(comp.properties).to.equal(null);
+  });
+});

--- a/test/unit/specs/infoclick/ToggleButton.spec.js
+++ b/test/unit/specs/infoclick/ToggleButton.spec.js
@@ -2,6 +2,24 @@ import Vue from 'vue'
 import InfoClickToggleBtn from '@/components/infoclick/ToggleButton'
 
 describe('infoclick/ToggleButton.vue', () => {
+  // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof InfoClickToggleBtn).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(InfoClickToggleBtn);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
+    }).$mount();
+
+    expect(comp.icon).to.equal('info');
+    expect(comp.text).to.equal('');
+  });
+
   // Check methods
   it('has a method toggleUi', () => {
     const Constructor = Vue.extend(InfoClickToggleBtn);
@@ -15,5 +33,7 @@ describe('infoclick/ToggleButton.vue', () => {
     expect(typeof InfoClickToggleBtn.data).to.equal('function');
     const defaultData = InfoClickToggleBtn.data();
     expect(typeof defaultData).to.equal('object');
+    expect(defaultData.moduleName).to.equal('wgu-infoclick');
+    expect(defaultData.useDarkTheme).to.equal(false);
   });
 });


### PR DESCRIPTION
This PR refactors the `InfoClickWin` component:

- Split the components into sub-components `CoordsTable` and `PropertyTable`
- Make the coordinate representations configurable
- Optimize registering / unregistering of map-click event