### PR TITLE
Application sidebar

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -20,6 +20,7 @@
             :is="moduleWin.type" :key="index" :ref="moduleWin.type"
             :win="moduleWin.win" :color="baseColor"
             :backgroundImage="moduleWin.backgroundImage"
+            :minimizable="moduleWin.minimizable"
           />
       </template>
     </wgu-app-sidebar>      
@@ -45,6 +46,7 @@
         :draggable="moduleWin.draggable"
         :initPos="moduleWin.initPos"
         :backgroundImage="moduleWin.backgroundImage"
+        :minimizable="moduleWin.minimizable"
       />
     </template>
 
@@ -147,7 +149,8 @@
               win: moduleOpts.win,
               draggable: moduleOpts.draggable,
               initPos: moduleOpts.initPos,
-              backgroundImage: moduleOpts.backgroundImage
+              backgroundImage: moduleOpts.backgroundImage,
+              minimizable: moduleOpts.minimizable
             });
           }
         }

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -19,6 +19,7 @@
           <component
             :is="moduleWin.type" :key="index" :ref="moduleWin.type"
             :win="moduleWin.win" :color="baseColor"
+            :backgroundImage="moduleWin.backgroundImage"
           />
       </template>
     </wgu-app-sidebar>      
@@ -43,6 +44,7 @@
         :win="moduleWin.win" :color="baseColor"
         :draggable="moduleWin.draggable"
         :initPos="moduleWin.initPos"
+        :backgroundImage="moduleWin.backgroundImage"
       />
     </template>
 
@@ -144,7 +146,8 @@
               type: key + '-win',
               win: moduleOpts.win,
               draggable: moduleOpts.draggable,
-              initPos: moduleOpts.initPos
+              initPos: moduleOpts.initPos,
+              backgroundImage: moduleOpts.backgroundImage
             });
           }
         }

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -4,6 +4,7 @@
     :color="color"
     fixed
     app
+    clipped-left
     clipped-right
   >
 

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-navigation-drawer
+      class="wgu-app-sidebar"
+      app
+      clipped
+      width="400"
+      v-model="sidebarOpen"
+      >
+      <!-- Forward the default slot for sidebar content. -->
+      <slot></slot>
+      <!-- Sidebar toggle button -->
+      <template v-slot:prepend>
+        <v-btn 
+          class="wgu-app-sidebar-toggle-btn px0"
+          absolute
+          top
+          color="white"
+          width="20" min-width="20" 
+          @click="sidebarOpen = !sidebarOpen"> 
+          <v-icon v-if="sidebarOpen">chevron_left</v-icon> 
+          <v-icon v-else>chevron_right</v-icon> 
+        </v-btn>
+      </template>
+  </v-navigation-drawer>
+</template>
+
+<script>
+
+export default {
+  name: 'wgu-app-sidebar',
+  data () {
+    return {
+      sidebarOpen: true
+    }
+  }
+}
+</script>

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -34,7 +34,7 @@
   "modules": {
     "wgu-helpwin": {
       "target": "toolbar",
-      "win": true,
+      "win": "floating",
       "icon": "help",
       "darkLayout": true, 
       "windowTitle": "About",

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -122,14 +122,14 @@
   "modules": {
     "wgu-layerlist": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "icon": "layers",
       "darkLayout": true,
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "icon": "photo_size_select_small",
       "darkLayout": true,
       "draggable": false,
@@ -142,7 +142,7 @@
     },
     "wgu-infoclick": {
       "target": "menu",
-      "win": true,
+      "win":"floating",
       "icon": "info",
       "darkLayout": true,
       "draggable": false,
@@ -173,7 +173,7 @@
     },
     "wgu-helpwin": {
       "target": "toolbar",
-      "win": true,
+      "win": "floating",
       "icon": "help",
       "darkLayout": true,
       "windowTitle": "About",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -185,14 +185,14 @@
   "modules": {
     "wgu-layerlist": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "icon": "layers",
       "darkLayout": true,
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "icon": "photo_size_select_small",
       "darkLayout": true,
       "draggable": false,
@@ -205,7 +205,7 @@
     },
     "wgu-infoclick": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "icon": "info",
       "darkLayout": true,
       "draggable": false,
@@ -235,7 +235,7 @@
     },
     "wgu-helpwin": {
       "target": "toolbar",
-      "win": true,
+      "win": "floating",
       "icon": "help",
       "darkLayout": true,
       "windowTitle": "About",
@@ -250,7 +250,7 @@
     },
     "wgu-attributetable": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "icon": "table_chart",
       "darkLayout": true,
       "syncTableMapSelection": true

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -9,7 +9,7 @@ The `modules` object contains sub-objects, whereas the key is the identifier for
 ```json
   "wgu-layerlist": {
     "target": "menu",
-    "win": true,
+    "win": "floating",
     "draggable": false
   }
 ```
@@ -18,11 +18,25 @@ The following properties can be applied to all map module types:
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| **target**         | Where should the button to enable/disable the module be rendered. Valid options are `menu` or `toolbar` | `"target": "menu"`. |
-| **win**            | Boolean value to mark if the module has a window as sub component to show addition module UI elements. | `"win": true"` |
-| draggable          | Boolean value to enable a window module be draggable over the viewport. Only applies if `win` is set to `true`. **CAUTION: This feature is experimental and not recommended for production usage.** | `"draggable": false` |
-| initPos            | The initial position for the module window in absolute viewport coordinates. Only applies if `win` is set to `true`. | `"initPos": {"left": 8, "top": 74}` |
+| **target**         | Where should the button to enable/disable the module be rendered. Valid options are `menu` or `toolbar` | `"target": "menu"` |
+| **win**            | Value to mark if the module has a window as sub component and where to show the module UI elements. Valid options are `floating` and `sidebar`. If the value is omitted, then the module is not associated with a window.  | `"win": "floating"` |
+| minimizable        | Indicates whether the module window can be minimized. Only applies if a module window is present as indicated by the `win` parameter. | `"minimizable": true` |
+| backgroundImage    | Optional background image for the window header. Only applies if a module window is present as indicated by the `win` parameter. | `"backgroundImage": "static/icon/myImage.png"}` |
 | darkLayout         | Boolean value to ensure that your module element (mostly a button) is rendered bright since your basic theme color is dark.  | `"darkLayout": true` |
+
+The following positioning and sizing properties can be assigned to all module types, which are associated with a floating window - This is when the `win` parameter is set to `floating`:
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| draggable          | Boolean value to enable a window module be draggable over the viewport. **CAUTION: This feature is experimental and not recommended for production usage.** | `"draggable": false` |
+| initPos            | The initial position for the module window in absolute viewport coordinates. | `"initPos": {"left": 8, "top": 74}` |
+| height            | The height of the module window in viewport coordinates. | `"height": 500` |
+| width            | The width of the module window in viewport coordinates. | `"width": 500` |
+| maxHeight            | The maximum height of the module window in viewport coordinates. | `"maxHeight": 500` |
+| maxWidth            | The maximum width of the module window in viewport coordinates. | `"maxWidth": 500` |
+| minHeight            | The minimum height of the module window in viewport coordinates. | `"minHeight": 500` |
+| minWidth            | The minimum width of the module window in viewport coordinates. | `"minWidth": 500` |
+
 
 ## GeoCoder
 

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -24,18 +24,12 @@ The following properties can be applied to all map module types:
 | backgroundImage    | Optional background image for the window header. Only applies if a module window is present as indicated by the `win` parameter. | `"backgroundImage": "static/icon/myImage.png"}` |
 | darkLayout         | Boolean value to ensure that your module element (mostly a button) is rendered bright since your basic theme color is dark.  | `"darkLayout": true` |
 
-The following positioning and sizing properties can be assigned to all module types, which are associated with a floating window - This is when the `win` parameter is set to `floating`:
+The following positioning can be assigned to all module types, which are associated with a floating window - This is when the `win` parameter is set to `floating`:
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
 | draggable          | Boolean value to enable a window module be draggable over the viewport. **CAUTION: This feature is experimental and not recommended for production usage.** | `"draggable": false` |
 | initPos            | The initial position for the module window in absolute viewport coordinates. | `"initPos": {"left": 8, "top": 74}` |
-| height            | The height of the module window in viewport coordinates. | `"height": 500` |
-| width            | The width of the module window in viewport coordinates. | `"width": 500` |
-| maxHeight            | The maximum height of the module window in viewport coordinates. | `"maxHeight": 500` |
-| maxWidth            | The maximum width of the module window in viewport coordinates. | `"maxWidth": 500` |
-| minHeight            | The minimum height of the module window in viewport coordinates. | `"minHeight": 500` |
-| minWidth            | The minimum width of the module window in viewport coordinates. | `"minWidth": 500` |
 
 
 ## GeoCoder

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -234,12 +234,12 @@ Example configurations can be found in the `app-starter/static` directory. Below
   "modules": {
     "wgu-layerlist": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "draggable": false,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
@@ -250,7 +250,7 @@ Example configurations can be found in the `app-starter/static` directory. Below
     },
     "wgu-infoclick": {
       "target": "menu",
-      "win": true,
+      "win": "floating",
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -278,7 +278,7 @@ Example configurations can be found in the `app-starter/static` directory. Below
     },
     "wgu-helpwin": {
       "target": "toolbar",
-      "win": true,
+      "win": "floating",
       "darkLayout": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9395,6 +9395,12 @@
         "find-up": "^2.1.0"
       }
     },
+    "portal-vue": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "optimize-css-assets-webpack-plugin": "^2.0.0",
     "ora": "^3.4.0",
     "phantomjs-prebuilt": "^2.1.16",
+    "portal-vue": "^2.1.7",
     "rimraf": "^2.7.1",
     "semver": "^6.3.0",
     "shelljs": "^0.8.4",

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -28,14 +28,14 @@ html {
 /* TODO 
   Generalize the positioning concept for windows,
   this interferes with positioning and draggable settings in the app.conf */
-.wgu-measurewin {
+.wgu-measurewin.wgu-floating {
   left: auto !important;
   top: auto !important;
   right: 10px;
   bottom: 4.8em;
 }
 
-.wgu-layerlist {
+.wgu-layerlist.wgu-floating {
   left: auto !important;
   top: 75px !important;
   right: 10px;

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -21,8 +21,8 @@ html {
 }
 
 .wgu-app-logo {
-  left: 8px;
-  bottom: 50px;
+  left: 15px;
+  bottom: 45px;
 }
 
 /* TODO 

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -64,3 +64,12 @@ html {
    -ms-user-select: none;
    user-select: none;
 }
+
+.wgu-app-sidebar {
+  overflow: visible
+}
+
+.wgu-app-sidebar-toggle-btn {
+  left: 100%; 
+  visibility: visible
+}

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -127,14 +127,14 @@ export default {
     Generalize the positioning concept for windows,
     this interferes with positioning and draggable settings in the app.conf */
 
-  .wgu-attributetable-win {
+  .wgu-attributetable-win.wgu-floating {
     top: inherit !important;
     position: relative;
     bottom: 35px;
   }
 
   @media only screen and (max-width: 600px) {
-    .wgu-attributetable-win {
+    .wgu-attributetable-win.wgu-floating {
       bottom: 33px;
       height: 100%;
     }

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -55,7 +55,7 @@
   /* TODO 
     Generalize the positioning concept for windows,
     this interferes with positioning and draggable settings in the app.conf */
-  .v-card.wgu-helpwin {
+  .wgu-helpwin.wgu-floating {
     left: 50% !important;
     top: 50% !important;
     transform: translate(-50%, -50%);

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -134,7 +134,7 @@ export default {
       this interferes with positioning and draggable settings in the app.conf */
       
     /* tmp. approach to position on small screens */
-    .v-card.wgu-infoclick-win {
+    .wgu-infoclick-win.wgu-floating {
       /* tmp. fix */
       left: 0 !important;
       top: 40% !important;
@@ -142,7 +142,7 @@ export default {
       max-width: 600px;
     }
 
-    .wgu-infoclick-win-title {
+    .wgu-infoclick-win.wgu-floating > .wgu-infoclick-win-title {
       overflow: scroll;
       max-height: 300px;
     }

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -50,7 +50,7 @@
       moduleName: {type: String, required: true},
       icon: {type: String, required: true},
       title: {type: String, required: true},
-      win: {type: String, required: true},
+      win: {type: String, required: false, default: 'floating'},
       minimizable: {type: Boolean, required: false, default: true},
       color: {type: String, required: false, default: 'red darken-3'},
       backgroundImage: {type: String, required: false, default: undefined},

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -51,7 +51,7 @@
       icon: {type: String, required: true},
       title: {type: String, required: true},
       win: {type: String, required: false, default: 'floating'},
-      minimizable: {type: Boolean, required: false, default: true},
+      minimizable: {type: Boolean, required: false, default: false},
       color: {type: String, required: false, default: 'red darken-3'},
       backgroundImage: {type: String, required: false, default: undefined},
       // Positioning / sizing properties will be ignored for sidebar cards.

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -18,8 +18,8 @@
         <v-spacer></v-spacer>
         <v-btn v-if="minimizable" icon small 
           @click="minimized = !minimized">
-          <v-icon v-if="minimized">mdi-window-maximize</v-icon> 
-          <v-icon v-else>mdi-window-minimize</v-icon> 
+          <v-icon v-if="minimized">web_asset</v-icon> 
+          <v-icon v-else>remove</v-icon>
         </v-btn>
         <v-btn icon small class="mr-0" 
           @click="toggleUi">

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -16,14 +16,20 @@
         <slot name="wgu-win-toolbar"></slot>
 
         <v-spacer></v-spacer>
-        <v-app-bar-nav-icon @click="toggleUi">
+        <v-btn v-if="minimizable" icon small 
+          @click="minimized = !minimized">
+          <v-icon v-if="minimized">mdi-window-maximize</v-icon> 
+          <v-icon v-else>mdi-window-minimize</v-icon> 
+        </v-btn>
+        <v-btn icon small class="mr-0" 
+          @click="toggleUi">
           <v-icon>close</v-icon>
-        </v-app-bar-nav-icon>
+        </v-btn>
       </v-toolbar>
     </v-img>
     
     <!-- Default slot for module content -->
-    <slot name="default"></slot>
+    <slot v-if="!minimized" name="default"></slot>
 
   </v-card>
 </template>
@@ -43,6 +49,7 @@
       icon: {type: String, required: true},
       title: {type: String, required: true},
       win: {type: String, required: true},
+      minimizable: {type: Boolean, required: false, default: true},
       color: {type: String, required: false, default: 'red darken-3'},
       backgroundImage: {type: String, required: false, default: undefined},
       // Positioning / sizing properties will be ignored for sidebar cards.
@@ -57,7 +64,8 @@
     },
     data () {
       return {
-        show: false
+        show: false,
+        minimized: false
       }
     },
     created () {

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -29,7 +29,9 @@
     </v-img>
     
     <!-- Default slot for module content -->
-    <slot v-if="!minimized" name="default"></slot>
+    <div v-show="!minimized">
+      <slot name="default"></slot>
+    </div>
 
   </v-card>
 </template>

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -1,10 +1,11 @@
 <template>
-  <v-card class="wgu-module-card wgu-floating" 
-    v-bind="$attrs"
-    v-if=show 
-    v-draggable-win="draggable"  
-    v-bind:style="{ left: left, top: top }"> 
-
+  <v-card :class="cardClasses" 
+    :style="cardStyles"
+    v-bind="cardAttr"
+    v-if=show
+    v-draggable-win="cardDraggable"
+    > 
+    
     <v-toolbar :color="color" dark>
       <v-icon class="mr-4">{{ icon }}</v-icon>
       <v-toolbar-title class="wgu-win-title">{{ title }}</v-toolbar-title>
@@ -35,18 +36,25 @@
       DraggableWin
     },
     props: {
+      // Common properties
       moduleName: {type: String, required: true},
       icon: {type: String, required: true},
       title: {type: String, required: true},
+      win: {type: String, required: true},
       color: {type: String, required: false, default: 'red darken-3'},
+      // Positioning / sizing properties will be ignored for sidebar cards.
       draggable: {type: Boolean, required: false, default: true},
-      initPos: {type: Object, required: false}
+      initPos: {type: Object, required: false},
+      height: {type: [Number, String], required: false, default: undefined},
+      width: {type: [Number, String], required: false, default: undefined},
+      maxHeight: {type: [Number, String], required: false, default: undefined},
+      maxWidth: {type: [Number, String], required: false, default: undefined},
+      minHeight: {type: [Number, String], required: false, default: undefined},
+      minWidth: {type: [Number, String], required: false, default: undefined}
     },
     data () {
       return {
-        show: false,
-        left: this.initPos ? this.initPos.left + 'px' : '0px',
-        top: this.initPos ? this.initPos.top + 'px' : '0px'
+        show: false
       }
     },
     created () {
@@ -54,6 +62,38 @@
         this.show = visible;
         this.$emit('visibility-change', visible);
       });
+    },
+    computed: {
+      cardClasses () {
+        return (this.win === 'floating')
+          ? ['wgu-module-card', 'wgu-floating']
+          : ['wgu-module-card', 'wgu-sidebar']
+      },
+      cardStyles () {
+        return (this.win === 'floating')
+          ? {
+            left: this.initPos ? this.initPos.left + 'px' : '0px',
+            top: this.initPos ? this.initPos.top + 'px' : '0px'
+          }
+          : {}
+      },
+      cardAttr () {
+        return (this.win === 'floating')
+          ? {
+            height: this.height,
+            width: this.width,
+            maxHeight: this.maxHeight,
+            maxWidth: this.maxWidth,
+            minHeight: this.minHeight,
+            minWidth: this.minWidth
+          }
+          : {}
+      },
+      cardDraggable () {
+        return (this.win === 'floating')
+          ? this.draggable
+          : false
+      }
     },
     methods: {
       toggleUi () {

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -6,20 +6,22 @@
     v-draggable-win="cardDraggable"
     > 
     
-    <v-toolbar :color="color" dark>
-      <v-icon class="mr-4">{{ icon }}</v-icon>
-      <v-toolbar-title class="wgu-win-title">{{ title }}</v-toolbar-title>
-      <v-spacer></v-spacer>
+    <v-img :src="backgroundImage">
+      <v-toolbar v-bind="toolbarAttr">
+        <v-icon class="mr-4">{{ icon }}</v-icon>
+        <v-toolbar-title class="wgu-win-title">{{ title }}</v-toolbar-title>
+        <v-spacer></v-spacer>
 
-      <!-- Slot for optional window toolbar content -->
-      <slot name="wgu-win-toolbar"></slot>
+        <!-- Slot for optional window toolbar content -->
+        <slot name="wgu-win-toolbar"></slot>
 
-      <v-spacer></v-spacer>
-      <v-app-bar-nav-icon @click="toggleUi">
-        <v-icon>close</v-icon>
-      </v-app-bar-nav-icon>
-    </v-toolbar>
-
+        <v-spacer></v-spacer>
+        <v-app-bar-nav-icon @click="toggleUi">
+          <v-icon>close</v-icon>
+        </v-app-bar-nav-icon>
+      </v-toolbar>
+    </v-img>
+    
     <!-- Default slot for module content -->
     <slot name="default"></slot>
 
@@ -42,6 +44,7 @@
       title: {type: String, required: true},
       win: {type: String, required: true},
       color: {type: String, required: false, default: 'red darken-3'},
+      backgroundImage: {type: String, required: false, default: undefined},
       // Positioning / sizing properties will be ignored for sidebar cards.
       draggable: {type: Boolean, required: false, default: true},
       initPos: {type: Object, required: false},
@@ -93,6 +96,18 @@
         return (this.win === 'floating')
           ? this.draggable
           : false
+      },
+      toolbarAttr () {
+        return this.backgroundImage
+          ? {
+            dark: true,
+            flat: true,
+            color: 'transparent'
+          }
+          : {
+            dark: true,
+            color: this.color
+          }
       }
     },
     methods: {

--- a/src/main.js
+++ b/src/main.js
@@ -40,10 +40,27 @@ if (appCtx) {
   // simple aproach to avoid path traversal
   appCtxFile = '-' + appCtx.replace(/(\.\.[/])+/g, '');
 }
+
+/**
+ * Backwards compatibility layer for legacy features in app-conf.json.
+ */
+const migrateAppConfig = function (appConfig) {
+  // Migrate boolean values for module.win.
+  if (appConfig.modules) {
+    Object.keys(appConfig.modules).forEach(name => {
+      var module = appConfig.modules[name];
+      if (typeof module.win === 'boolean') {
+        module.win = module.win ? 'floating' : undefined;
+      }
+    });
+  }
+  return appConfig;
+}
+
 const opts = {};
 const createApp = function (appConfig) {
   // make app config accessible for all components
-  Vue.prototype.$appConfig = appConfig;
+  Vue.prototype.$appConfig = migrateAppConfig(appConfig);
   /* eslint-disable no-new */
   new Vue({
     vuetify: new Vuetify(opts),

--- a/src/main.js
+++ b/src/main.js
@@ -2,12 +2,14 @@
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue';
 import Vuetify from 'vuetify';
+import PortalVue from 'portal-vue'
 import '../node_modules/ol/ol.css';
 import WguApp from '../app/WguApp';
 import UrlUtil from './util/Url';
 import 'vuetify/dist/vuetify.min.css';
 
 Vue.use(Vuetify);
+Vue.use(PortalVue);
 
 // necessary for some components
 export default new Vuetify({


### PR DESCRIPTION
This feature branch adds an application wide sidebar to the project template, which serves as a container for module content. The sidebar is only visible, if at least one module has been configured to use the sidebar target.

![Wegue_sidebars](https://user-images.githubusercontent.com/46027124/117798194-29e68380-b251-11eb-877b-c5c850887dff.png)


In app.conf.json, the "win" property of "modules" has been changed to type string accepting the values {floating, sidebar}, e.g. 

`"modules": {
    "wgu-layerlist": {
      "target": "menu",
      "win": "sidebar"
    },
    "wgu-measuretool": {
      "target": "menu",
      "win": "floating"   
    }
 }`
A boolean value is still accepted for backward compatibility, 

Additionally to make sidebar windows look a little nicer, the config accepts 2 new module properties, which can be applied to floating windows too:
* 'minimizable': Option to minimize windows and show a minimizer next to the window closer (default is true).
* 'backgroundImage': Optional background image for the window header.

