### PR TITLE
Fix tests for watchers

### DIFF
--- a/test/unit/specs/components/infoclick/CoordsTable.spec.js
+++ b/test/unit/specs/components/infoclick/CoordsTable.spec.js
@@ -47,7 +47,7 @@ describe('infoclick/CoordsTable.vue', () => {
     });
   });
 
-  describe('watchers', () => {
+  describe('watchers', done => {
     let comp;
     beforeEach(() => {
       comp = shallowMount(CoordsTable);
@@ -63,9 +63,12 @@ describe('infoclick/CoordsTable.vue', () => {
         'WGS 84': '1.0000000° 1.0000000°',
         'HDMS': '1° 00′ 00″ N 1° 00′ 00″ E'
       };
-      expect(comp.vm.coordRows['MAP PROJ']).to.equal(expextedCoordRows['MAP PROJ']);
-      expect(comp.vm.coordRows['WGS 84']).to.equal(expextedCoordRows['WGS 84']);
-      expect(comp.vm.coordRows['HDMS']).to.equal(expextedCoordRows['HDMS']);
+      comp.vm.$nextTick(() => {
+        expect(comp.vm.coordRows['MAP PROJ']).to.equal(expextedCoordRows['MAP PROJ']);
+        expect(comp.vm.coordRows['WGS 84']).to.equal(expextedCoordRows['WGS 84']);
+        expect(comp.vm.coordRows['HDMS']).to.equal(expextedCoordRows['HDMS']);
+        done();
+      });
     });
   });
 });

--- a/test/unit/specs/components/infoclick/InfoClickWin.spec.js
+++ b/test/unit/specs/components/infoclick/InfoClickWin.spec.js
@@ -122,21 +122,27 @@ describe('infoclick/InfoClickWin.vue', () => {
       comp = shallowMount(InfoClickWin);
     });
 
-    it('watches show setting to false', () => {
+    it('watches show setting to false', done => {
       comp.vm.show = true;
       comp.vm.show = false;
-      expect(comp.vm.attributeData).to.equal(null);
-      expect(comp.vm.coordsData).to.equal(null);
+      comp.vm.$nextTick(() => {
+        expect(comp.vm.attributeData).to.equal(null);
+        expect(comp.vm.coordsData).to.equal(null);
+        done();
+      });
     });
 
-    it('watches show setting to true', () => {
+    it('watches show setting to true', done => {
       let cnt = 0;
       let mockFn = () => {
         cnt++;
       };
       comp.vm.registerMapClick = mockFn;
       comp.vm.show = true;
-      expect(cnt).to.equal(1);
+      comp.vm.$nextTick(() => {
+        expect(cnt).to.equal(1);
+        done();
+      });
     });
   });
 });

--- a/test/unit/specs/components/measuretool/MeasureResult.spec.js
+++ b/test/unit/specs/components/measuretool/MeasureResult.spec.js
@@ -64,18 +64,24 @@ describe('measuretool/MeasureResult.vue', () => {
       comp = shallowMount(MeasureResult);
     });
 
-    it('watches measureGeom Polygon', () => {
+    it('watches measureGeom Polygon', done => {
       const polyGeom = new PolygonGeom([[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]);
 
       comp.vm.measureGeom = {geom: polyGeom};
-      expect(comp.vm.area).to.equal('1 m²');
+      comp.vm.$nextTick(() => {
+        expect(comp.vm.area).to.equal('1 m²');
+        done();
+      });
     });
 
-    it('watches measureGeom LineString', () => {
+    it('watches measureGeom LineString', done => {
       const lineGeom = new LineStringGeom([[0, 0], [1, 0], [1, 1], [0, 1]]);
 
       comp.vm.measureGeom = {geom: lineGeom};
-      expect(comp.vm.distance).to.equal('3 m');
+      comp.vm.$nextTick(() => {
+        expect(comp.vm.distance).to.equal('3 m');
+        done();
+      });
     });
 
     it('watches measureGeom non supported geom', () => {

--- a/test/unit/specs/components/measuretool/MeasureTypeChooser.spec.js
+++ b/test/unit/specs/components/measuretool/MeasureTypeChooser.spec.js
@@ -34,13 +34,16 @@ describe('measuretool/MeasureTypeChooser.vue', () => {
       comp = shallowMount(MeasureTypeChooser);
     });
 
-    it('watches measureTypeData fires event "wgu-measuretype-change"', () => {
+    it('watches measureTypeData fires event "wgu-measuretype-change"', done => {
       let cnt = 0;
       comp.vm.$on('wgu-measuretype-change', () => {
         cnt++;
       });
       comp.vm.measureTypeData = 'kalle';
-      expect(cnt).to.equal(1);
+      comp.vm.$nextTick(() => {
+        expect(cnt).to.equal(1);
+        done();
+      });
     });
   });
 });

--- a/test/unit/specs/components/measuretool/MeasureWin.spec.js
+++ b/test/unit/specs/components/measuretool/MeasureWin.spec.js
@@ -47,7 +47,7 @@ describe('measuretool/MeasureWin.vue', () => {
       vm = comp.vm;
     });
 
-    it('watches show setting to false', () => {
+    it('watches show setting to false', done => {
       let cnt = 0;
       let mockFn = () => {
         cnt++;
@@ -60,11 +60,18 @@ describe('measuretool/MeasureWin.vue', () => {
       vm.olMapCtrl.removeInteraction = mockFn;
       // toggle to trigger the watcher
       vm.show = true;
+      vm.$nextTick(() => {
+        expect(cnt).to.equal(0);
+        done();
+      });
       vm.show = false;
-      expect(cnt).to.equal(1);
+      vm.$nextTick(() => {
+        expect(cnt).to.equal(1);
+        done();
+      });
     });
 
-    it('watches show setting to true', () => {
+    it('watches show setting to true', done => {
       let cnt = 0;
       let mockFn = () => {
         cnt++;
@@ -76,12 +83,18 @@ describe('measuretool/MeasureWin.vue', () => {
       vm.onMapBound();
       vm.olMapCtrl.addInteraction = mockFn;
       vm.show = true;
-      expect(cnt).to.equal(1);
+      vm.$nextTick(() => {
+        expect(cnt).to.equal(1);
+        done();
+      });
     });
 
-    it('watches measureType resets old data', () => {
-      comp.vm.measureType = 'area';
-      expect(comp.vm.measureGeom).to.be.an('object').that.is.empty;
+    it('watches measureType resets old data', done => {
+      vm.measureType = 'area';
+      vm.$nextTick(() => {
+        expect(vm.measureGeom).to.be.an('object').that.is.empty;
+        done();
+      })
     });
   });
 


### PR DESCRIPTION
This PR fixes the units tests for Vue watchers. Since watchers are deferred to the next update cycle the calculated values are available after the test has finished.
This reworks the tests so the` vm.$nextTick` function is used to defer the assertions to the next update cycle.

Unfortunately the tests weren't failing on Travis in the past and they are still not failing in the local dev setup. That's why this came a bit unexpected.   