### PR TITLE
Add feature hover functionality to map

### DIFF
--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -143,7 +143,9 @@ export const LayerFactory = {
         format: new this.formatMapping[lConf.format](lConf.formatConfig),
         attributions: lConf.attributions
       }),
-      style: OlStyleFactory.getInstance(lConf.style) || OlStyleDefs[lConf.styleRef]
+      style: OlStyleFactory.getInstance(lConf.style) || OlStyleDefs[lConf.styleRef],
+      hoverable: lConf.hoverable,
+      hoverAttribute: lConf.hoverAttribute
     });
 
     return vectorLayer;
@@ -167,7 +169,9 @@ export const LayerFactory = {
         format: new this.formatMapping[lConf.format](),
         attributions: lConf.attributions
       }),
-      style: OlStyleFactory.getInstance(lConf.style) || OlStyleDefs[lConf.styleRef]
+      style: OlStyleFactory.getInstance(lConf.style) || OlStyleDefs[lConf.styleRef],
+      hoverable: lConf.hoverable,
+      hoverAttribute: lConf.hoverAttribute
     });
 
     return vtLayer;

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -41,6 +41,8 @@
       "visible": true,
       "attributions": "U.S. Geological Survey",
       "selectable": true,
+      "hoverable": true,
+      "hoverAttribute": "name",
       "style": {
         "radius": 4,
         "strokeColor": "rgb(207, 16, 32)",


### PR DESCRIPTION
This adds a feature hover functionality on the map. By hovering a feature of an activated vector layer a little tooltip-like element is shown on the map as OL Overlay.
To activate a vector layer for hovering it has to be configured as `hoverable`. By setting a config option `hoverAttribute` the shown attribute value can be influenced.

Here a demo config: 

```JSON
    {
      "type": "VECTOR",
      "lid": "earthquakes",
      "name": "Earthquakes 2012 (Mag 5)",
      "url": "./static/data/2012_Earthquakes_Mag5.kml",
      "formatConfig": {
        "extractStyles": false
      },
      "format": "KML",
      "visible": true,
      "attributions": "U.S. Geological Survey",
      "selectable": true,
      "hoverable": true,
      "hoverAttribute": "name",
      "style": {
        "radius": 4,
        "strokeColor": "rgb(207, 16, 32)",
        "strokeWidth": 1,
        "fillColor": "rgba(207, 16, 32, 0.6)"
      }
    },
```