### PR TITLE
Make HTML document title configurable

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -86,6 +86,10 @@
         baseColor: Vue.prototype.$appConfig.baseColor
       }
     },
+    created () {
+      // set document title (e.g. shown in browser tab) from app config
+      document.title = Vue.prototype.$appConfig.browserTitle || document.title;
+    },
     mounted () {
       // apply the isEmbedded state to the member var
       this.isEmbedded = this.$isEmbedded;

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -1,6 +1,7 @@
 {
 
   "title": "Vue.js / OpenLayers WebGIS",
+  "browserTitle": "Wegue Demo App",
 
   "baseColor": "red darken-3",
 
@@ -208,7 +209,7 @@
     },
     "wgu-helpwin": {
       "target": "toolbar",
-      "darkLayout": true, 
+      "darkLayout": true,
       "windowTitle": "About",
       "textTitle": "About Wegue",
       "htmlContent": "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js",

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -8,7 +8,8 @@ This describes the Wegue application configuration, which is modelled as JSON do
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| title              | Title shown in the top toolbar | `"title": "A Wegue WebGIS App"` |
+| title              | Title shown in the top toolbar of the application | `"title": "A Wegue WebGIS App"` |
+| browserTitle       | HTML document title that is shown in the browser title bar or a browser page tab | `"browserTitle": "Wegue Demo App"` |
 | baseColor          | Main colour of the UI elements | `"baseColor": "red darken-3"` or `"baseColor": "#ff3388"` |
 | logo               | URL to an image shown as application logo | ` "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue"`
 | logoWidth          | Width of the application logo defined in `logo` | `"logoWidth": "200"`|


### PR DESCRIPTION
Sets the [document title](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title) (e.g. shown in browser tab) from a new config `browserTitle` in the app config.

Closes #178 