### PR TITLE
Add text-based style for points

### DIFF
--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -61,7 +61,7 @@
         }
       },
       "columnMapping": {
-        "name": "Name", 
+        "name": "Name",
         "email": "Email",
         "website": "Website"
       }
@@ -81,10 +81,9 @@
       "visible": false,
       "selectable": true,
       "style": {
-        "radius": 6,
-        "strokeColor": "blue",
-        "strokeWidth": 2,
-        "fillColor": "rgba(155,153,51,0.5)"
+        "textIcon": "local_gas_station",
+        "font": "normal 30px Material Icons",
+        "fillColor": "blue"
       },
       "attributions": "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors.",
       "columnMapping": {

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -89,7 +89,7 @@ The following properties can be applied to all map layer types
 ## Style for Vectorlayers
 
 Mandatory properties:
-- Points require **`radius`** and/or **`iconUrl`**.
+- Points require **`radius`** and/or **`iconUrl`** and/or **`textIcon`**.
 - Polygons require **`fillColor`**.
 - Lines require **`strokeColor`** or **`strokeWidth`**.
 
@@ -105,6 +105,8 @@ Mandatory properties:
 | iconAnchor         | Point only, see [anchor](https://openlayers.org/en/latest/apidoc/module-ol_style_Icon-Icon.html) | `"anchor": [0.5, 37]` |
 | iconAnchorXUnits   | Point only, see [anchorXUnits](https://openlayers.org/en/latest/apidoc/module-ol_style_Icon-Icon.html) | `"anchorXUnits": "fraction"` |
 | iconAnchorYUnits   | Point only, see [anchorYUnits](https://openlayers.org/en/latest/apidoc/module-ol_style_Icon-Icon.html) | `"anchorYUnits": "pixels"` |
+| textIcon           | Point only, see [text](https://openlayers.org/en/latest/apidoc/module-ol_style_Text-Text.html). Icons for font `normal 30px Material Icons` can be found [here](https://fonts.google.com/icons?selected=Material+Icons) | `"textIcon": "local_gas_station"` |
+| font               | Point only, see [font](https://openlayers.org/en/latest/apidoc/module-ol_style_Text-Text.html) | `"font": "normal 30px Material Icons"` |
 
 #### Label
 

--- a/src/factory/OlStyle.js
+++ b/src/factory/OlStyle.js
@@ -22,7 +22,7 @@ export const OlStyleFactory = {
     let style;
     if (!styleConf) {
       return;
-    } else if (styleConf.radius || styleConf.iconUrl) {
+    } else if (styleConf.radius || styleConf.iconUrl || styleConf.textIcon) {
       style = OlStyleFactory.createPointStyle(styleConf);
     } else if (styleConf.fillColor) {
       style = OlStyleFactory.createPolygonStyle(styleConf);
@@ -57,12 +57,20 @@ export const OlStyleFactory = {
           anchorYUnits: styleConf.iconAnchorYUnits
         }))
       })
-    } else {
+    } else if (styleConf.radius) {
       pointStyle = new Style({
         image: new CircleStyle({
           radius: styleConf.radius,
           fill: OlStyleFactory.createFill(styleConf),
           stroke: OlStyleFactory.createStroke(styleConf)
+        })
+      });
+    } else {
+      pointStyle = new Style({
+        text: new Text({
+          text: styleConf.textIcon,
+          font: styleConf.font || 'normal 30px Material Icons',
+          fill: OlStyleFactory.createFill(styleConf)
         })
       });
     }


### PR DESCRIPTION
Add text-based style for points. The font currently defaults to `normal 30px Material Icons`, but can be changed. 

Know limitation: A text-based icon cannot use the built-in (Wegue) `label` funcitonality, because the label-text overwrites the text-based style icon.

The style property in the `appConfig` looks like:

```json
{       
   "textIcon": "local_gas_station",
   "font": "normal 30px Material Icons",
   "fillColor": "blue"
}
```

![image](https://user-images.githubusercontent.com/15704517/114363466-b7628500-9b78-11eb-92bd-6449557b33f8.png)
