### PR TITLE
Introduce OpenLayers Style factory

### DIFF
--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -9,6 +9,7 @@ import TopoJsonFormat from 'ol/format/TopoJSON'
 import KmlFormat from 'ol/format/KML'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
+import { OlStyleFactory } from './OlStyle'
 import OlStyleDefs from '../style/OlStyleDefs'
 
 /**
@@ -142,7 +143,7 @@ export const LayerFactory = {
         format: new this.formatMapping[lConf.format](lConf.formatConfig),
         attributions: lConf.attributions
       }),
-      style: OlStyleDefs[lConf.styleRef]
+      style: OlStyleFactory.getInstance(lConf.style) || OlStyleDefs[lConf.styleRef]
     });
 
     return vectorLayer;
@@ -166,7 +167,7 @@ export const LayerFactory = {
         format: new this.formatMapping[lConf.format](),
         attributions: lConf.attributions
       }),
-      style: OlStyleDefs[lConf.styleRef]
+      style: OlStyleFactory.getInstance(lConf.style) || OlStyleDefs[lConf.styleRef]
     });
 
     return vtLayer;

--- a/src/factory/OlStyle.js
+++ b/src/factory/OlStyle.js
@@ -1,0 +1,99 @@
+import { Circle as CircleStyle, Fill, Stroke, Style } from 'ol/style';
+
+/**
+ * Factory, which creates OpenLayers style instances according to a given config
+ * object.
+ * This only covers a minimal subset of the OpenLayers style capabilities.
+ * It allows to create simple styles for points, line and polygons.
+ * For advanced styling use a custom style function or
+ * GeoStyler<https://github.com/terrestris/geostyler>
+ */
+export const OlStyleFactory = {
+
+  /**
+   * Returns an OpenLayers Style instance due to given config.
+   *
+   * @param  {Object} styleConf  Style config object
+   * @return {Style}             OL Style instance
+   */
+  getInstance (styleConf) {
+    if (!styleConf) {
+      return;
+    } else if (styleConf.radius) {
+      return OlStyleFactory.createPointStyle(styleConf);
+    } else if (styleConf.fillColor) {
+      return OlStyleFactory.createPolygonStyle(styleConf);
+    } else if (styleConf.strokeColor || styleConf.strokeWidth) {
+      return OlStyleFactory.createLineStyle();
+    }
+  },
+
+  /**
+   * Returns an OpenLayers style instance for point due to given config.
+   *
+   * @param  {Object} styleConf  Style config object
+   * @return {Style}             OL style instance
+   */
+  createPointStyle (styleConf) {
+    return new Style({
+      image: new CircleStyle({
+        radius: styleConf.radius,
+        fill: OlStyleFactory.createFill(styleConf),
+        stroke: OlStyleFactory.createStroke(styleConf)
+      })
+    });
+  },
+
+  /**
+   * Returns an OpenLayers style instance for lines due to given config.
+   *
+   * @param  {Object} styleConf  Style config object
+   * @return {Style}             OL style instance
+   */
+  createLineStyle (styleConf) {
+    const olStyle = new Style({
+      stroke: OlStyleFactory.createStroke(styleConf)
+    });
+
+    return olStyle;
+  },
+
+  /**
+   * Returns an OpenLayers style instance for polygons due to given config.
+   *
+   * @param  {Object} styleConf  Style config object
+   * @return {Style}             OL style instance
+   */
+  createPolygonStyle (styleConf) {
+    let olStyle = OlStyleFactory.createLineStyle(styleConf);
+    olStyle.setFill(OlStyleFactory.createFill(styleConf));
+
+    return olStyle;
+  },
+
+  /**
+   * Creates an OL Stroke object due to given config.
+   *
+   * @param  {Object} styleConf Style config object
+   * @return {Stroke}           OL Stroke instance
+   */
+  createStroke (styleConf) {
+    return new Stroke({
+      color: styleConf.strokeColor,
+      width: styleConf.strokeWidth
+    });
+  },
+
+  /**
+   * Creates an OL Fill object due to given config.
+   *
+   * @param  {Object} styleConf Style config object
+   * @return {Fill}             OL Fill instance
+   */
+  createFill (styleConf) {
+    return new Fill({
+      color: styleConf.fillColor
+    });
+  }
+
+}

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -30,6 +30,26 @@
     },
 
     {
+      "type": "VECTOR",
+      "lid": "earthquakes",
+      "name": "Earthquakes 2012 (Mag 5)",
+      "url": "./static/data/2012_Earthquakes_Mag5.kml",
+      "formatConfig": {
+        "extractStyles": false
+      },
+      "format": "KML",
+      "visible": true,
+      "attributions": "U.S. Geological Survey",
+      "selectable": true,
+      "style": {
+        "radius": 4,
+        "strokeColor": "rgb(207, 16, 32)",
+        "strokeWidth": 1,
+        "fillColor": "rgba(207, 16, 32, 0.6)"
+      }
+    },
+
+    {
       "type": "WMS",
       "lid": "ahocevar-wms",
       "name": "WMS (ahocevar)",

--- a/test/unit/specs/factory/OlStyle.spec.js
+++ b/test/unit/specs/factory/OlStyle.spec.js
@@ -1,0 +1,94 @@
+import { OlStyleFactory } from '@/factory/OlStyle'
+import { Style, Circle as CircleStyle, Stroke, Fill } from 'ol/style';
+
+describe('OlStyleFactory', () => {
+  it('is defined', () => {
+    expect(typeof OlStyleFactory).to.not.equal(undefined);
+  });
+
+  it('has the correct functions', () => {
+    expect(typeof OlStyleFactory.getInstance).to.equal('function');
+    expect(typeof OlStyleFactory.createPointStyle).to.equal('function');
+    expect(typeof OlStyleFactory.createLineStyle).to.equal('function');
+    expect(typeof OlStyleFactory.createPolygonStyle).to.equal('function');
+    expect(typeof OlStyleFactory.createStroke).to.equal('function');
+    expect(typeof OlStyleFactory.createFill).to.equal('function');
+  });
+
+  it('getInstance returns correct polygon Style instance', () => {
+    const styleConf = {
+      strokeColor: '#d4de24',
+      strokeWidth: 2,
+      fillColor: 'rgba(255, 255, 255, 0.4)'
+    };
+    const style = OlStyleFactory.getInstance(styleConf);
+    expect((style instanceof Style)).to.equal(true);
+    expect(style.getFill().getColor()).to.equal('rgba(255, 255, 255, 0.4)');
+    expect(style.getStroke().getColor()).to.equal('#d4de24');
+    expect(style.getStroke().getWidth()).to.equal(2);
+  });
+
+  it('createPointStyle returns correct Style instance', () => {
+    const styleConf = {
+      radius: 8,
+      strokeColor: '#d4de24',
+      strokeWidth: 2,
+      fillColor: 'rgba(255, 255, 255, 0.4)'
+    };
+    const style = OlStyleFactory.createPointStyle(styleConf);
+    expect((style instanceof Style)).to.equal(true);
+    const circleStyle = style.getImage();
+    expect((circleStyle instanceof CircleStyle)).to.equal(true);
+    expect(circleStyle.getFill().getColor()).to.equal('rgba(255, 255, 255, 0.4)');
+    expect(circleStyle.getStroke().getColor()).to.equal('#d4de24');
+    expect(circleStyle.getStroke().getWidth()).to.equal(2);
+  });
+
+  it('createLineStyle returns correct Style instance', () => {
+    const styleConf = {
+      radius: 8,
+      strokeColor: '#d4de24',
+      strokeWidth: 2,
+      fillColor: 'rgba(255, 255, 255, 0.4)'
+    };
+    const style = OlStyleFactory.createLineStyle(styleConf);
+    expect((style instanceof Style)).to.equal(true);
+    expect(style.getFill()).to.equal(null);
+    expect(style.getStroke().getColor()).to.equal('#d4de24');
+    expect(style.getStroke().getWidth()).to.equal(2);
+  });
+
+  it('createPolygonStyle returns correct Style instance', () => {
+    const styleConf = {
+      radius: 8,
+      strokeColor: '#d4de24',
+      strokeWidth: 2,
+      fillColor: 'rgba(255, 255, 255, 0.4)'
+    };
+    const style = OlStyleFactory.createPolygonStyle(styleConf);
+    expect((style instanceof Style)).to.equal(true);
+    expect(style.getFill().getColor()).to.equal('rgba(255, 255, 255, 0.4)');
+    expect(style.getStroke().getColor()).to.equal('#d4de24');
+    expect(style.getStroke().getWidth()).to.equal(2);
+  });
+
+  it('createStroke returns correct Stroke instance', () => {
+    const styleConf = {
+      strokeColor: '#d4de24',
+      strokeWidth: 2
+    };
+    const stroke = OlStyleFactory.createStroke(styleConf);
+    expect((stroke instanceof Stroke)).to.equal(true);
+    expect(stroke.getColor()).to.equal('#d4de24');
+    expect(stroke.getWidth()).to.equal(2);
+  });
+
+  it('createFill returns correct Fill instance', () => {
+    const styleConf = {
+      fillColor: 'rgba(255, 255, 255, 0.4)'
+    };
+    const fill = OlStyleFactory.createFill(styleConf);
+    expect((fill instanceof Fill)).to.equal(true);
+    expect(fill.getColor()).to.equal('rgba(255, 255, 255, 0.4)');
+  });
+});


### PR DESCRIPTION
This introduces a factory to create simple OpenLayers Style instances. This only covers a minimal subset of the OpenLayers style capabilities (allows creation of simple styles for points, line and polygons).
By adding a `style` property to the layer-config of a vector-layer the data gets styled on the map. 

A style object looks like this:

```JSON
     {
        "radius": 8,
        "strokeColor": "#ff3399",
        "strokeWidth": 1,
        "fillColor": "rgba(207, 16, 32, 0.6)"
      }
```
For more sophisticated styling use [GeoStyler](https://github.com/terrestris/geostyler) and its format-parser instead.