### PR TITLE
PR for #98 app-specific config file location under app/

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,17 +33,27 @@ if (appCtx) {
   appCtxFile = '-' + appCtx.replace(/(\.\.[/])+/g, '');
 }
 
-fetch('static/app-conf' + appCtxFile + '.json')
+const createApp = function (appConfig) {
+  // make app config accessible for all components
+  Vue.prototype.$appConfig = appConfig;
+  /* eslint-disable no-new */
+  new Vue({
+    el: '#app',
+    template: '<wgu-app/>',
+    components: { WguApp }
+  });
+};
+
+// First look in the app dir for an app-specific config file.
+fetch('app/static/app-conf' + appCtxFile + '.json')
   .then(function (response) {
-    return response.json();
-  })
-  .then(function (appConfig) {
-    // make app config accessible for all components
-    Vue.prototype.$appConfig = appConfig;
-    /* eslint-disable no-new */
-    new Vue({
-      el: '#app',
-      template: '<wgu-app/>',
-      components: { WguApp }
-    });
+    return response.json().then(function (appConfig) {
+      createApp(appConfig);
+    })
+  }).catch(function () {
+    fetch('static/app-conf' + appCtxFile + '.json').then(function (response) {
+      return response.json().then(function (appConfig) {
+        createApp(appConfig);
+      })
+    })
   });


### PR DESCRIPTION
Solves #98 :

* on startup `main.js` will first search in `app/static/` and then `static/` for th app context config .json file
* works for both dev-server and built (prod) versions


