### PR TITLE
Make dark style configurable for toolbar buttons 

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -21,7 +21,12 @@
     <slot name="wgu-tb-before-auto-buttons"></slot>
 
     <template v-for="(tbButton, index) in tbButtons">
-      <component :is="tbButton.type" :key="index" :icon="tbButton.icon" :text="tbButton.text" :color="color" />
+      <component
+        :is="tbButton.type" :key="index"
+        :icon="tbButton.icon" :text="tbButton.text"
+        :color="color"
+        :dark="tbButton.dark"
+      />
     </template>
 
     <!-- slot to inject components after the auto-generated buttons (by config) -->
@@ -90,7 +95,10 @@ export default {
       for (const key of Object.keys(appConfig.modules)) {
         const moduleOpts = appConfig.modules[key];
         if (moduleOpts.target === 'menu') {
-          moduleWins.push({type: key + '-btn', target: moduleOpts.target});
+          moduleWins.push({
+            type: key + '-btn',
+            target: moduleOpts.target
+          });
         }
       }
       return moduleWins;
@@ -110,7 +118,11 @@ export default {
       for (const key of Object.keys(appConfig.modules)) {
         const moduleOpts = appConfig.modules[key];
         if (moduleOpts.target === 'toolbar') {
-          moduleWins.push({type: key + '-btn', target: moduleOpts.target});
+          moduleWins.push({
+            type: key + '-btn',
+            target: moduleOpts.target,
+            dark: moduleOpts.darkLayout
+          });
         }
       }
       return moduleWins;

--- a/src/components/helpwin/ToggleButton.vue
+++ b/src/components/helpwin/ToggleButton.vue
@@ -2,7 +2,7 @@
 
   <v-dialog v-model="show" max-width="300" :hide-overlay="false">
 
-    <v-btn icon slot="activator" dark>
+    <v-btn icon :dark="dark" slot="activator">
       <v-icon medium>{{icon}}</v-icon>
       {{text}}
     </v-btn>
@@ -36,6 +36,7 @@ export default {
     color: {type: String, required: false, default: 'red darken-3'},
     icon: {type: String, required: false, default: 'help'},
     text: {type: String, required: false},
+    dark: {type: Boolean, required: false, default: false},
     headline: {type: String, required: false},
     content: {type: String, required: false},
     infoLink: {type: String, required: false},

--- a/src/components/infoclick/ToggleButton.vue
+++ b/src/components/infoclick/ToggleButton.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-btn icon @click="toggleUi">
+  <v-btn icon :dark="dark" @click="toggleUi">
     <v-icon medium>{{icon}}</v-icon>
     {{text}}
   </v-btn>
@@ -15,7 +15,8 @@ export default {
   name: 'wgu-infoclick-btn',
   props: {
     icon: {type: String, required: false, default: 'info'},
-    text: {type: String, required: false, default: ''}
+    text: {type: String, required: false, default: ''},
+    dark: {type: Boolean, required: false, default: false}
   },
   data: function () {
     return {

--- a/src/components/layerlist/ToggleButton.vue
+++ b/src/components/layerlist/ToggleButton.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-btn icon @click="toggleUi">
+  <v-btn icon :dark="dark" @click="toggleUi">
     <v-icon medium>{{icon}}</v-icon>
     {{text}}
   </v-btn>
@@ -20,7 +20,8 @@ export default {
   },
   props: {
     icon: {type: String, required: false, default: 'layers'},
-    text: {type: String, required: false, default: ''}
+    text: {type: String, required: false, default: ''},
+    dark: {type: Boolean, required: false, default: false}
   },
   data: function () {
     return {

--- a/src/components/layerlist/ToggleButton.vue
+++ b/src/components/layerlist/ToggleButton.vue
@@ -1,13 +1,9 @@
 <template>
 
-  <div class="" dark>
-
-    <v-btn icon @click="toggleUi">
-      <v-icon medium>{{icon}}</v-icon>
-      {{text}}
-    </v-btn>
-
-  </div>
+  <v-btn icon @click="toggleUi">
+    <v-icon medium>{{icon}}</v-icon>
+    {{text}}
+  </v-btn>
 
 </template>
 

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-btn icon @click="onClick" dark>
+  <v-btn icon :dark="dark" @click="onClick">
     <v-icon medium>{{icon}}</v-icon>
     {{text}}
   </v-btn>
@@ -16,7 +16,8 @@ export default {
   mixins: [Mapable],
   props: {
     icon: {type: String, required: false, default: 'zoom_out_map'},
-    text: {type: String, required: false, default: ''}
+    text: {type: String, required: false, default: ''},
+    dark: {type: Boolean, required: false, default: false}
   },
   methods: {
     onClick () {

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,13 +1,9 @@
 <template>
 
-  <!-- <div class=""> -->
-
-    <v-btn icon @click="onClick" dark>
-      <v-icon medium>{{icon}}</v-icon>
-      {{text}}
-    </v-btn>
-
-  <!-- </div> -->
+  <v-btn icon @click="onClick" dark>
+    <v-icon medium>{{icon}}</v-icon>
+    {{text}}
+  </v-btn>
 
 </template>
 

--- a/src/components/measuretool/ToggleButton.vue
+++ b/src/components/measuretool/ToggleButton.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-btn icon @click="toggleUi">
+  <v-btn icon :dark="dark" @click="toggleUi">
     <v-icon medium>{{icon}}</v-icon>
     {{text}}
   </v-btn>
@@ -21,7 +21,8 @@ export default {
   },
   props: {
     icon: {type: String, required: false, default: 'photo_size_select_small'},
-    text: {type: String, required: false}
+    text: {type: String, required: false},
+    dark: {type: Boolean, required: false, default: false}
   },
   data: function () {
     return {

--- a/static/app-conf.json
+++ b/static/app-conf.json
@@ -114,10 +114,12 @@
       }
     },
     "wgu-zoomtomaxextent": {
-      "target": "toolbar"
+      "target": "toolbar",
+      "darkLayout": true
     },
     "wgu-helpwin": {
-      "target": "toolbar"
+      "target": "toolbar",
+      "darkLayout": true
     }
   }
 


### PR DESCRIPTION
This makes the `dark` property for buttons in the toolbar (does not apply if placed in the menu) configurable. By setting `darkLayout: true` in the module-config within the app-config file, the corresponding `v-btn` component gets the `dark` property (so the icon will be rendered white).

Example config:

```json
// ...

    "wgu-zoomtomaxextent": {
      "target": "toolbar",
      "darkLayout": true
    },

// ...
```