### PR TITLE
AttributeTable-Map interaction

### DIFF
--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -242,7 +242,8 @@
     },
     "wgu-attributetable": {
       "target": "menu",
-      "win": true
+      "win": true,
+      "activateTableMapInteraction": true
     }
   }
 }

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -243,7 +243,7 @@
     "wgu-attributetable": {
       "target": "menu",
       "win": true,
-      "activateTableMapInteraction": true
+      "syncTableMapSelection": true
     }
   }
 }

--- a/app/README.md
+++ b/app/README.md
@@ -1,12 +1,5 @@
-# Wegue App Dir
-This directory will contain your Wegue Application.
-By using the command `npm run init:app` this directory is populated with
-the contents from the `app-starter/` dir.
+# Wegue App Starter Dir
+This directory contains a Wegue starter app.
+By using the command `npm run init:app` this directory is copied to the `app/` directory.
+For now this copy will not overwrite files already present in the `app/` dir.
 
-You can develop your Wegue app by modifying/adding files here, under the `app/` dir, for example:
-
-* modifying the core `.vue` files like `app/WguApp.vue` and `app/WguAppTemplate.vue`
-* placing or modifying custom/app-specific components under `app/components`
-* placing or modifying  static content like configuration, data, icons and css under `app/static`.
-
-The default config file is `app/static/app-conf.json`.

--- a/app/README.md
+++ b/app/README.md
@@ -1,5 +1,12 @@
-# Wegue App Starter Dir
-This directory contains a Wegue starter app.
-By using the command `npm run init:app` this directory is copied to the `app/` directory.
-For now this copy will not overwrite files already present in the `app/` dir.
+# Wegue App Dir
+This directory will contain your Wegue Application.
+By using the command `npm run init:app` this directory is populated with
+the contents from the `app-starter/` dir.
 
+You can develop your Wegue app by modifying/adding files here, under the `app/` dir, for example:
+
+* modifying the core `.vue` files like `app/WguApp.vue` and `app/WguAppTemplate.vue`
+* placing or modifying custom/app-specific components under `app/components`
+* placing or modifying  static content like configuration, data, icons and css under `app/static`.
+
+The default config file is `app/static/app-conf.json`.

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -91,4 +91,4 @@ Module identifier: `wgu-attributetable`
 
 | Property                    | Meaning   | Example |
 |-----------------------------|:---------:|---------|
-| activateTableMapInteraction | Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"activateTableMapInteraction": true` |
+| syncTableMapSelection | Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"syncTableMapSelection": true` |

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -91,4 +91,4 @@ Module identifier: `wgu-attributetable`
 
 | Property                    | Meaning   | Example |
 |-----------------------------|:---------:|---------|
-| activateTableMapInteraction | Works only for desktop view, it is automatically disabled on mobile view. Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"activateTableMapInteraction": true` |
+| activateTableMapInteraction | Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"activateTableMapInteraction": true` |

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -89,4 +89,6 @@ The attribute table displays features of vector layers. It is possible to specif
 
 Module identifier: `wgu-attributetable`
 
-No additional config options besides the general ones.
+| Property                    | Meaning   | Example |
+|-----------------------------|:---------:|---------|
+| activateTableMapInteraction | Works only for desktop view, it is automatically disabled on mobile view. Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"activateTableMapInteraction": true` |

--- a/src/components/attributeTable/AttributeTable.vue
+++ b/src/components/attributeTable/AttributeTable.vue
@@ -89,8 +89,10 @@ export default {
     }
   },
   beforeDestroy () {
-    // unregister event after table is closed
-    this.layer.getSource().un('change', this.prepareTableDataAndColumns);
+    if (this.layer && this.layer.getSource()) {
+      // unregister event after table is closed
+      this.layer.getSource().un('change', this.prepareTableDataAndColumns);
+    }
   },
   watch: {
     layerId () {

--- a/src/components/attributeTable/AttributeTable.vue
+++ b/src/components/attributeTable/AttributeTable.vue
@@ -28,7 +28,7 @@
 import { Mapable } from '../../mixins/Mapable';
 import LayerUtil from '../../util/Layer';
 import { WguEventBus } from '../../WguEventBus';
-import SelectInteraction from 'ol/interaction/Select';
+import MapInteractionUtil from '../../util/MapInteraction';
 
 export default {
   name: 'wgu-attributetable',
@@ -124,15 +124,8 @@ export default {
      * before table is opened.
      */
     highlightInitialFeatureSelectionInTable () {
-      const interactions = this.map.getInteractions().getArray();
-      if (!interactions) {
-        return;
-      }
+      const correspondingInteraction = MapInteractionUtil.getSelectInteraction(this.map, this.layerId);
 
-      const correspondingInteraction = interactions.find(interaction => {
-        return interaction instanceof SelectInteraction &&
-              interaction.get('lid') === this.layerId;
-      });
       if (!correspondingInteraction) {
         return;
       }
@@ -240,17 +233,7 @@ export default {
         maxZoom: this.maxZoomOnFeature
       });
 
-      // find respective map interaction
-      if (!this.map.getInteractions() ||
-      !this.map.getInteractions().getArray()) {
-        return;
-      }
-      const interactions = this.map.getInteractions().getArray();
-
-      const correspondingInteraction = interactions.find(interaction => {
-        return interaction instanceof SelectInteraction &&
-              interaction.get('lid') === this.layerId;
-      });
+      const correspondingInteraction = MapInteractionUtil.getSelectInteraction(this.map, this.layerId);
 
       // we can only select layers that have a select interaction
       if (!correspondingInteraction) {

--- a/src/components/attributeTable/AttributeTable.vue
+++ b/src/components/attributeTable/AttributeTable.vue
@@ -50,7 +50,7 @@ export default {
     rowsPerPage: {type: Number, required: false, default: 10},
 
     /**
-     * The hight of the table in pixel.
+     * The height of the table in pixel.
      * Should be manually adjusted with rowsPerPage.
      */
     tableHeight: {type: Number, required: false, default: 272},

--- a/src/components/attributeTable/AttributeTable.vue
+++ b/src/components/attributeTable/AttributeTable.vue
@@ -56,7 +56,7 @@ export default {
     tableHeight: {type: Number, required: false, default: 272},
 
     /** If map and table should be synced */
-    activateTableMapInteraction: {type: Boolean, required: false, default: true},
+    syncTableMapSelection: {type: Boolean, required: false, default: true},
 
     /** The maximum zoom level when clicking on a row */
     maxZoomOnFeature: {type: Number, required: false, default: 15},
@@ -84,7 +84,7 @@ export default {
   created () {
     this.populateTable()
 
-    if (this.activateTableMapInteraction) {
+    if (this.syncTableMapSelection) {
       this.activateSelectRowOnMapClick();
     }
   },
@@ -219,7 +219,7 @@ export default {
      * map will be styled as selected.
      */
     onRowClick (record) {
-      if (!this.activateTableMapInteraction) {
+      if (!this.syncTableMapSelection) {
         return;
       }
 

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -31,7 +31,9 @@
 
   <wgu-attributetable
     v-if="layerId"
+    v-resize="onResize"
     :layerId="layerId"
+    :activateTableMapInteraction="activateTableMapInteraction"
   >
   </wgu-attributetable>
   </v-card>
@@ -60,10 +62,39 @@ export default {
     }
   },
   mixins: [Mapable],
+  created () {
+    const config = this.$appConfig.modules['wgu-attributetable'];
+    this.activateTableMapInteraction = config.activateTableMapInteraction || false
+  },
   components: {
     'wgu-attributetable': AttributeTable
   },
+  watch: {
+    show () {
+      // resize map properly after closing
+      // the AttributeTable
+      this.resizeOlMap()
+    }
+  },
   methods: {
+    onResize () {
+      // change map size when window is changing
+      this.resizeOlMap()
+    },
+
+    /**
+     * Update the OpenLayers map size.
+     *
+     * Necessary because the map does not automatically
+     * notice when its size is changed externally.
+     */
+    resizeOlMap () {
+      this.$nextTick(() => {
+        // must be within '$nextTick' to take effect
+        this.map.updateSize();
+      })
+    },
+
     /**
      * Store selected layerId in the respective
      * variable of the component.

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -33,7 +33,7 @@
     v-if="layerId"
     v-resize="onResize"
     :layerId="layerId"
-    :activateTableMapInteraction="activateTableMapInteraction"
+    :syncTableMapSelection="syncTableMapSelection"
   >
   </wgu-attributetable>
   </v-card>
@@ -64,7 +64,7 @@ export default {
   mixins: [Mapable],
   created () {
     const config = this.$appConfig.modules['wgu-attributetable'];
-    this.activateTableMapInteraction = config.activateTableMapInteraction || false
+    this.syncTableMapSelection = config.syncTableMapSelection || false
   },
   components: {
     'wgu-attributetable': AttributeTable

--- a/src/util/MapInteraction.js
+++ b/src/util/MapInteraction.js
@@ -50,6 +50,28 @@ const MapInteractionUtil = {
     });
 
     return selectClick;
+  },
+
+  /**
+   * Find the selectIntercation of a layer
+   *
+   * @param {ol.Map} olMap The OL map to search in
+   * @param {String} layerId The layer id, typically 'lid' the property
+   * @returns {ol.interaction.Select} The respective selectInteraction
+   */
+  getSelectInteraction (olMap, layerId) {
+    if (!olMap || !olMap.getInteractions()) {
+      return;
+    }
+    const interactions = olMap.getInteractions().getArray();
+    if (!interactions) {
+      return;
+    }
+
+    return interactions.find(interaction => {
+      return interaction instanceof SelectInteraction &&
+            interaction.get('lid') === layerId;
+    });
   }
 };
 

--- a/test/unit/specs/components/attributeTable/AttributeTable.spec.js
+++ b/test/unit/specs/components/attributeTable/AttributeTable.spec.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import {shallowMount} from '@vue/test-utils';
 
 const appConfig = {modules: { 'wgu-attributetable-win': {
-  activateTableMapInteraction: true
+  syncTableMapSelection: true
 } }};
 
 describe('attributeTable/AttributeTable.vue', () => {
@@ -68,7 +68,7 @@ describe('attributeTable/AttributeTable.vue', () => {
 
       expect(comp.vm.rowsPerPage).to.be.a('number');
       expect(comp.vm.tableHeight).to.be.a('number');
-      expect(comp.vm.activateTableMapInteraction).to.be.a('boolean');
+      expect(comp.vm.syncTableMapSelection).to.be.a('boolean');
       expect(comp.vm.maxZoomOnFeature).to.be.a('number');
       expect(comp.vm.forbiddenColumnNames).to.be.an.instanceof(Array);
     });

--- a/test/unit/specs/components/attributeTable/AttributeTable.spec.js
+++ b/test/unit/specs/components/attributeTable/AttributeTable.spec.js
@@ -1,9 +1,12 @@
 import Vue from 'vue';
+import Vuetify from 'vuetify'
 import AttributeTable from '@/components/attributeTable/AttributeTable';
 import { expect } from 'chai';
-import { shallowMount, mount } from '@vue/test-utils';
+import {shallowMount} from '@vue/test-utils';
 
-const appConfig = {modules: { 'wgu-attributetable': {} }};
+const appConfig = {modules: { 'wgu-attributetable-win': {
+  activateTableMapInteraction: true
+} }};
 
 describe('attributeTable/AttributeTable.vue', () => {
   it('is defined', () => {
@@ -25,23 +28,48 @@ describe('attributeTable/AttributeTable.vue', () => {
     expect(defaultData.records).to.be.an('array');
     expect(defaultData.records.length).to.eql(0);
 
-    expect(defaultData.records).to.eql([]);
-    expect(defaultData.headers).to.eql([]);
+    expect(defaultData.features).to.be.an('array');
+    expect(defaultData.features.length).to.eql(0);
+
+    expect(defaultData.selectedRow).to.be.an('array');
+    expect(defaultData.selectedRow.length).to.eql(0);
+
+    expect(defaultData.layer).to.be.null;
+
+    expect(defaultData.loading).to.eql(true);
 
     expect(defaultData.page).to.eql(1);
-    expect(defaultData.loading).to.eql(true);
   });
 
   describe('props', () => {
     let comp;
+    let vuetify;
+
     beforeEach(() => {
       Vue.prototype.$appConfig = appConfig;
-      comp = mount(AttributeTable);
+      vuetify = new Vuetify()
+
+      comp = shallowMount(AttributeTable, {
+        mocks: {
+          $vuetify: {
+            breakpoint: {
+              t: (val) => val
+            }
+          }
+        },
+        vuetify
+      });
     });
 
     it('has correct default props', () => {
       expect(comp.vm.layerId).to.be.null;
       expect(comp.vm.loadingText).to.not.be.null;
+      expect(comp.vm.uniqueRecordKeyName).to.not.be.null;
+
+      expect(comp.vm.rowsPerPage).to.be.a('number');
+      expect(comp.vm.tableHeight).to.be.a('number');
+      expect(comp.vm.activateTableMapInteraction).to.be.a('boolean');
+      expect(comp.vm.maxZoomOnFeature).to.be.a('number');
       expect(comp.vm.forbiddenColumnNames).to.be.an.instanceof(Array);
     });
 
@@ -54,14 +82,31 @@ describe('attributeTable/AttributeTable.vue', () => {
   describe('methods', () => {
     let comp;
     let vm;
+    let vuetify;
     beforeEach(() => {
-      comp = shallowMount(AttributeTable);
+      vuetify = new Vuetify()
+
+      comp = shallowMount(AttributeTable, {
+        mocks: {
+          $vuetify: {
+            breakpoint: {
+              t: (val) => val
+            }
+          }
+        },
+        vuetify
+      });
       vm = comp.vm;
     });
 
     it('are implemented', () => {
+      expect(vm.highlightInitialFeatureSelectionInTable).to.be.a('function');
+      expect(vm.getTableHeight).to.be.a('function');
+      expect(vm.activateSelectRowOnMapClick).to.be.a('function');
+      expect(vm.highlightRowFromSelectedFeature).to.be.a('function');
+      expect(vm.onRowClick).to.be.a('function');
       expect(vm.populateTable).to.be.a('function');
-      expect(vm.applyRecordsFromOlLayer).to.be.a('function');
+      expect(vm.prepareTableDataAndColumns).to.be.a('function');
       expect(vm.applyColumnMapping).to.be.a('function');
     });
   });

--- a/test/unit/specs/components/attributeTable/AttributeTableWin.spec.js
+++ b/test/unit/specs/components/attributeTable/AttributeTableWin.spec.js
@@ -1,9 +1,9 @@
 import Vue from 'vue';
 import AttributeTableWin from '@/components/attributeTable/AttributeTableWin'
 import { expect } from 'chai';
-import { mount, shallowMount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 
-const appConfig = {modules: { 'wgu-attributetable-win': {} }};
+const appConfig = {modules: { 'wgu-attributetable': {} }};
 
 describe('attributeTable/AttributeTableWin.vue', () => {
   it('is defined', () => {
@@ -14,7 +14,7 @@ describe('attributeTable/AttributeTableWin.vue', () => {
     let comp;
     beforeEach(() => {
       Vue.prototype.$appConfig = appConfig;
-      comp = mount(AttributeTableWin);
+      comp = shallowMount(AttributeTableWin);
     });
 
     it('has correct default props', () => {
@@ -47,11 +47,14 @@ describe('attributeTable/AttributeTableWin.vue', () => {
     let comp;
     let vm;
     beforeEach(() => {
+      Vue.prototype.$appConfig = appConfig;
       comp = shallowMount(AttributeTableWin);
       vm = comp.vm;
     });
 
     it('are implemented', () => {
+      expect(vm.onResize).to.be.a('function');
+      expect(vm.resizeOlMap).to.be.a('function');
       expect(vm.handleLayerSelect).to.be.a('function');
       expect(vm.onMapBound).to.be.a('function');
       expect(vm.populateLayerItems).to.be.a('function');


### PR DESCRIPTION
This PR creates an interaction between the AttributeTable and its corresponding  layer:

- a click on a row zooms to the feature in the map
- a click on a row selects a feature in the map, if this layer is `selectable`
- selecting a feature on the map shows the corresponding row in the table, if it is currently opened
- the interaction between the layer and the map can be configured with `activateTableMapInteraction`
- ~~the AttributeTable-Map interaction is only enabled on desktop views, because it is not applicable on mobile views~~ it works for mobile as well
- the loading process of the features is refactored

## TODO

- [x] Re-Use `MapInteraction.js` util. If possible move code there. see https://github.com/meggsimum/wegue/pull/201
- [x] Tests are missing. 
    - There is the need to mock `$vuetify` (see [here](https://vuetifyjs.com/en/getting-started/unit-testing/#mocking-vuetify) or [GithHub Issue](https://github.com/vuetifyjs/vuetify/issues/11278))
    - The property `activateTableMapInteraction` is somehow not recognized yet

referencing issue https://github.com/meggsimum/wegue/issues/192

![Peek 2021-03-26 18-16](https://user-images.githubusercontent.com/15704517/112669029-7faccb00-8e5f-11eb-8220-89a9fce7174f.gif)