### PR TITLE
Fix for passing a null value into XYZSource tile grid, which overrides the OpenLayers default configuration and causes map offsets.

### DIFF
--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -167,7 +167,9 @@ export default {
       const mapLayersConfig = appConfig.mapLayers || [];
       mapLayersConfig.reverse().forEach(function (lConf) {
         // Some Layers may require a TileGrid object
-        lConf.tileGrid = lConf.tileGridRef ? me.tileGrids[lConf.tileGridRef] : null;
+        // Remarks: Passing null instead of undefined as parameters into the
+        //  constructor of OpenLayers sources overwrites OpenLayers defaults.
+        lConf.tileGrid = lConf.tileGridRef ? me.tileGrids[lConf.tileGridRef] : undefined;
 
         let layer = LayerFactory.getInstance(lConf, me.map);
         layers.push(layer);


### PR DESCRIPTION
Map offset bug can be reproduced with the following layer and projection in app-conf.json .


  "mapProjection":
  {
    "code": "EPSG:3857",
    "units": "m",
    "extent": [-20026376.39, -20048966.10, 20026376.39, 20048966.10]
  },
"mapLayers": [
   {
      "type": "XYZ",
      "name": "Esri Satellitenkarte",
      "lid": "esri-sat",
      "url": "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
      "attributions": "Karte: Tiles © <a href='https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer'>ArcGIS</a>",
      "isBaseLayer": false,
      "visible": false,
      "displayInLayerList": true
    }
]