### PR TITLE
Load app-conf by URL parameter 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import WguApp from './WguApp'
+import UrlUtil from './util/Url'
 
 import 'vuetify/dist/vuetify.min.css'
 
@@ -20,7 +21,15 @@ Vue.config.productionTip = false;
 const appEl = document.querySelector('#app');
 Vue.prototype.$isEmbedded = appEl.hasAttribute('embedded');
 
-fetch('static/app-conf.json')
+// Detect an URL parameter for a custom app context
+const appCtx = UrlUtil.getQueryParam('appCtx');
+let appCtxFile = '';
+if (appCtx) {
+  // simple aproach to avoid path traversal
+  appCtxFile = '-' + appCtx.replace(/(\.\.[/])+/g, '');
+}
+
+fetch('static/app-conf' + appCtxFile + '.json')
   .then(function (response) {
     return response.json();
   })

--- a/static/app-conf-minimal.json
+++ b/static/app-conf-minimal.json
@@ -1,0 +1,40 @@
+{
+
+  "title": "Vue.js / OpenLayers WebGIS",
+
+  "baseColor": "green darken-3",
+
+  "footerTextLeft": "Powered by <a href='https://meggsimum.de/wegue/' target='_blank'>Wegue WebGIS</a>",
+  "footerTextRight": "meggsimum",
+  "showCopyrightYear": true,
+
+  "mapZoom": 2,
+  "mapCenter": [0, 0],
+
+  "mapLayers": [
+
+    {
+      "type": "WMS",
+      "lid": "terrestris-osm-wms",
+      "name": "OSM WMS",
+      "format": "image/png",
+      "layers": "OSM-WMS",
+      "url": "http://ows.terrestris.de/osm-gray/service",
+      "transparent": true,
+      "singleTile": false,
+      "projection": "EPSG:3857",
+      "attributions": "<a href='https://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap-Mitwirkende</a>",
+      "isBaseLayer": false,
+      "visibility": false,
+      "displayInLayerList": true
+    }
+
+  ],
+
+  "modules": {
+    "wgu-helpwin": {
+      "target": "toolbar"
+    }
+  }
+
+}


### PR DESCRIPTION
This introduces the ability to load a custom app-config JSON file, which is defined by an URL parameter 'appCtx'. The app-config has to be placed in the 'static' folder and the file has to be named by the pattern app-conf-[appCtxParam].json:

`?appCtx=minimal` ==> `static/app-conf-minimal.json`

If no param is given the default app-config is loaded (as before).