### PR TITLE
Add 'zoomToLayerExtent' function to LayerUtil

### DIFF
--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -36,6 +36,21 @@ const LayerUtil = {
    */
   getLayerByLid (lid, olMap) {
     return LayerUtil.getLayersBy('lid', lid, olMap)[0];
+  },
+
+  /**
+   * Zooms to the given layer's extent.
+   * Will only work if the layer has kind of vector source.
+   *
+   * @param  {ol.layer.Base} vecLayer OL vector layer
+   * @param  {ol.Map} olMap           The map to perform the zoom on
+   */
+  zoomToLayerExtent (vecLayer, olMap) {
+    if (!vecLayer || !vecLayer.getSource().getExtent || !olMap) {
+      return;
+    }
+    const extent = vecLayer.getSource().getExtent();
+    olMap.getView().fit(extent);
   }
 }
 

--- a/test/unit/specs/util/Layer.spec.js
+++ b/test/unit/specs/util/Layer.spec.js
@@ -3,6 +3,10 @@ import Map from 'ol/Map'
 import View from 'ol/View'
 import TileLayer from 'ol/layer/Tile'
 import OSM from 'ol/source/OSM'
+import Feature from 'ol/Feature';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import Point from 'ol/geom/Point';
 
 describe('LayerUtil', () => {
   it('is defined', () => {
@@ -12,6 +16,7 @@ describe('LayerUtil', () => {
   it('has the correct functions', () => {
     expect(typeof LayerUtil.getLayersBy).to.equal('function');
     expect(typeof LayerUtil.getLayerByLid).to.equal('function');
+    expect(typeof LayerUtil.zoomToLayerExtent).to.equal('function');
   });
 
   it('getLayersBy returns correct layers wrapped as array', () => {
@@ -108,5 +113,64 @@ describe('LayerUtil', () => {
   it('getLayerByLid returns undefined if no OL map is passed', () => {
     const layer = LayerUtil.getLayerByLid('kalle');
     expect(layer).to.equal(undefined);
+  });
+
+  it('zoomToLayerExtent zooms the map correctly', () => {
+    const vectorLayer = new VectorLayer({
+      lid: 'veclyr',
+      source: new VectorSource()
+    });
+
+    const p1 = new Feature({geometry: new Point([0, 0])});
+    const p2 = new Feature({geometry: new Point([8, 8])});
+    vectorLayer.getSource().addFeatures([p1, p2]);
+
+    const olMap = new Map({
+      layers: [
+        vectorLayer
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    LayerUtil.zoomToLayerExtent(vectorLayer, olMap);
+    expect(olMap.getView().getZoom()).to.equal(20);
+    expect(olMap.getView().getCenter()[0]).to.equal(4);
+    expect(olMap.getView().getCenter()[1]).to.equal(4);
+  });
+
+  it('zoomToLayerExtent does not do anything if no valid vector layer is passed', () => {
+    const olMap = new Map({
+      layers: [],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    LayerUtil.zoomToLayerExtent(null, olMap);
+    expect(olMap.getView().getZoom()).to.equal(2);
+    expect(olMap.getView().getCenter()[0]).to.equal(0);
+    expect(olMap.getView().getCenter()[1]).to.equal(0);
+  });
+
+  it('zoomToLayerExtent does not do anything if no valid OL map is passed', () => {
+    const vecLayer = new VectorLayer({
+      lid: 'veclyr',
+      source: new VectorSource()
+    });
+    const olMap = new Map({
+      layers: [
+        vecLayer
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2
+      })
+    });
+    LayerUtil.zoomToLayerExtent(vecLayer);
+    expect(olMap.getView().getZoom()).to.equal(2);
+    expect(olMap.getView().getCenter()[0]).to.equal(0);
+    expect(olMap.getView().getCenter()[1]).to.equal(0);
   });
 });


### PR DESCRIPTION
This adds a function `zoomToLayerExtent` to the `LayerUtil`. The function zooms to the current data extent of the given vector-based layer.