### PR TITLE
Refactor SelectInteraction

### DIFF
--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -64,7 +64,14 @@
         "name": "Name",
         "email": "Email",
         "website": "Website"
-      }
+      },
+      "selectStyle": {
+        "radius": 10,
+        "strokeColor": "gray",
+        "strokeWidth": 5,
+        "fillColor": "rgb(255, 255, 0, 0.2)"
+      },
+      "doAppendSelectStyle": true
     },
     {
       "type": "WFS",
@@ -88,7 +95,13 @@
       "attributions": "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors.",
       "columnMapping": {
         "name": "Name"
-      }
+      },
+      "selectStyle": {
+        "textIcon": "star",
+        "font": "normal 30px Material Icons",
+        "fillColor": "black"
+      },
+      "doAppendSelectStyle": false
     },
 
     {

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -25,34 +25,36 @@ The following properties can be applied to all map layer types
 
 ## VECTOR
 
-| Property           | Meaning | Example |
-|--------------------|:---------:|---------|
-| **type**           | Indicator that the layer is a vector layer, always `VECTOR` here  | `"type": "VECTOR"` |
-| **url**            | The URL to the vector data resource (file) | `"url": "./static/data/2012_Earthquakes_Mag5.kml"` |
-| **format**         | The format of the data linked in `url` (either `KML` or `GeoJSON` ) | `"format": "KML"` |
-| selectable         | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
-| hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
-| hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
-| style              | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
-| selectStyle        | The additional style for a selected feature | see [style](map-layer-configuration?id=style-for-vectorlayers) |
-| columnMapping      | Maps the property names to human-readable text. Can be used by `AttributeTable`. | `"columnMapping": {"name": "Name", "email": "Email"}`
+| Property            | Meaning | Example |
+|---------------------|:---------:|---------|
+| **type**            | Indicator that the layer is a vector layer, always `VECTOR` here  | `"type": "VECTOR"` |
+| **url**             | The URL to the vector data resource (file) | `"url": "./static/data/2012_Earthquakes_Mag5.kml"` |
+| **format**          | The format of the data linked in `url` (either `KML` or `GeoJSON` ) | `"format": "KML"` |
+| selectable          | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
+| hoverable           | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
+| hoverAttribute      | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
+| style               | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| selectStyle         | The style for a selected feature | see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| doAppendSelectStyle | If the selectStyle should be appended to the original style, defaults to `false` | `"doAppendSelectStyle": true` |
+| columnMapping       | Maps the property names to human-readable text. Can be used by `AttributeTable`. | `"columnMapping": {"name": "Name", "email": "Email"}`
 
 ## WFS
 
-| Property           |  Meaning  | Example |
-|--------------------|:---------:|---------|
-| **type**           | Indicator that the layer is a WFS-based vector layer, always `WFS` here  | `"type": "WFS"` |
-| **url**            | The URL to the Web Feature Service (WFS) | `"url": "https://ows.terrestris.de/geoserver/osm/wfs"` |
-| **typeName**       | The name of the FeatureType | `"typeName": "osm:osm-fuel"`|
-| style              | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
-| version            | The version of the WFS, defaults to `1.1.0` | `"version": "2.0.0"`|
-| maxFeatures        | Limits the amount of features that are queried and displayed | `"maxFeatures": 50`|
-| format             | The format that should be used. Possible values are `GeoJSON`, `GML2`, `GML3` and `GML32`. Defaults to `GML3` |  `"format": "GeoJSON"`|
-| selectable         | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
-| selectStyle        | The additional style for a selected feature| see [style](map-layer-configuration?id=style-for-vectorlayers) |
-| columnMapping      | Maps the property names to human-readable text. Can be used by `AttributeTable`. | `"columnMapping": {"name": "Name", "email": "Email"}`
-| hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
-| hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
+| Property            |  Meaning  | Example |
+|---------------------|:---------:|---------|
+| **type**            | Indicator that the layer is a WFS-based vector layer, always `WFS` here  | `"type": "WFS"` |
+| **url**             | The URL to the Web Feature Service (WFS) | `"url": "https://ows.terrestris.de/geoserver/osm/wfs"` |
+| **typeName**        | The name of the FeatureType | `"typeName": "osm:osm-fuel"`|
+| style               | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| version             | The version of the WFS, defaults to `1.1.0` | `"version": "2.0.0"`|
+| maxFeatures         | Limits the amount of features that are queried and displayed | `"maxFeatures": 50`|
+| format              | The format that should be used. Possible values are `GeoJSON`, `GML2`, `GML3` and `GML32`. Defaults to `GML3` |  `"format": "GeoJSON"`|
+| selectable          | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
+| selectStyle         | The style for a selected feature | see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| doAppendSelectStyle | If the selectStyle should be appended to the original style, defaults to `false` | `"doAppendSelectStyle": true` |
+| columnMapping       | Maps the property names to human-readable text. Can be used by `AttributeTable`. | `"columnMapping": {"name": "Name", "email": "Email"}`
+| hoverable           | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
+| hoverAttribute      | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
 
 
 ## VECTORTILE

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -34,7 +34,7 @@ The following properties can be applied to all map layer types
 | hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
 | hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |
 | style              | Object to define a rendering style for the features of the layer  | see [style](map-layer-configuration?id=style-for-vectorlayers) |
-| selectStyle        | The style for a selected feature | see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| selectStyle        | The additional style for a selected feature | see [style](map-layer-configuration?id=style-for-vectorlayers) |
 | columnMapping      | Maps the property names to human-readable text. Can be used by `AttributeTable`. | `"columnMapping": {"name": "Name", "email": "Email"}`
 
 ## WFS
@@ -49,7 +49,7 @@ The following properties can be applied to all map layer types
 | maxFeatures        | Limits the amount of features that are queried and displayed | `"maxFeatures": 50`|
 | format             | The format that should be used. Possible values are `GeoJSON`, `GML2`, `GML3` and `GML32`. Defaults to `GML3` |  `"format": "GeoJSON"`|
 | selectable         | Boolean value, whether the features of the layer can be selected by click in order to display the attributes in a window | `"selectable": true` |
-| selectStyle        | The style for a selected feature| see [style](map-layer-configuration?id=style-for-vectorlayers) |
+| selectStyle        | The additional style for a selected feature| see [style](map-layer-configuration?id=style-for-vectorlayers) |
 | columnMapping      | Maps the property names to human-readable text. Can be used by `AttributeTable`. | `"columnMapping": {"name": "Name", "email": "Email"}`
 | hoverable          | Boolean value, whether the features of the layer can be hovered in order to display an attribute (see `hoverAttribute`) in a tooltip  | `"hoverable": true` |
 | hoverAttribute     | Attribute to be shown if a feature of the layer is hovered. Only has an effect if `hoverable` is set to `true`  | `"hoverAttribute": "name"` |

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -7,7 +7,6 @@ import Map from 'ol/Map'
 import View from 'ol/View'
 import Attribution from 'ol/control/Attribution';
 import Zoom from 'ol/control/Zoom';
-import SelectInteraction from 'ol/interaction/Select';
 import {
   DragAndDrop,
   defaults as defaultInteractions
@@ -28,7 +27,7 @@ import { LayerFactory } from '../../factory/Layer.js';
 import ColorUtil from '../../util/Color';
 import LayerUtil from '../../util/Layer';
 import PermalinkController from './PermalinkController';
-import { OlStyleFactory } from '../../factory/OlStyle.js';
+import MapInteractionUtil from '../../util/MapInteraction';
 
 export default {
   name: 'wgu-map',
@@ -174,28 +173,7 @@ export default {
 
         // if layer is selectable register a select interaction
         if (lConf.selectable) {
-          // check if a style is provided in the appConfig
-          let selectStyle;
-          if (lConf.selectStyle) {
-            // layer specific select style
-            selectStyle = OlStyleFactory.getInstance(lConf.selectStyle);
-          }
-
-          const selectClick = new SelectInteraction({
-            layers: [layer],
-            style: selectStyle
-          });
-
-          // forward an event if feature selection changes
-          selectClick.on('select', function (evt) {
-            // TODO use identifier for layer (once its implemented)
-            WguEventBus.$emit(
-              'map-selectionchange',
-              layer.get('lid'),
-              evt.selected,
-              evt.deselected
-            );
-          });
+          let selectClick = MapInteractionUtil.createSelectInteraction(layer, lConf.selectStyle)
           // register/activate interaction on map
           me.map.addInteraction(selectClick);
         }

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -173,7 +173,11 @@ export default {
 
         // if layer is selectable register a select interaction
         if (lConf.selectable) {
-          let selectClick = MapInteractionUtil.createSelectInteraction(layer, lConf.selectStyle)
+          let selectClick = MapInteractionUtil.createSelectInteraction(
+            layer,
+            lConf.selectStyle,
+            lConf.doAppendSelectStyle
+          )
           // register/activate interaction on map
           me.map.addInteraction(selectClick);
         }

--- a/src/util/MapInteraction.js
+++ b/src/util/MapInteraction.js
@@ -10,22 +10,25 @@ const MapInteractionUtil = {
    *
    * @param {ol.layer.Layer} layer The layer to create the interaction for
    * @param {Object} [selectStyleConf] The configuration for the selection style
+   * @param {Boolean} [doAppendSelectStyle] If the selection style should be appended to the original style.
    *
    * @returns {ol.interaction.Select} The select interaction
    */
-  createSelectInteraction (layer, selectStyleConf) {
+  createSelectInteraction (layer, selectStyleConf, doAppendSelectStyle) {
     let selectClick;
     let selectStyle;
     if (selectStyleConf) {
       // layer specific select style
       selectStyle = OlStyleFactory.getInstance(selectStyleConf);
 
-      // append selectStyle to original style of layer
-      const combinedStyle = StyleUtil.appendStyle(layer.getStyle(), selectStyle);
+      if (doAppendSelectStyle) {
+        // append selectStyle to original style of layer
+        selectStyle = StyleUtil.appendStyle(layer.getStyle(), selectStyle);
+      }
 
       selectClick = new SelectInteraction({
         layers: [layer],
-        style: combinedStyle
+        style: selectStyle
       });
     } else {
       selectClick = new SelectInteraction({

--- a/src/util/MapInteraction.js
+++ b/src/util/MapInteraction.js
@@ -1,0 +1,72 @@
+import SelectInteraction from 'ol/interaction/Select';
+import { WguEventBus } from '../WguEventBus.js';
+import { OlStyleFactory } from '../factory/OlStyle.js'
+
+const MapInteractionUtil = {
+
+  /**
+   * Create a selectInteraction for a layer
+   *
+   * @param {ol.layer.Layer} layer The layer to create the interaction for
+   * @param {Object} [selectStyleConf] The configuration for the selection style
+   *
+   * @returns {ol.interaction.Select} The select interaction
+   */
+  createSelectInteraction (layer, selectStyleConf) {
+    let selectClick;
+    let selectStyle;
+    if (selectStyleConf) {
+      // layer specific select style
+      selectStyle = OlStyleFactory.getInstance(selectStyleConf);
+
+      selectClick = new SelectInteraction({
+        layers: [layer],
+        style: function (feature, resolution) {
+          // we return an array of the selection style and the features style
+          if (typeof layer.getStyle() === 'function') {
+            const layerStyleFunction = layer.getStyle();
+
+            // check what kind of result we can expect
+            let layerStyle = layerStyleFunction(feature, resolution);
+
+            if (Array.isArray(layerStyle)) {
+              // case result is an style array
+              const resultArray = [selectStyle];
+
+              // add the array elements to the result Array
+              layerStyle.forEach(item => resultArray.push(item));
+
+              return resultArray;
+            } else {
+              // classic case that result is a simple style
+              return [selectStyle, layerStyleFunction(feature, resolution)]
+            }
+          } else {
+            return [selectStyle, layer.getStyle()]
+          }
+        }
+      });
+    } else {
+      selectClick = new SelectInteraction({
+        layers: [layer]
+      })
+    }
+
+    // necessary for identifying referenced layer
+    selectClick.set('lid', layer.get('lid'));
+
+    // forward an event if feature selection changes
+    selectClick.on('select', function (evt) {
+      WguEventBus.$emit(
+        'map-selectionchange',
+        layer.get('lid'),
+        evt.selected,
+        evt.deselected
+      );
+    });
+
+    return selectClick;
+  }
+};
+
+export default MapInteractionUtil;

--- a/src/util/MapInteraction.js
+++ b/src/util/MapInteraction.js
@@ -1,6 +1,7 @@
 import SelectInteraction from 'ol/interaction/Select';
 import { WguEventBus } from '../WguEventBus.js';
 import { OlStyleFactory } from '../factory/OlStyle.js'
+import StyleUtil from './Style.js';
 
 const MapInteractionUtil = {
 
@@ -19,32 +20,12 @@ const MapInteractionUtil = {
       // layer specific select style
       selectStyle = OlStyleFactory.getInstance(selectStyleConf);
 
+      // append selectStyle to original style of layer
+      const combinedStyle = StyleUtil.appendStyle(layer.getStyle(), selectStyle);
+
       selectClick = new SelectInteraction({
         layers: [layer],
-        style: function (feature, resolution) {
-          // we return an array of the selection style and the features style
-          if (typeof layer.getStyle() === 'function') {
-            const layerStyleFunction = layer.getStyle();
-
-            // check what kind of result we can expect
-            let layerStyle = layerStyleFunction(feature, resolution);
-
-            if (Array.isArray(layerStyle)) {
-              // case result is an style array
-              const resultArray = [selectStyle];
-
-              // add the array elements to the result Array
-              layerStyle.forEach(item => resultArray.push(item));
-
-              return resultArray;
-            } else {
-              // classic case that result is a simple style
-              return [selectStyle, layerStyleFunction(feature, resolution)]
-            }
-          } else {
-            return [selectStyle, layer.getStyle()]
-          }
-        }
+        style: combinedStyle
       });
     } else {
       selectClick = new SelectInteraction({

--- a/src/util/Style.js
+++ b/src/util/Style.js
@@ -1,0 +1,37 @@
+const StyleUtil = {
+
+  /**
+   * Appends a style to another style.
+   *
+   * @param {ol.style.Style} originalStyle A style, an array of styles or a style function.
+   * @param {ol.style.Style} additionalStyle A single style.
+   *
+   * @returns {ol.style.Style}
+   */
+  appendStyle (originalStyle, additionalStyle) {
+    return function (feature, resolution) {
+      if (typeof originalStyle === 'function') {
+        const layerStyleFunction = originalStyle;
+
+        // check what kind of result we can expect
+        let layerStyle = layerStyleFunction(feature, resolution);
+
+        if (Array.isArray(layerStyle)) {
+          // case result is an style array
+          const resultArray = [additionalStyle];
+
+          // add the array elements to the result Array
+          layerStyle.forEach(item => resultArray.push(item));
+          return resultArray;
+        } else {
+          // classic case that result is a simple style
+          return [additionalStyle, layerStyleFunction(feature, resolution)]
+        }
+      } else {
+        return [additionalStyle, originalStyle]
+      }
+    };
+  }
+};
+
+export default StyleUtil;


### PR DESCRIPTION
- Move the creation of the selectInteraction to an util class. 
- Extent style append function and move it a separate util 
- this makes it possible to combine the select style with the current style

- [x] TODO: selection-style - it should both be possible to replace the original style and to combine the styles

![Peek 2021-04-22 11-33](https://user-images.githubusercontent.com/15704517/115691783-a70f8e80-a35e-11eb-9960-3b4dfd67188b.gif)
