### PR TITLE
Improve positioning of module windows in demo app

### DIFF
--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -25,6 +25,19 @@ html {
   bottom: 50px;
 }
 
+.wgu-measurewin {
+  left: auto !important;
+  top: auto !important;
+  right: 10px;
+  bottom: 4.8em;
+}
+
+.wgu-layerlist {
+  left: auto !important;
+  top: 75px !important;
+  right: 10px;
+}
+
 .wgu-footer-left {
   padding-left: 5px;
 }

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -7,7 +7,7 @@
       <v-spacer></v-spacer>
       <v-toolbar-side-icon @click="show = false"><v-icon>close</v-icon></v-toolbar-side-icon>
     </v-toolbar>
-    <v-card-title primary-title>
+    <v-card-title primary-title class="wgu-infoclick-win-title">
 
       <div v-if="!this.attributeData && !this.coordsData" class="no-data">
         Click on the map to get information for the clicked map position.
@@ -141,9 +141,14 @@ export default {
     .v-card.wgu-infoclick-win {
       /* tmp. fix */
       left: 0 !important;
-      top: 45% !important;
+      top: 40% !important;
       width: 100%;
       max-width: 600px;
+    }
+
+    .wgu-infoclick-win-title {
+      overflow: scroll;
+      max-height: 300px;
     }
   }
 

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -60,12 +60,6 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
 
-.wgu-proptable .attr-tbody {
-  display: block;
-  max-height: 225px;
-  overflow-y: scroll;
-}
-
 .wgu-proptable table {
  border-radius: 3px;
  background-color: #fff;

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -91,20 +91,12 @@
     "wgu-layerlist": {
       "target": "menu",
       "win": true,
-      "draggable": true,
-      "initPos": {
-        "left": 8,
-        "top": 70
-      }
+      "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
       "win": true,
-      "draggable": true,
-      "initPos": {
-        "left": 8,
-        "top": 340
-      },
+      "draggable": false,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
       "sketchStrokeColor": "rgba(198,40,40,0.8)",

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -107,10 +107,10 @@
     "wgu-infoclick": {
       "target": "menu",
       "win": true,
-      "draggable": true,
+      "draggable": false,
       "initPos": {
         "left": 8,
-        "top": 340
+        "top": 74
       }
     },
     "wgu-zoomtomaxextent": {


### PR DESCRIPTION
This PR introduces some improvements in the positioning of the floating module windows:

- Remove (non-cross-browser) dragging, use a fix positioning
- Use CSS to position the windows instead of Vue properties
- Optimize the size of the InfoClickWin on mini screens, e.g. mobile phones