### PR TITLE
Make AppLogo size more flexible

### DIFF
--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -5,7 +5,8 @@
   "baseColor": "red darken-3",
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
-  "logoSize": "100",
+  "logoWidth": "100",
+  "logoHeight": "100",
 
   "footerTextLeft": "Powered by <a href='https://meggsimum.de/wegue/' target='_blank'>Wegue WebGIS</a>",
   "footerTextRight": "meggsimum",

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -11,7 +11,9 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | title             |  | Title shown in the top toolbar | `"title": "A Wegue WebGIS App"` |
 | baseColor         |  | Main colour of the UI elements | `"baseColor": "red darken-3"` or `"baseColor": "#ff3388"` |
 | logo              |  | URL to an image shown as application logo | ` "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue"`
-| logoSize          |  | Size of the application logo defined in `logo` | `"logoSize": "100"` |
+| logoWidth         |  | Width of the application logo defined in `logo` | `"logoWidth": "200"`|
+| logoHeight        |  | Height of the application logo defined in `logo` | `"logoWidth": "100"` |
+| logoSize          |  | Squared size of the application logo defined in `logo`. Only has an effect if `logoWidth` and `logoHeight` are **not** set. Otherwise these will overwrite the `logoSize` setting. | `"logoSize": "100"` |
 | footerTextLeft    |  | Text or HTML string to be displayed in the left side of the toolbar | `"footerTextLeft": "Powered by <a href='https://meggsimum.de/wegue/' target='_blank'>Wegue WebGIS</a>"` |
 | footerTextRight   |  | Text or HTML string to be displayed in the right side of the toolbar | `"footerTextRight": "meggsimum"` |
 | showCopyrightYear |  | Boolean value, whether the copyright year should be shown on the right side of the toolbar | `"showCopyrightYear": true` or `"showCopyrightYear": false` | 

--- a/src/components/AppLogo.vue
+++ b/src/components/AppLogo.vue
@@ -2,7 +2,8 @@
 
   <v-avatar
      v-if="!!logoSrc"
-     :size="logoSize"
+     :width="logoWidth"
+     :height="logoHeight"
      :tile="true"
      class="wgu-app-logo"
     >
@@ -18,7 +19,16 @@ export default {
   data () {
     return {
       logoSrc: this.$appConfig.logo,
-      logoSize: this.$appConfig.logoSize
+      logoSize: this.$appConfig.logoSize,
+      logoWidth: this.$appConfig.logoWidth,
+      logoHeight: this.$appConfig.logoHeight
+    }
+  },
+  created () {
+    // for backwards compat we use logoSize if width and height are missing
+    if (this.logoSize && !this.logoWidth && !this.logoHeight) {
+      this.logoWidth = this.logoSize;
+      this.logoHeight = this.logoSize;
     }
   }
 }


### PR DESCRIPTION
This makes the `AppLogo` sizing more flexible. A separate width and height could be specified now in the app configuration:

```json
// ...
  "logoWidth": "200",
  "logoHeight": "100",
// ...

```

For backwards compatibility `logoSize` for squared images could still be used in app config (if neither `logoWidth` nor `logoHeight` is set).

Please review @justb4 and @JakobMiksch (and of course anybody else who is willing to review).

Closes #117 