### PR TITLE
Enable hoverable configuration for WFS layers

### DIFF
--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -48,6 +48,8 @@ The following properties can be applied to all map layer types
 | format             | The format that should be used. Possible values are `GeoJSON`, `GML2`, `GML3` and `GML32`. Defaults to `GML3` |  `"format": "GeoJSON"`|
 | selectable         | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
 | selectStyle        | The style for a selected feature| see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
+| hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
 
 
 ## VECTORTILE

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -187,7 +187,9 @@ export const LayerFactory = {
       visible: lConf.visible,
       opacity: lConf.opacity,
       source: vectorSource,
-      style: OlStyleFactory.getInstance(lConf.style)
+      style: OlStyleFactory.getInstance(lConf.style),
+      hoverable: lConf.hoverable,
+      hoverAttribute: lConf.hoverAttribute
     });
 
     return vector;


### PR DESCRIPTION
Enables `hoverable` and `hoverAttribute` configuration for WFS layers. Also adds the corresponding docs.

Closes #162