### PR TITLE
Ignore measure-layer for permalink

### DIFF
--- a/src/components/ol/PermalinkController.js
+++ b/src/components/ol/PermalinkController.js
@@ -13,6 +13,7 @@ export default class PermalinkController {
   projection = null;
   conf = null;
   urlParams = null;
+  ignoreLayers = ['measure-layer'];
 
   constructor (map, permalinkConf) {
     this.map = map;
@@ -261,10 +262,12 @@ export default class PermalinkController {
   }
 
   /**
-   * Get array of visible layer id's.
+   * Get array of visible and not ignored layer IDs.
    */
   getLayerIds () {
-    return this.map.getLayers().getArray().filter(layer => !!layer.get('lid') && layer.getVisible()).map(layer => layer.get('lid'));
+    return this.map.getLayers().getArray().filter(
+      layer => !!layer.get('lid') && layer.getVisible() && !this.ignoreLayers.includes(layer.get('lid'))
+    ).map(layer => layer.get('lid'));
   }
 
   /**


### PR DESCRIPTION
This ensures that the layer for the measurement geometries (`measure-layer`) is not listed in the permalink.

Fixes #194