### PR TITLE
Docs: link to a demo application

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -5,7 +5,7 @@
 ![](_media/cover.gif)
 
 [GitHub](https://github.com/meggsimum/wegue)
-[Demo](https://meggsimum.github.io/wegue/)
+[Demo](https://apps.meggsimum.de/wegue-demos/global/)
 [Quickstart](?id=quickstart)
 
 ![color](#DADADA)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15704517/108089267-b2ea8600-7079-11eb-9040-608a86a21dd2.png)


Adds a link to the demo button: https://apps.meggsimum.de/wegue-demos/global/

We can of course also take another demo app for the link

fixes: #141
also partly: #140 