### PR TITLE
 Wrap app footer into own Vue component

### DIFF
--- a/src/WguApp.vue
+++ b/src/WguApp.vue
@@ -20,14 +20,16 @@
     />
     </template>
 
-    <v-footer :color="baseColor" class="white--text" app>
+    <wgu-app-footer />
+
+    <!-- <v-footer :color="baseColor" class="whitetext" app>
       <span class="wgu-footer-left" v-html="footerTextLeft"></span>
       <v-spacer></v-spacer>
       <div class="wgu-footer-right">
         <span  v-html="footerTextRight"></span>
         <span v-if="showCopyrightYear" >&copy; {{ new Date().getFullYear() }}</span>
       </div>
-    </v-footer>
+    </v-footer> -->
 
   </v-app>
 </template>
@@ -37,6 +39,7 @@
   import { WguEventBus } from './WguEventBus'
   import OlMap from './components/ol/Map'
   import AppHeader from './components/AppHeader'
+  import AppFooter from './components/AppFooter'
   import AppLogo from './components/AppLogo'
   import MeasureWin from './components/measuretool/MeasureWin'
   import LayerListWin from './components/layerlist/LayerListWin'
@@ -47,6 +50,7 @@
     components: {
       'wgu-map': OlMap,
       'wgu-app-header': AppHeader,
+      'wgu-app-footer': AppFooter,
       'wgu-app-logo': AppLogo,
       'wgu-measuretool-win': MeasureWin,
       'wgu-layerlist-win': LayerListWin,

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -1,0 +1,30 @@
+<template>
+
+  <v-footer :color="color" class="white--text" app>
+    <span class="wgu-footer-left" v-html="footerTextLeft"></span>
+    <v-spacer></v-spacer>
+    <div class="wgu-footer-right">
+      <span v-html="footerTextRight"></span>
+      <span v-if="showCopyrightYear" >&copy; {{ new Date().getFullYear() }}</span>
+    </div>
+  </v-footer>
+
+</template>
+
+<script>
+
+export default {
+  name: 'wgu-app-footer',
+  props: {
+    color: {type: String, required: false, default: 'red darken-3'},
+    footerTextLeft: {type: String, required: false, default: 'Powered by <a href="https://meggsimum.de/wegue/" target="_blank">Wegue WebGIS</a>'},
+    footerTextRight: {type: String, required: false, default: 'meggsimum'},
+    showCopyrightYear: {type: Boolean, required: false, default: true}
+  }
+}
+
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+</style>

--- a/test/unit/specs/AppFooter.spec.js
+++ b/test/unit/specs/AppFooter.spec.js
@@ -1,0 +1,24 @@
+import Vue from 'vue'
+import AppFooter from '@/components/AppFooter'
+
+describe('AppFooter.vue', () => {
+  // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof AppFooter).to.not.equal('undefined');
+  });
+
+  it('has the correct properties', () => {
+    // Extend the component to get the constructor, which we can then
+    // initialize directly.
+    const Constructor = Vue.extend(AppFooter);
+    const comp = new Constructor({
+      // Props are passed in "propsData"
+      propsData: {}
+    }).$mount();
+
+    expect(comp.color).to.equal('red darken-3');
+    expect(comp.footerTextLeft).to.equal('Powered by <a href="https://meggsimum.de/wegue/" target="_blank">Wegue WebGIS</a>');
+    expect(comp.footerTextRight).to.equal('meggsimum');
+    expect(comp.showCopyrightYear).to.equal(true);
+  });
+});


### PR DESCRIPTION
This encapsulates the application footer in an own Vue component (`AppFooter`) instead of designing it directly in the App file.

Fixes #61 