### PR TITLE
Follow-up for initial website version

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,7 +6,7 @@
     - [Wegue Config](wegue-configuration.md)
     - [Map Layers](map-layer-configuration.md)
     - [Module Configuration](module-configuration.md)
-    - [QGIS Plugin](qgis_plugin.md)
+- [QGIS2Wegue](qgis_plugin.md)
 
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Document</title>
+  <title>Wegue</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
@@ -17,7 +17,7 @@
       homepage: 'home.md',
       name: 'Wegue',
       repo: 'https://github.com/meggsimum/wegue',
-      basePath: 'https://jakobmiksch.github.io/wegue-docs',
+      basePath: 'https://meggsimum.github.io/wegue',
       themeColor: '#cc0000'
     }
   </script>

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -1,14 +1,20 @@
-# QGIS Plugin
+# QGIS2Wegue QGIS Plugin
 
-Adding many layers to a configuration file can be laborious, this is where `QGIS2Wegue` ([GitHub Repository](https://github.com/meggsimum/qgis2wegue)) comes in handy. It converts all layers of a QGIS project into a valid Wegue configuration. This works for `WMS`, `XYZ`, `KML`, `GeoJSON`, `WFS`.
+Configuring your Wegue application by hand can be laborious. This is where QGIS plugin `QGIS2Wegue` ([GitHub Repository](https://github.com/meggsimum/qgis2wegue)) comes in handy. It derives a valid Wegue application configuration from your QGIS project:
+
+  - All layers of a QGIS project are converted into a valid Wegue layer configuration. This works for `WMS`, `XYZ`, `KML`, `GeoJSON`, `WFS`
+  - The map extent is taken over to the configuration
+  - Textual elements, like title and footer can be set in a GUI
+  - The modules, which should be included in your Wegue application, be easily be added / removed via GUI
 
 ![Screenshot QGIS2Wegue](_media/qgis2wegue.jpg)
 
 ## Usage
 
 - Add all your desired layers to QGIS
-- Open the plugin, chose a filepath and click `OK`
-- Now you have a configuration file that works with Wegue 
+- Center the map to your area of interest
+- Open the plugin, chose a filepath (optionally add some custom settings) and click `OK`
+- Now you have a configuration file that works with Wegue
 
 ## Installation
 

--- a/docs/qgis_plugin.md
+++ b/docs/qgis_plugin.md
@@ -5,7 +5,7 @@ Configuring your Wegue application by hand can be laborious. This is where QGIS 
   - All layers of a QGIS project are converted into a valid Wegue layer configuration. This works for `WMS`, `XYZ`, `KML`, `GeoJSON`, `WFS`
   - The map extent is taken over to the configuration
   - Textual elements, like title and footer can be set in a GUI
-  - The modules, which should be included in your Wegue application, be easily be added / removed via GUI
+  - Modules to be included in your Wegue application can be easily added / removed via the GUI
 
 ![Screenshot QGIS2Wegue](_media/qgis2wegue.jpg)
 


### PR DESCRIPTION
This adds some adaptations for the initial Wegue website version:

  - Set Docsify base path
  - Change website title
  - Put QGIS2Wegue in a separate menu entry
  - Add more information about QGIS2Wegue
  - Hint for currently missing live demo

Please review @JakobMiksch (and anyone else of course) 