### PR TITLE
Add basic support for vector labels

### DIFF
--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -40,7 +40,17 @@
         "radius": 4,
         "strokeColor": "purple",
         "strokeWidth": 2,
-        "fillColor": "rgba(155,153,51,0.5)"
+        "fillColor": "rgba(155,153,51,0.5)",
+        "label": {
+          "attribute": "name",
+          "minResolution": 4.0,
+          "outlineColor": "white",
+          "outlineWidth": 2,
+          "fillColor": "black",
+          "offsetX": 0,
+          "offsetY": 15,
+          "align": "center"
+        }
       }
     },
     {

--- a/src/factory/OlStyle.js
+++ b/src/factory/OlStyle.js
@@ -1,4 +1,6 @@
-import { Circle as CircleStyle, Icon as IconStyle, Fill, Stroke, Style } from 'ol/style';
+import {
+  Circle as CircleStyle, Icon as IconStyle, Fill, Stroke, Style, Text }
+  from 'ol/style';
 
 /**
  * Factory, which creates OpenLayers style instances according to a given config
@@ -17,15 +19,24 @@ export const OlStyleFactory = {
    * @return {Style}             OL Style instance
    */
   getInstance (styleConf) {
+    let style;
     if (!styleConf) {
       return;
     } else if (styleConf.radius || styleConf.iconUrl) {
-      return OlStyleFactory.createPointStyle(styleConf);
+      style = OlStyleFactory.createPointStyle(styleConf);
     } else if (styleConf.fillColor) {
-      return OlStyleFactory.createPolygonStyle(styleConf);
+      style = OlStyleFactory.createPolygonStyle(styleConf);
     } else if (styleConf.strokeColor || styleConf.strokeWidth) {
-      return OlStyleFactory.createLineStyle(styleConf);
+      style = OlStyleFactory.createLineStyle(styleConf);
     }
+
+    if (styleConf.label && styleConf.label.attribute &&
+        styleConf.label.attribute !== '') {
+      // use an OL style function to enable labels
+      return OlStyleFactory.getTextStyleFunction(style, styleConf.label);
+    }
+
+    return style;
   },
 
   /**
@@ -109,6 +120,56 @@ export const OlStyleFactory = {
     return new Fill({
       color: styleConf.fillColor
     });
+  },
+
+  /**
+   * Creates and returns a basic OL style object for texts.
+   *
+   * @param {Object} labelConf Style config object for labels
+   * @returns {ol/style/Text} The OL style object for texts
+   */
+  getTextStyle (labelConf) {
+    const textConf = { ...labelConf };
+
+    textConf.fill = new Fill({color: textConf.fillColor});
+    textConf.stroke = new Stroke({
+      color: textConf.outlineColor,
+      width: textConf.outlineWidth
+    });
+
+    const textStyle = new Text(textConf);
+
+    return textStyle;
+  },
+
+  /**
+   * Wraps the given OL style as function and injects a text style symbolizer
+   * in order to show a label at the feature.
+   *
+   * @param {ol/style/Style} style
+   * @param {Object} labelStyleConf
+   * @returns {ol/style/Style~StyleFunction}
+   *    Style function returning the OL style object enriched by texts / labels
+   */
+  getTextStyleFunction (style, labelStyleConf) {
+    const labelStyle = OlStyleFactory.getTextStyle(labelStyleConf);
+    const labelAttr = labelStyleConf.attribute;
+    return (feature, resolution) => {
+      // detect min/max resolution to show labels
+      // if nothing is confured labels are shown regardless of resolution
+      const minRes = labelStyleConf.minResolution || Number.MAX_SAFE_INTEGER;
+      const maxRes = labelStyleConf.maxResolution || 0;
+      if (resolution < minRes && resolution > maxRes) {
+        // set text to display
+        labelStyle.setText(feature.get(labelAttr));
+        // apply text style to overall style object
+        style.setText(labelStyle);
+      } else {
+        labelStyle.setText(null);
+      }
+
+      return style;
+    }
   }
 
 }

--- a/src/factory/OlStyle.js
+++ b/src/factory/OlStyle.js
@@ -129,6 +129,7 @@ export const OlStyleFactory = {
    * @returns {ol/style/Text} The OL style object for texts
    */
   getTextStyle (labelConf) {
+    // create a clone to avoid unwanted in place modification
     const textConf = { ...labelConf };
 
     textConf.fill = new Fill({color: textConf.fillColor});
@@ -156,7 +157,7 @@ export const OlStyleFactory = {
     const labelAttr = labelStyleConf.attribute;
     return (feature, resolution) => {
       // detect min/max resolution to show labels
-      // if nothing is confured labels are shown regardless of resolution
+      // if nothing is configured labels are shown regardless of resolution
       const minRes = labelStyleConf.minResolution || Number.MAX_SAFE_INTEGER;
       const maxRes = labelStyleConf.maxResolution || 0;
       if (resolution < minRes && resolution > maxRes) {


### PR DESCRIPTION
This adds basic support to configure labels in the style for vector based layers. Base for the label text is a single attribute in the
underlying vector data. A configuration like this can be added to the style section of each vector based layer configuration:

```json
        "label": {
          "attribute": "name",
          "minResolution": 4.0,
          "outlineColor": "white",
          "outlineWidth": 2,
          "fillColor": "blue",
          "offsetX": 0,
          "offsetY": 15,
          "align": "center"
        }
```
Result:
![image](https://user-images.githubusercontent.com/1185547/102515897-925c7a80-408e-11eb-9606-dd8bb4397a2e.png)

Besides `attribute`, `outlineColor`, `outlineWidth`, `fillColor`, `minResolution`, `maxResolution` every  config property of [ol/style/Text](https://openlayers.org/en/latest/apidoc/module-ol_style_Text-Text.html) can be set, e.g. `offsetX` and `offsetY`.

More sophisticated templating can be discussed in #157.
