### PR TITLE
Change basepath of docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
       homepage: 'home.md',
       name: 'Wegue',
       repo: 'https://github.com/meggsimum/wegue',
-      basePath: 'https://meggsimum.github.io/wegue',
+      basePath: 'http://www.wegue.org',
       themeColor: '#cc0000'
     }
   </script>


### PR DESCRIPTION
we already have the domain [www.wegue.org](http://www.wegue.org) - However the docs does not really use it. See screenshot:

![image](https://user-images.githubusercontent.com/15704517/102991930-894e2c00-451a-11eb-815b-546a92236314.png)

I guess it should just the small change in this PR, but I cannot really test it ... 

- [ ] We might need to check if HTTP**S** is supported or not
