### PR TITLE
Load OL CSS before Wegue App template

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,13 +2,12 @@
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue';
 import Vuetify from 'vuetify';
+import '../node_modules/ol/ol.css';
 import WguApp from '../app/WguApp';
 import UrlUtil from './util/Url';
 import 'vuetify/dist/vuetify.min.css';
 
 Vue.use(Vuetify);
-
-require('../node_modules/ol/ol.css');
 
 require('./assets/css/wegue.css');
 


### PR DESCRIPTION
This ensures that the OpenLayers CSS is loaded before the Wegue App template. So overwrites of OL CSS will have affect in production build (not just in dev mode).

Please review @justb4 and @JakobMiksch (and of course anybody else who is willing to review).

Fixes #134 

