### PR TITLE
Update non-dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "ol": "5.3.0",
-    "vue": "2.5.20",
-    "vuetify": "1.3.12"
+    "vue": "2.6.6",
+    "vuetify": "1.5.2"
   },
   "devDependencies": {
     "autoprefixer": "^7.2.5",
@@ -77,7 +77,7 @@
     "url-loader": "^1.1.2",
     "vue-loader": "^13.7.0",
     "vue-style-loader": "^3.1.0",
-    "vue-template-compiler": "2.5.20",
+    "vue-template-compiler": "2.6.6",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.9.2",
     "webpack-dev-middleware": "^1.12.2",


### PR DESCRIPTION
This PR updates the non-dev dependencies to their latest versions:

  - Vue: v2.6.6
  - Vuetify: v1.5.2