### PR TITLE
Optimize AppHeader (toolbar) component

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -6,18 +6,26 @@
     app
     clipped-right
   >
+
+    <!-- slot to inject components at the beginning (before title) -->
+    <slot name="wgu-tb-start"></slot>
+
     <v-toolbar-title>{{title}}</v-toolbar-title>
+
+    <!-- slot to inject components after the title text -->
+    <slot name="wgu-tb-after-title"></slot>
+
     <v-spacer></v-spacer>
 
-    <!--This <slot> is going to be replaced by the toolbar buttons in the
-      app configuration tags (see App.vue) -->
-    <!-- <v-layout justify-end class="">
-      <slot name="wgu-tb-buttons"></slot>
-    </v-layout> -->
+    <!-- slot to inject components before the auto-generated buttons (by config) -->
+    <slot name="wgu-tb-before-auto-buttons"></slot>
 
     <template v-for="(tbButton, index) in tbButtons">
       <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text" :color="color" />
     </template>
+
+    <!-- slot to inject components after the auto-generated buttons (by config) -->
+    <slot name="wgu-tb-after-auto-buttons"></slot>
 
     <v-menu offset-y>
       <v-btn icon dark slot="activator">
@@ -31,6 +39,9 @@
           </template>
       </v-list>
     </v-menu>
+
+    <!-- slot to inject components at the end of the toolbar (after menu) -->
+    <slot name="wgu-tb-end"></slot>
 
   </v-toolbar>
 </template>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -27,7 +27,7 @@
     <!-- slot to inject components after the auto-generated buttons (by config) -->
     <slot name="wgu-tb-after-auto-buttons"></slot>
 
-    <v-menu offset-y>
+    <v-menu v-if="menuButtons.length" offset-y>
       <v-btn icon dark slot="activator">
         <v-icon medium>menu</v-icon>
       </v-btn>

--- a/test/unit/specs/AppHeader.spec.js
+++ b/test/unit/specs/AppHeader.spec.js
@@ -2,13 +2,21 @@ import Vue from 'vue'
 import AppHeader from '@/components/AppHeader'
 
 describe('AppHeader.vue', () => {
-  //
-  it('has a method toggleUi', () => {
+  // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof AppHeader).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
     const Constructor = Vue.extend(AppHeader);
-    const ah = new Constructor({
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
     }).$mount();
-    expect(typeof ah.getModuleButtonData).to.equal('function');
-    expect(typeof ah.getToolbarButtons).to.equal('function');
+
+    expect(comp.color).to.equal('red darken-3');
   });
 
   // Evaluate the results of functions in
@@ -17,19 +25,21 @@ describe('AppHeader.vue', () => {
     AppHeader.$appConfig = {
       title: 'foo'
     };
-    expect(typeof AppHeader.data).to.equal('function');
+    // mock some functions used in data()
+    AppHeader.getModuleButtonData = () => { return [] };
+    AppHeader.getToolbarButtons = () => { return [] };
+    const defaultData = AppHeader.data();
+    expect(defaultData.title).to.equal('foo');
+    expect(defaultData.menuButtons).to.deep.equal([]);
+    expect(defaultData.tbButtons).to.deep.equal([]);
   });
 
-  // Mount an instance and inspect the render output
-  it('renders the correct title', () => {
-    AppHeader.$appConfig = {
-      title: 'foo'
-    };
+  // Check methods
+  it('has the correct functions', () => {
     const Constructor = Vue.extend(AppHeader);
-    const vm = new Constructor({
-      title: 'foo'
+    const ah = new Constructor({
     }).$mount();
-
-    expect(vm.$el.querySelector('v-toolbar-title') !== null).to.equal(true);
+    expect(typeof ah.getModuleButtonData).to.equal('function');
+    expect(typeof ah.getToolbarButtons).to.equal('function');
   });
 });


### PR DESCRIPTION
This PR has some improvements for the `AppHeader` (toolbar) component:

  - Add some slots in order to have hooks to inject custom components
  - Render toolbar menu button only when it has entries