### PR TITLE
 Fix broken line style generation in OlStyleFactory 

### DIFF
--- a/src/factory/OlStyle.js
+++ b/src/factory/OlStyle.js
@@ -24,7 +24,7 @@ export const OlStyleFactory = {
     } else if (styleConf.fillColor) {
       return OlStyleFactory.createPolygonStyle(styleConf);
     } else if (styleConf.strokeColor || styleConf.strokeWidth) {
-      return OlStyleFactory.createLineStyle();
+      return OlStyleFactory.createLineStyle(styleConf);
     }
   },
 

--- a/test/unit/specs/factory/OlStyle.spec.js
+++ b/test/unit/specs/factory/OlStyle.spec.js
@@ -15,6 +15,32 @@ describe('OlStyleFactory', () => {
     expect(typeof OlStyleFactory.createFill).to.equal('function');
   });
 
+  it('getInstance returns correct point Style instance', () => {
+    const styleConf = {
+      radius: 8,
+      strokeColor: '#d4de24',
+      strokeWidth: 2,
+      fillColor: 'rgba(255, 255, 255, 0.4)'
+    };
+    const style = OlStyleFactory.getInstance(styleConf);
+    const circleStyle = style.getImage();
+    expect((circleStyle instanceof CircleStyle)).to.equal(true);
+    expect(circleStyle.getFill().getColor()).to.equal('rgba(255, 255, 255, 0.4)');
+    expect(circleStyle.getStroke().getColor()).to.equal('#d4de24');
+    expect(circleStyle.getStroke().getWidth()).to.equal(2);
+  });
+
+  it('getInstance returns correct line Style instance', () => {
+    const styleConf = {
+      strokeColor: '#d4de24',
+      strokeWidth: 2
+    };
+    const style = OlStyleFactory.getInstance(styleConf);
+    expect((style instanceof Style)).to.equal(true);
+    expect(style.getStroke().getColor()).to.equal('#d4de24');
+    expect(style.getStroke().getWidth()).to.equal(2);
+  });
+
   it('getInstance returns correct polygon Style instance', () => {
     const styleConf = {
       strokeColor: '#d4de24',


### PR DESCRIPTION
Creating a line style in the `OlStyleFactory`, e.g. by adding a corresponding `style` property to layer-config was broken and is fixed by this PR.  