### PR TITLE
Refactor measure tool UIs

### DIFF
--- a/src/components/measuretool/MeasureResult.vue
+++ b/src/components/measuretool/MeasureResult.vue
@@ -38,6 +38,9 @@
         } else if (geom instanceof LineStringGeom) {
           output = me.formatLength(geom);
           me.distance = output;
+        } else {
+          me.area = ' -- ';
+          me.distance = ' -- ';
         }
       }
     },

--- a/src/components/measuretool/MeasureResult.vue
+++ b/src/components/measuretool/MeasureResult.vue
@@ -1,0 +1,91 @@
+<template>
+
+  <div class="">
+    <div class="measure-result">
+      LENGTH: {{distance}}
+    </div>
+    <div class="measure-result">
+      AREA: {{area}}
+    </div>
+  </div>
+
+</template>
+
+<script>
+  import LineStringGeom from 'ol/geom/LineString';
+  import PolygonGeom from 'ol/geom/Polygon';
+  import { getArea, getLength } from 'ol/sphere.js';
+
+  export default {
+    name: 'wgu-measure-result',
+    props: {
+      measureGeom: {type: Object}
+    },
+    data () {
+      return {
+        area: ' -- ',
+        distance: ' -- '
+      }
+    },
+    watch: {
+      measureGeom () {
+        const me = this;
+        const geom = me.measureGeom.geom;
+        let output;
+        if (geom instanceof PolygonGeom) {
+          output = me.formatArea(geom);
+          me.area = output;
+        } else if (geom instanceof LineStringGeom) {
+          output = me.formatLength(geom);
+          me.distance = output;
+        }
+      }
+    },
+    methods: {
+      /**
+       * Calculates and formats the length of the given line.
+       *
+       * @param  {ol.geom.LineString} line The LineString object to calculate length for
+       */
+      formatLength (line) {
+        const length = getLength(line);
+        let output;
+        if (length > 100) {
+          output = (Math.round(length / 1000 * 100) / 100) +
+              ' ' + 'km';
+        } else {
+          output = (Math.round(length * 100) / 100) +
+              ' ' + 'm';
+        }
+        return output;
+      },
+      /**
+       * Calculates and formats the area of the given polygon.
+       *
+       * @param  {ol.geom.Polygon} polygon The Polygon object to calculate area for
+       */
+      formatArea (polygon) {
+        const area = getArea(polygon);
+        let output;
+        if (area > 10000) {
+          output = (Math.round(area / 1000000 * 100) / 100) +
+              ' ' + 'km²';
+        } else {
+          output = (Math.round(area * 100) / 100) +
+              ' ' + 'm²';
+        }
+        return output;
+      }
+    }
+  }
+</script>
+
+<style>
+
+  .measure-result {
+    font-size: 14px;
+    padding-left: 8px;
+    padding-bottom: 8px;
+  }
+
+</style>

--- a/src/components/measuretool/MeasureTypeChooser.vue
+++ b/src/components/measuretool/MeasureTypeChooser.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <v-btn-toggle v-model="measureType" mandatory>
+     <v-btn large value="distance">
+       Distance
+     </v-btn>
+     <v-btn large value="area">
+       Area
+     </v-btn>
+   </v-btn-toggle>
+
+</template>
+
+<script>
+  export default {
+    name: 'wgu-measure-type-chooser',
+    props: {},
+    data () {
+      return {
+        measureType: 'distance'
+      }
+    },
+    watch: {
+      // listen to changed measurement type and forward to parent component
+      measureType (newVal, oldVal) {
+        this.$emit('wgu-measuretype-change', newVal, oldVal);
+      }
+    }
+  }
+</script>
+
+<style>
+</style>

--- a/src/components/measuretool/MeasureTypeChooser.vue
+++ b/src/components/measuretool/MeasureTypeChooser.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-btn-toggle v-model="measureType" mandatory>
+  <v-btn-toggle v-model="measureTypeData" mandatory>
      <v-btn large value="distance">
        Distance
      </v-btn>
@@ -14,15 +14,17 @@
 <script>
   export default {
     name: 'wgu-measure-type-chooser',
-    props: {},
+    props: {
+      measureType: {type: String, default: 'distance'}
+    },
     data () {
       return {
-        measureType: 'distance'
+        measureTypeData: this.measureType
       }
     },
     watch: {
       // listen to changed measurement type and forward to parent component
-      measureType (newVal, oldVal) {
+      measureTypeData (newVal, oldVal) {
         this.$emit('wgu-measuretype-change', newVal, oldVal);
       }
     }

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -29,18 +29,11 @@
 </template>
 
 <script>
-  import DrawInteraction from 'ol/interaction/Draw';
-  import {unByKey} from 'ol/Observable.js';
-  import VectorSource from 'ol/source/Vector';
-  import VectorLayer from 'ol/layer/Vector';
-  import Style from 'ol/style/Style';
-  import Stroke from 'ol/style/Stroke';
-  import Circle from 'ol/style/Circle';
-  import Fill from 'ol/style/Fill';
   import { DraggableWin } from '../../directives/DraggableWin';
   import { Mapable } from '../../mixins/Mapable';
   import MeasureTypeChooser from './MeasureTypeChooser';
   import MeasureResult from './MeasureResult';
+  import OlMeasureController from './OlMeasureController';
 
   export default {
     name: 'wgu-measuretool-win',
@@ -71,13 +64,16 @@
       show () {
         var me = this;
         if (me.show === true) {
-          me.addInteraction();
+          me.olMapCtrl.addInteraction(me.measureType, me.onMeasureVertexSet);
         } else {
-          me.removeInteraction();
+          me.olMapCtrl.removeInteraction();
         }
       },
       measureType () {
-        this.addInteraction();
+        var me = this;
+        // reset old geom
+        me.measureGeom = {};
+        me.olMapCtrl.addInteraction(me.measureType, me.onMeasureVertexSet);
       }
     },
     methods: {
@@ -95,112 +91,23 @@
        * This function is executed, after the map is bound (see mixins/Mapable)
        */
       onMapBound () {
-        this.createMeasureLayer();
-      },
-      /**
-       * Creates a vector layer for the measurement results and adds it to the
-       * map.
-       */
-      createMeasureLayer () {
         const me = this;
         const measureConf = me.$appConfig.modules[me.moduleName] || {};
-        // create a vector layer to
-        var source = new VectorSource();
-        var vector = new VectorLayer({
-          name: 'Measure Layer',
-          displayInLayerList: false,
-          source: source,
-          style: new Style({
-            fill: new Fill({
-              color: measureConf.fillColor || 'rgba(255, 255, 255, 0.2)'
-            }),
-            stroke: new Stroke({
-              color: measureConf.strokeColor || 'rgba(0, 0, 0, 0.5)',
-              width: 2
-            })
-          })
-        });
+        this.olMapCtrl = new OlMeasureController(me.map, measureConf);
 
-        me.map.addLayer(vector);
-
-        // make vector source available as member
-        me.source = source;
+        me.olMapCtrl.createMeasureLayer();
       },
       /**
-       * Creates and adds the necessary draw interaction and adds it to the map.
+       * Callback function executed when user sets a measure point on the map.
+       *
+       * @param  {ol/geom/Geometry} geom The geometry object of the map
        */
-      addInteraction (newMeasureType) {
-        const me = this;
-        const measureConf = me.$appConfig.modules[me.moduleName] || {};
-        // cleanup possible old draw interaction
-        if (me.draw) {
-          me.removeInteraction();
-        }
-
-        var type = (me.measureType === 'area' ? 'Polygon' : 'LineString');
-        var draw = new DrawInteraction({
-          source: me.source,
-          type: type,
-          style: new Style({
-            fill: new Fill({
-              color: measureConf.sketchFillColor || 'rgba(255, 255, 255, 0.2)'
-            }),
-            stroke: new Stroke({
-              color: measureConf.sketchStrokeColor || 'rgba(0, 0, 0, 0.5)',
-              lineDash: [10, 10],
-              width: 2
-            }),
-            image: new Circle({
-              radius: 5,
-              stroke: new Stroke({
-                color: measureConf.sketchVertexStrokeColor || 'rgba(0, 0, 0, 0.7)'
-              }),
-              fill: new Fill({
-                color: measureConf.sketchVertexFillColor || 'rgba(255, 255, 255, 0.2)'
-              })
-            })
-          })
-        });
-        me.map.addInteraction(draw);
-
-        var listener;
-        var sketch;
-        draw.on('drawstart', (evt) => {
-          // clear old measure features
-          me.source.clear();
-          // preserve sketch
-          sketch = evt.feature;
-
-          listener = me.map.on('click', (evt) => {
-            const geom = sketch.getGeometry();
-            // wrap geom into object, otherwise the injection into childs does
-            // not work. Maybe the OL object does not feel changed for Vue
-            me.measureGeom = {
-              geom: geom
-            };
-          });
-        }, me);
-
-        draw.on('drawend', () => {
-          // unset sketch
-          sketch = null;
-          unByKey(listener);
-        }, me);
-
-        // make draw interaction available as member
-        me.draw = draw;
-      },
-      /**
-       * Removes the current interaction and clears the values.
-       */
-      removeInteraction () {
-        var me = this;
-        if (me.draw) {
-          me.map.removeInteraction(me.draw);
-        }
-        if (me.source) {
-          me.source.clear();
-        }
+      onMeasureVertexSet (geom) {
+        // wrap geom into object, otherwise the injection into childs does
+        // not work. Maybe the OL object does not feel changed for Vue
+        this.measureGeom = {
+          geom: geom
+        };
       }
     }
   }

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -2,35 +2,26 @@
 
   <v-card class="wgu-measurewin" v-draggable-win v-if="show" v-bind:style="{ left: left, top: top }">
     <v-toolbar :color="color" class="" dark>
-      <v-toolbar-side-icon><v-icon>{{icon}}</v-icon></v-toolbar-side-icon>
-      <v-toolbar-title class="wgu-win-title">{{title}}</v-toolbar-title>
+      <v-toolbar-side-icon><v-icon>{{ icon }}</v-icon></v-toolbar-side-icon>
+      <v-toolbar-title class="wgu-win-title">{{ title }}</v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
+      <v-toolbar-side-icon @click="show=false"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
 
     <v-card-title primary-title>
-      <div class="">
-        <v-btn-toggle v-model="measureType" mandatory>
-           <v-btn large value="distance">
-             Distance
-           </v-btn>
-           <v-btn large value="area">
-             Area
-           </v-btn>
-         </v-btn-toggle>
-      </div>
+
+      <!-- toggle button to choose measure type -->
+      <wgu-measure-type-chooser
+        :measureType="measureType"
+        @wgu-measuretype-change="applyMeasureType"
+      />
 
     </v-card-title>
 
     <v-card-actions>
-      <div class="">
-        <div class="measure-result">
-          LENGTH: {{distance}}
-        </div>
-        <div class="measure-result">
-          AREA: {{area}}
-        </div>
-      </div>
+
+      <!-- result display -->
+      <wgu-measure-result :measureGeom="measureGeom" />
 
     </v-card-actions>
   </v-card>
@@ -39,8 +30,6 @@
 
 <script>
   import DrawInteraction from 'ol/interaction/Draw';
-  import LineStringGeom from 'ol/geom/LineString';
-  import PolygonGeom from 'ol/geom/Polygon';
   import {unByKey} from 'ol/Observable.js';
   import VectorSource from 'ol/source/Vector';
   import VectorLayer from 'ol/layer/Vector';
@@ -48,14 +37,19 @@
   import Stroke from 'ol/style/Stroke';
   import Circle from 'ol/style/Circle';
   import Fill from 'ol/style/Fill';
-  import {getArea, getLength} from 'ol/sphere.js';
   import { DraggableWin } from '../../directives/DraggableWin';
   import { Mapable } from '../../mixins/Mapable';
+  import MeasureTypeChooser from './MeasureTypeChooser';
+  import MeasureResult from './MeasureResult';
 
   export default {
     name: 'wgu-measuretool-win',
     directives: {
       DraggableWin
+    },
+    components: {
+      'wgu-measure-type-chooser': MeasureTypeChooser,
+      'wgu-measure-result': MeasureResult
     },
     mixins: [Mapable],
     props: {
@@ -66,8 +60,7 @@
     data () {
       return {
         moduleName: 'wgu-measuretool',
-        area: ' -- ',
-        distance: ' -- ',
+        measureGeom: null,
         measureType: 'distance',
         show: false,
         left: '10px',
@@ -83,12 +76,21 @@
           me.removeInteraction();
         }
       },
-      // listen to changed measurement type
-      measureType (newVal, oldVal) {
+      measureType () {
         this.addInteraction();
       }
     },
     methods: {
+      /**
+       * Applies the changed measure value to this.measureType.
+       * Called as callback of MeasureTypeChooser
+       *
+       * @param  {String} newMeasureType New measure type
+       * @param  {String} oldMeasureType Old measure type
+       */
+      applyMeasureType (newMeasureType, oldMeasureType) {
+        this.measureType = newMeasureType;
+      },
       /**
        * This function is executed, after the map is bound (see mixins/Mapable)
        */
@@ -127,7 +129,7 @@
       /**
        * Creates and adds the necessary draw interaction and adds it to the map.
        */
-      addInteraction () {
+      addInteraction (newMeasureType) {
         const me = this;
         const measureConf = me.$appConfig.modules[me.moduleName] || {};
         // cleanup possible old draw interaction
@@ -135,7 +137,7 @@
           me.removeInteraction();
         }
 
-        var type = (this.measureType === 'area' ? 'Polygon' : 'LineString');
+        var type = (me.measureType === 'area' ? 'Polygon' : 'LineString');
         var draw = new DrawInteraction({
           source: me.source,
           type: type,
@@ -164,29 +166,26 @@
         var listener;
         var sketch;
         draw.on('drawstart', (evt) => {
-          // clear old measure ffeatures
+          // clear old measure features
           me.source.clear();
           // preserve sketch
           sketch = evt.feature;
 
           listener = me.map.on('click', (evt) => {
-            var geom = sketch.getGeometry();
-            var output;
-            if (geom instanceof PolygonGeom) {
-              output = me.formatArea(geom);
-              me.area = output;
-            } else if (geom instanceof LineStringGeom) {
-              output = me.formatLength(geom);
-              me.distance = output;
-            }
+            const geom = sketch.getGeometry();
+            // wrap geom into object, otherwise the injection into childs does
+            // not work. Maybe the OL object does not feel changed for Vue
+            me.measureGeom = {
+              geom: geom
+            };
           });
-        }, this);
+        }, me);
 
         draw.on('drawend', () => {
           // unset sketch
           sketch = null;
           unByKey(listener);
-        }, this);
+        }, me);
 
         // make draw interaction available as member
         me.draw = draw;
@@ -202,42 +201,6 @@
         if (me.source) {
           me.source.clear();
         }
-        me.distance = ' -- ';
-        me.area = ' -- ';
-      },
-      /**
-       * Calculates and formats the length of the given line.
-       *
-       * @param  {ol.geom.LineString} line The LineString object to calculate length for
-       */
-      formatLength (line) {
-        const length = getLength(line);
-        let output;
-        if (length > 100) {
-          output = (Math.round(length / 1000 * 100) / 100) +
-              ' ' + 'km';
-        } else {
-          output = (Math.round(length * 100) / 100) +
-              ' ' + 'm';
-        }
-        return output;
-      },
-      /**
-       * Calculates and formats the area of the given polygon.
-       *
-       * @param  {ol.geom.Polygon} polygon The Polygon object to calculate area for
-       */
-      formatArea (polygon) {
-        const area = getArea(polygon);
-        let output;
-        if (area > 10000) {
-          output = (Math.round(area / 1000000 * 100) / 100) +
-              ' ' + 'km²';
-        } else {
-          output = (Math.round(area * 100) / 100) +
-              ' ' + 'm²';
-        }
-        return output;
       }
     }
   }
@@ -252,12 +215,6 @@
 
   .v-card.wgu-measurewin {
     position: absolute;
-  }
-
-  .measure-result {
-    font-size: 14px;
-    padding-left: 8px;
-    padding-bottom: 8px;
   }
 
 </style>

--- a/src/components/measuretool/OlMeasureController.js
+++ b/src/components/measuretool/OlMeasureController.js
@@ -1,0 +1,128 @@
+
+import DrawInteraction from 'ol/interaction/Draw';
+import {unByKey} from 'ol/Observable.js';
+import VectorSource from 'ol/source/Vector';
+import VectorLayer from 'ol/layer/Vector';
+import Style from 'ol/style/Style';
+import Stroke from 'ol/style/Stroke';
+import Circle from 'ol/style/Circle';
+import Fill from 'ol/style/Fill';
+
+/**
+ * Class holding the OpenLayers related logic for the measure tool.
+ */
+export default class OlMeasureController {
+
+  /* the OL map we want to measure on */
+  map = null;
+
+  constructor (olMap, measureConf) {
+    this.map = olMap;
+    this.measureConf = measureConf || {};
+  }
+
+  /**
+   * Creates a vector layer for the measurement results and adds it to the
+   * map.
+   */
+  createMeasureLayer () {
+    const me = this;
+    const measureConf = me.measureConf;
+    // create a vector layer to
+    var source = new VectorSource();
+    var vector = new VectorLayer({
+      name: 'Measure Layer',
+      displayInLayerList: false,
+      source: source,
+      style: new Style({
+        fill: new Fill({
+          color: measureConf.fillColor || 'rgba(255, 255, 255, 0.2)'
+        }),
+        stroke: new Stroke({
+          color: measureConf.strokeColor || 'rgba(0, 0, 0, 0.5)',
+          width: 2
+        })
+      })
+    });
+
+    me.map.addLayer(vector);
+
+    // make vector source available as member
+    me.source = source;
+  }
+
+  /**
+   * Creates and adds the necessary draw interaction and adds it to the map.
+   */
+  addInteraction (measureType, mapClickCb) {
+    const me = this;
+    const measureConf = me.measureConf;
+    // cleanup possible old draw interaction
+    if (me.draw) {
+      me.removeInteraction();
+    }
+
+    var type = (measureType === 'area' ? 'Polygon' : 'LineString');
+    var draw = new DrawInteraction({
+      source: me.source,
+      type: type,
+      style: new Style({
+        fill: new Fill({
+          color: measureConf.sketchFillColor || 'rgba(255, 255, 255, 0.2)'
+        }),
+        stroke: new Stroke({
+          color: measureConf.sketchStrokeColor || 'rgba(0, 0, 0, 0.5)',
+          lineDash: [10, 10],
+          width: 2
+        }),
+        image: new Circle({
+          radius: 5,
+          stroke: new Stroke({
+            color: measureConf.sketchVertexStrokeColor || 'rgba(0, 0, 0, 0.7)'
+          }),
+          fill: new Fill({
+            color: measureConf.sketchVertexFillColor || 'rgba(255, 255, 255, 0.2)'
+          })
+        })
+      })
+    });
+    me.map.addInteraction(draw);
+
+    var listener;
+    var sketch;
+    draw.on('drawstart', (evt) => {
+      // clear old measure features
+      me.source.clear();
+      // preserve sketch
+      sketch = evt.feature;
+
+      listener = me.map.on('click', (evt) => {
+        const geom = sketch.getGeometry();
+        // execute given callback
+        mapClickCb(geom);
+      });
+    }, me);
+
+    draw.on('drawend', () => {
+      // unset sketch
+      sketch = null;
+      unByKey(listener);
+    }, me);
+
+    // make draw interaction available as member
+    me.draw = draw;
+  }
+
+  /**
+   * Removes the current interaction and clears the values.
+   */
+  removeInteraction () {
+    var me = this;
+    if (me.draw) {
+      me.map.removeInteraction(me.draw);
+    }
+    if (me.source) {
+      me.source.clear();
+    }
+  }
+}

--- a/test/unit/specs/measuretool/MeasureResult.spec.js
+++ b/test/unit/specs/measuretool/MeasureResult.spec.js
@@ -1,0 +1,36 @@
+import Vue from 'vue'
+import MeasureResult from '@/components/measuretool/MeasureResult'
+
+describe('measuretool/MeasureWin.vue', () => {
+  it('is defined', () => {
+    expect(typeof MeasureResult).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(MeasureResult);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
+    }).$mount();
+
+    expect(comp.measureGeom).to.equal(undefined);
+  });
+
+  // Evaluate the results of functions in
+  // the raw component options
+  it('sets the correct default data', () => {
+    expect(typeof MeasureResult.data).to.equal('function');
+    const defaultData = MeasureResult.data();
+    expect(defaultData.area).to.equal(' -- ');
+    expect(defaultData.distance).to.equal(' -- ');
+  });
+
+  it('has the correct functions', () => {
+    const Constructor = Vue.extend(MeasureResult);
+    const vm = new Constructor().$mount();
+    expect(typeof vm.formatLength).to.equal('function');
+    expect(typeof vm.formatArea).to.equal('function');
+  });
+});

--- a/test/unit/specs/measuretool/MeasureTypeChooser.spec.js
+++ b/test/unit/specs/measuretool/MeasureTypeChooser.spec.js
@@ -1,0 +1,15 @@
+import MeasureTypeChooser from '@/components/measuretool/MeasureTypeChooser'
+
+describe('measuretool/MeasureWin.vue', () => {
+  it('is defined', () => {
+    expect(typeof MeasureTypeChooser).to.not.equal('undefined');
+  });
+
+  // Evaluate the results of functions in
+  // the raw component options
+  it('sets the correct default data', () => {
+    expect(typeof MeasureTypeChooser.data).to.equal('function');
+    const defaultData = MeasureTypeChooser.data();
+    expect(defaultData.measureType).to.equal('distance');
+  });
+});

--- a/test/unit/specs/measuretool/MeasureTypeChooser.spec.js
+++ b/test/unit/specs/measuretool/MeasureTypeChooser.spec.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import MeasureTypeChooser from '@/components/measuretool/MeasureTypeChooser'
 
 describe('measuretool/MeasureWin.vue', () => {
@@ -5,11 +6,23 @@ describe('measuretool/MeasureWin.vue', () => {
     expect(typeof MeasureTypeChooser).to.not.equal('undefined');
   });
 
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(MeasureTypeChooser);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
+    }).$mount();
+
+    expect(comp.measureType).to.equal('distance');
+  });
+
   // Evaluate the results of functions in
   // the raw component options
   it('sets the correct default data', () => {
     expect(typeof MeasureTypeChooser.data).to.equal('function');
     const defaultData = MeasureTypeChooser.data();
-    expect(defaultData.measureType).to.equal('distance');
+    expect(defaultData.measureTypeData).to.equal(undefined);
   });
 });

--- a/test/unit/specs/measuretool/MeasureWin.spec.js
+++ b/test/unit/specs/measuretool/MeasureWin.spec.js
@@ -38,9 +38,6 @@ describe('measuretool/MeasureWin.vue', () => {
     const vm = new Constructor().$mount();
     expect(typeof vm.applyMeasureType).to.equal('function');
     expect(typeof vm.onMapBound).to.equal('function');
-    expect(typeof vm.createMeasureLayer).to.equal('function');
-    expect(typeof vm.addInteraction).to.equal('function');
-    expect(typeof vm.removeInteraction).to.equal('function');
   });
 
   // Mount an instance and inspect the render output

--- a/test/unit/specs/measuretool/MeasureWin.spec.js
+++ b/test/unit/specs/measuretool/MeasureWin.spec.js
@@ -2,25 +2,45 @@ import Vue from 'vue'
 import MeasureWin from '@/components/measuretool/MeasureWin'
 
 describe('measuretool/MeasureWin.vue', () => {
+  it('is defined', () => {
+    expect(typeof MeasureWin).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(MeasureWin);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
+    }).$mount();
+
+    expect(comp.color).to.equal('red darken-3');
+    expect(comp.icon).to.equal('photo_size_select_small');
+    expect(comp.title).to.equal('Measure');
+  });
+
   // Evaluate the results of functions in
   // the raw component options
   it('sets the correct default data', () => {
     expect(typeof MeasureWin.data).to.equal('function');
     const defaultData = MeasureWin.data();
-    expect(defaultData.area).to.equal(' -- ');
-    expect(defaultData.distance).to.equal(' -- ');
+    expect(defaultData.moduleName).to.equal('wgu-measuretool');
+    expect(defaultData.measureGeom).to.equal(null);
     expect(defaultData.measureType).to.equal('distance');
     expect(defaultData.show).to.equal(false);
+    expect(defaultData.left).to.equal('10px');
+    expect(defaultData.top).to.equal('70px');
   });
 
   it('has the correct functions', () => {
     const Constructor = Vue.extend(MeasureWin);
     const vm = new Constructor().$mount();
+    expect(typeof vm.applyMeasureType).to.equal('function');
+    expect(typeof vm.onMapBound).to.equal('function');
     expect(typeof vm.createMeasureLayer).to.equal('function');
     expect(typeof vm.addInteraction).to.equal('function');
     expect(typeof vm.removeInteraction).to.equal('function');
-    expect(typeof vm.formatLength).to.equal('function');
-    expect(typeof vm.formatArea).to.equal('function');
   });
 
   // Mount an instance and inspect the render output

--- a/test/unit/specs/measuretool/OlMeasureController.spec.js
+++ b/test/unit/specs/measuretool/OlMeasureController.spec.js
@@ -1,0 +1,14 @@
+import OlMeasureController from '@/components/measuretool/OlMeasureController'
+
+describe('measuretool/MeasureWin.vue', () => {
+  it('is defined', () => {
+    expect(typeof OlMeasureController).to.not.equal('undefined');
+  });
+
+  it('has the correct functions', () => {
+    const olmc = new OlMeasureController();
+    expect(typeof olmc.createMeasureLayer).to.equal('function');
+    expect(typeof olmc.addInteraction).to.equal('function');
+    expect(typeof olmc.removeInteraction).to.equal('function');
+  });
+});


### PR DESCRIPTION
This PR splits the UIs of the measure tool into sub components:

 - MeasureResult
 - MeasureTypeChooser
 - MeasureWin

and introduces an own class to encapsulate the OL related (non-vue) logic for the measure functionality. So it becomes re-usable in other components.

Also adds some basic unit tests.