### PR TITLE
Several minor vector hover enhancements

### DIFF
--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -60,6 +60,8 @@
       "loadOnlyVisible": true,
       "visible": false,
       "selectable": true,
+      "hoverable": true,
+      "hoverAttribute": "naam",
       "style": {
         "strokeColor": "white",
         "strokeWidth": 2,
@@ -165,7 +167,7 @@
     },
     "wgu-helpwin": {
       "target": "toolbar",
-      "darkLayout": true, 
+      "darkLayout": true,
       "windowTitle": "About",
       "textTitle": "About Wegue",
       "htmlContent": "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js",

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -32,6 +32,7 @@ The following properties can be applied to all map layer types
 | **format**         | The format of the data linked in `url` (either `KML` or `GeoJSON` ) | `"format": "KML"` |
 | selectable         | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
 | hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
+| hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
 | style              | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
 | selectStyle        | The style for a selected feature | see [style](map-layer-configuration?id=style-for-vectorlayers) |
 
@@ -58,6 +59,8 @@ The following properties can be applied to all map layer types
 | **url**            | The URL to the vector tile service | `"url": "https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf"` |
 | **format**         | The format of the data linked in `url` (either `MVT`, `TopoJSON` or `GeoJSON` ) | `"format": "MVT"` |
 | style              | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
+| hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
 
 ## WMS
 

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -390,7 +390,8 @@ export default {
 
   /* Hover tooltip */
   .wgu-hover-tooltiptext {
-    width: 120px;
+    float: left; /* needed that max-width has an effect */
+    max-width: 200px;
     background-color: rgba(211, 211, 211, .9);
     color: #222;
     text-align: center;
@@ -398,7 +399,7 @@ export default {
     border-radius: 6px;
 
     /* Position the hover tooltip */
-    position: absolute;
+    position: relative;
     z-index: 1;
   }
 


### PR DESCRIPTION
  - Document `hoverable` + `hoverAttribute` in all necessary places in docs
  - Remove fixed with for vector hover tooltip element, using a max-width of 200px instead
  - Enable WFS layer hovering to `projected` example app

Should be merged after #190 is merged.