### PR TITLE
Fix position of attribution

### DIFF
--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -365,7 +365,6 @@ export default {
   }
 
   div.ol-attribution.ol-uncollapsible {
-    bottom: 12px;
     font-size: 10px;
   }
 


### PR DESCRIPTION
the position of the attribution was too high

before:
![image](https://user-images.githubusercontent.com/15704517/103000822-1057d000-452c-11eb-8375-02685c6d88d7.png)

after:
![image](https://user-images.githubusercontent.com/15704517/103000852-21a0dc80-452c-11eb-855a-4b15dd31436c.png)
 