### PR TITLE
Module property initialization

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -17,10 +17,8 @@
     <wgu-app-sidebar v-if="sidebarWins.length">
         <template v-for="(moduleWin, index) in sidebarWins">
           <component
-            :is="moduleWin.type" :key="index" :ref="moduleWin.type"
-            :win="moduleWin.win" :color="baseColor"
-            :backgroundImage="moduleWin.backgroundImage"
-            :minimizable="moduleWin.minimizable"
+            :is="moduleWin.type" :key="index" :color="baseColor"
+            v-bind="moduleWin"
           />
       </template>
     </wgu-app-sidebar>      
@@ -41,12 +39,8 @@
 
     <template v-for="(moduleWin, index) in floatingWins">
       <component
-        :is="moduleWin.type" :key="index" :ref="moduleWin.type"
-        :win="moduleWin.win" :color="baseColor"
-        :draggable="moduleWin.draggable"
-        :initPos="moduleWin.initPos"
-        :backgroundImage="moduleWin.backgroundImage"
-        :minimizable="moduleWin.minimizable"
+        :is="moduleWin.type" :key="index" :color="baseColor"
+        v-bind="moduleWin"
       />
     </template>
 
@@ -146,11 +140,7 @@
           if (moduleOpts.win === target) {
             moduleWins.push({
               type: key + '-win',
-              win: moduleOpts.win,
-              draggable: moduleOpts.draggable,
-              initPos: moduleOpts.initPos,
-              backgroundImage: moduleOpts.backgroundImage,
-              minimizable: moduleOpts.minimizable
+              ...moduleOpts
             });
           }
         }

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -24,8 +24,7 @@
     <template v-for="(tbButton, index) in tbButtons">
       <component
         :is="tbButton.type" :key="index"
-        :icon="tbButton.icon" :text="tbButton.text"
-        :dark="tbButton.dark" :moduleName="tbButton.moduleName"
+        v-bind="tbButton"
       />
     </template>
 
@@ -43,10 +42,9 @@
           <template v-for="(tbButton, index) in menuButtons">
             <v-list-item :key="index">
               <component 
-                :is="tbButton.type"
-                :icon="tbButton.icon" :text="tbButton.text"
-                :dark="tbButton.dark" :moduleName="tbButton.moduleName">
-              </component>
+                  :is="tbButton.type" :key="index"
+                  v-bind="tbButton"
+               />
               </v-list-item>
           </template>
       </v-list>
@@ -108,8 +106,9 @@ export default {
           buttons.push({
             type: moduleOpts.win ? 'wgu-toggle-btn' : key + '-btn',
             moduleName: key,
+            // TODO For further simplifications we should revise the config property 'darkLayout'.
             dark: moduleOpts.darkLayout,
-            icon: moduleOpts.icon
+            ...moduleOpts
           });
         }
       }

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -37,7 +37,7 @@
       "win": "floating",
       "icon": "help",
       "darkLayout": true, 
-      "windowTitle": "About",
+      "title": "About",
       "textTitle": "About Wegue",
       "htmlContent": "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js",
       "infoLinkText": "More Info",

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -176,7 +176,7 @@
       "win": "floating",
       "icon": "help",
       "darkLayout": true,
-      "windowTitle": "About",
+      "title": "About",
       "textTitle": "About Wegue",
       "htmlContent": "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js",
       "infoLinkText": "More Info",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -238,7 +238,7 @@
       "win": "floating",
       "icon": "help",
       "darkLayout": true,
-      "windowTitle": "About",
+      "title": "About",
       "textTitle": "About Wegue",
       "htmlContent": "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js",
       "infoLinkText": "More Info",

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -20,16 +20,24 @@ The following properties can be applied to all map module types:
 |--------------------|:---------:|---------|
 | **target**         | Where should the button to enable/disable the module be rendered. Valid options are `menu` or `toolbar` | `"target": "menu"` |
 | **win**            | Value to mark if the module has a window as sub component and where to show the module UI elements. Valid options are `floating` and `sidebar`. If the value is omitted, then the module is not associated with a window.  | `"win": "floating"` |
+| title              | Override the default module title. | `"title": "my module title"` |
+| icon               | Provide a customized icon for the module. | `"icon": "info"` |
 | minimizable        | Indicates whether the module window can be minimized. Only applies if a module window is present as indicated by the `win` parameter. | `"minimizable": true` |
 | backgroundImage    | Optional background image for the window header. Only applies if a module window is present as indicated by the `win` parameter. | `"backgroundImage": "static/icon/myImage.png"}` |
 | darkLayout         | Boolean value to ensure that your module element (mostly a button) is rendered bright since your basic theme color is dark.  | `"darkLayout": true` |
 
-The following positioning can be assigned to all module types, which are associated with a floating window - This is when the `win` parameter is set to `floating`:
+The following positioning and sizing properties can be assigned to all module types, which are associated with a floating window - This is when the `win` parameter is set to `floating`:
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
 | draggable          | Boolean value to enable a window module be draggable over the viewport. **CAUTION: This feature is experimental and not recommended for production usage.** | `"draggable": false` |
 | initPos            | The initial position for the module window in absolute viewport coordinates. | `"initPos": {"left": 8, "top": 74}` |
+| height            | The height of the module window in viewport coordinates. | `"height": 500` |
+| width            | The width of the module window in viewport coordinates. | `"width": 500` |
+| maxHeight            | The maximum height of the module window in viewport coordinates. | `"maxHeight": 500` |
+| maxWidth            | The maximum width of the module window in viewport coordinates. | `"maxWidth": 500` |
+| minHeight            | The minimum height of the module window in viewport coordinates. | `"minHeight": 500` |
+| minWidth            | The minimum width of the module window in viewport coordinates. | `"minWidth": 500` |
 
 
 ## GeoCoder
@@ -38,6 +46,10 @@ Module identifier: `wgu-geocoder`
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
+| rounded            | Adds a border radius to the input. | `"rounded": true` |
+| autofocus          | Enables autofocus  | `"autofocus": true` |
+| clearable          | Add input clear functionality.  | `"clearable": true` |
+| persistentHint     | Forces hint to always be visible.  | `"persistentHint": true` |
 | minChars           | Minimum number of characters which has to be entered so the query is triggered  | `"minChars": 2` |
 | queryDelay         | Delay in MS before a query is triggered | `"queryDelay": 200` |
 | selectZoom         | Zoom level which is set when a result entry is selected | `"selectZoom": 16` |
@@ -46,19 +58,28 @@ Module identifier: `wgu-geocoder`
 | provider           | Key defining which geocoder provider should be used. Could be `osm`, `photon` or `opencage` | `"provider": "osm"` |
 | providerOptions    | Optional options which are passed to the geocoder provider | `"providerOptions": {"lang": "en-US", "countrycodes": "", "limit": 6}` |
 
+## GeoLocator
+
+Module identifier: `wgu-geolocator`
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| zoomAnimation             | Use a zoom animation. | `"zoomAnimation": true` |
+| zoomAnimationDuration     | Duration of the zoom animation. | `"zoomAnimationDuration": 2400` |
+| maxZoom                   | Max zoom level for the zoom animation. | `"maxZoom": 15` |
+| markerColor               | Fill color of the geolocation marker. | `"markerColor": blue` |
+| markerText                | Style of the geolocation marker. | `"markerText": "person_pin_circle"` |
+
 ## HelpWindow
 
 Module identifier: `wgu-helpwin`
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| windowTitle        |  The title of the window itself         |   "About"      |
 | textTitle          |  The title over the text of the window         |   "About Wegue"      |
 | htmlContent        |   The text content of the window. HTML can be used.        |   "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js"      |
 | infoLinkText       |  The name of the link        |   "More Info"       |
 | infoLinkUrl        |  The URL of the link         |   "http://wegue.org/"       |
-
-No additional config options besides the general ones.
 
 ## InfoClick
 
@@ -97,6 +118,7 @@ The attribute table displays features of vector layers. It is possible to specif
 
 Module identifier: `wgu-attributetable`
 
-| Property                    | Meaning   | Example |
-|-----------------------------|:---------:|---------|
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| selectorLabel      | Override the placeholder text for the layer selection combo box.  | `"selectorLabel": "Choose a layer"` |
 | syncTableMapSelection | Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"syncTableMapSelection": true` |

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -44,7 +44,8 @@ export default {
   props: {
     icon: {type: String, required: false, default: 'table_chart'},
     title: {type: String, required: false, default: 'Attribute Table'},
-    selectorLabel: {type: String, required: false, default: 'Choose a layer'}
+    selectorLabel: {type: String, required: false, default: 'Choose a layer'},
+    syncTableMapSelection: {type: Boolean, required: false, default: false}
   },
   data () {
     return {
@@ -55,10 +56,6 @@ export default {
     }
   },
   mixins: [Mapable],
-  created () {
-    const config = this.$appConfig.modules['wgu-attributetable'];
-    this.syncTableMapSelection = config.syncTableMapSelection || false;
-  },
   components: {
     'wgu-module-card': ModuleCard,
     'wgu-attributetable': AttributeTable

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -40,16 +40,23 @@
     name: 'wgu-geocoder-input',
     mixins: [Mapable],
     props: {
-      buttonIcon: {type: String, required: false, default: 'search'},
+      buttonIcon: {type: String, required: false, default: 'search'}, // TODO rename to icon
       rounded: {type: Boolean, required: false, default: true},
       autofocus: {type: Boolean, required: false, default: true},
       clearable: {type: Boolean, required: false, default: true},
       dark: {type: Boolean, required: false, default: false},
-      persistentHint: {type: Boolean, required: false, default: true}
+      persistentHint: {type: Boolean, required: false, default: true},
+      debug: {type: Boolean, required: false, default: false},
+      minChars: {type: Number, required: false, default: 3},
+      queryDelay: {type: Number, required: false, default: 300},
+      selectZoom: {type: Number, required: false, default: 16},
+      placeHolder: {type: String, required: false, default: 'Search for an address'},
+      provider: {type: String, required: false, default: 'osm'},
+      providerOptions: {type: Object, required: false, default: function () { return {}; }}
+
     },
     data () {
       return {
-        placeHolder: '',
         results: [],
         lastQueryStr: '',
         noFilter: true,
@@ -166,15 +173,8 @@
       }
     },
     mounted () {
-      let config = this.$appConfig.modules['wgu-geocoder'] || {};
-      this.debug = config.debug || false;
-      this.minChars = config.minChars || 3;
-      this.queryDelay = config.queryDelay || 300;
-      this.selectZoom = config.selectZoom || 16;
-      this.placeHolder = config.placeHolder || 'Search for an address';
-
       // Setup GeocoderController to which we delegate Provider and query-handling
-      this.geocoderController = new GeocoderController(config.provider || 'osm', config.providerOptions || {}, this)
+      this.geocoderController = new GeocoderController(this.provider, this.providerOptions, this);
     }
   }
 </script>

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -21,7 +21,7 @@
   <v-toolbar-items>
 
     <v-btn @click='toggle()' icon :dark="dark" >
-      <v-icon medium>{{buttonIcon}}</v-icon>
+      <v-icon medium>{{icon}}</v-icon>
     </v-btn>
 
   </v-toolbar-items>
@@ -40,7 +40,7 @@
     name: 'wgu-geocoder-input',
     mixins: [Mapable],
     props: {
-      buttonIcon: {type: String, required: false, default: 'search'}, // TODO rename to icon
+      icon: {type: String, required: false, default: 'search'},
       rounded: {type: Boolean, required: false, default: true},
       autofocus: {type: Boolean, required: false, default: true},
       clearable: {type: Boolean, required: false, default: true},

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -2,7 +2,8 @@
   <wgu-module-card v-bind="$attrs"
       :moduleName="moduleName"
       class="wgu-helpwin" 
-      :icon="icon" 
+      :icon="icon"
+      :title="title"
       :width="width">
     <v-card-title primary-title>
       <div>
@@ -34,6 +35,7 @@
     },
     props: {
       icon: {type: String, required: false, default: 'help'},
+      title: {type: String, required: false, default: 'About'},
       textTitle: {type: String, required: false, default: 'About Wegue'},
       htmlContent: {type: String, required: false, default: '<h3>WebGIS with OpenLayers and Vue.js</h3>'},
       infoLinkUrl: {type: String, required: false, default: 'https://github.com/meggsimum/wegue'},

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -3,7 +3,6 @@
       :moduleName="moduleName"
       class="wgu-helpwin" 
       :icon="icon" 
-      :title="windowTitle"
       max-width="300">
     <v-card-title primary-title>
       <div>
@@ -35,8 +34,6 @@
     },
     props: {
       icon: {type: String, required: false, default: 'help'},
-      // TODO change this to 'title' property for conformance
-      windowTitle: {type: String, required: false, default: 'About'},
       textTitle: {type: String, required: false, default: 'About Wegue'},
       htmlContent: {type: String, required: false, default: '<h3>WebGIS with OpenLayers and Vue.js</h3>'},
       infoLinkUrl: {type: String, required: false, default: 'https://github.com/meggsimum/wegue'},

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -3,7 +3,7 @@
       :moduleName="moduleName"
       class="wgu-helpwin" 
       :icon="icon" 
-      max-width="300">
+      :width="width">
     <v-card-title primary-title>
       <div>
         <h3 class="headline mb-0" v-if="textTitle">{{ textTitle }}</h3>
@@ -37,7 +37,8 @@
       textTitle: {type: String, required: false, default: 'About Wegue'},
       htmlContent: {type: String, required: false, default: '<h3>WebGIS with OpenLayers and Vue.js</h3>'},
       infoLinkUrl: {type: String, required: false, default: 'https://github.com/meggsimum/wegue'},
-      infoLinkText: {type: String, required: false, default: 'More info'}
+      infoLinkText: {type: String, required: false, default: 'More info'},
+      width: {type: Number, required: false, default: 300}
     },
     data () {
       return {

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -34,18 +34,17 @@
       'wgu-module-card': ModuleCard
     },
     props: {
-      icon: {type: String, required: false, default: 'help'}
+      icon: {type: String, required: false, default: 'help'},
+      // TODO change this to 'title' property for conformance
+      windowTitle: {type: String, required: false, default: 'About'},
+      textTitle: {type: String, required: false, default: 'About Wegue'},
+      htmlContent: {type: String, required: false, default: '<h3>WebGIS with OpenLayers and Vue.js</h3>'},
+      infoLinkUrl: {type: String, required: false, default: 'https://github.com/meggsimum/wegue'},
+      infoLinkText: {type: String, required: false, default: 'More info'}
     },
     data () {
-      let config = this.$appConfig.modules['wgu-helpwin'] || {};
       return {
-        moduleName: 'wgu-helpwin',
-        // TODO change this to 'title' property for conformance
-        windowTitle: config.windowTitle || 'About',
-        textTitle: config.textTitle || 'About Wegue',
-        htmlContent: config.htmlContent || '<h3>WebGIS with OpenLayers and Vue.js</h3>',
-        infoLinkUrl: config.infoLinkUrl || 'https://github.com/meggsimum/wegue',
-        infoLinkText: config.infoLinkText || 'More info'
+        moduleName: 'wgu-helpwin'
       }
     }
   }

--- a/src/components/measuretool/MeasureWin.vue
+++ b/src/components/measuretool/MeasureWin.vue
@@ -98,13 +98,9 @@
         if (this.unbound) {
           return;
         }
-        // Only create if specified in config
-        if (!this.$appConfig.modules || !this.$appConfig.modules[this.moduleName]) {
-          return;
-        }
-        const measureConf = this.$appConfig.modules[this.moduleName] || {};
-        this.olMapCtrl = new OlMeasureController(this.map, measureConf);
 
+        // TODO: Should we explicitly declare all attributes as props?
+        this.olMapCtrl = new OlMeasureController(this.map, this.$attrs);
         this.olMapCtrl.createMeasureLayer();
       },
       /**

--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,13 @@ const migrateAppConfig = function (appConfig) {
       }
     });
   }
+  // Migrate windowTitle value for help win
+  if (appConfig.modules && appConfig.modules['wgu-helpwin']) {
+    var module = appConfig.modules['wgu-helpwin'];
+    if (!module.title && module.windowTitle) {
+      module.title = module.windowTitle;
+    }
+  }
   return appConfig;
 }
 


### PR DESCRIPTION
The purpose of this change-set is to forward the complete module configuration found in app-conf.json for each module. The configuration can then be picked up within each module via Vue props, rather than having to access the global $appConfig.modules.

The idea behind is:
* Provide better encapsulation of module configurations.
* Make it easier to validate properties (by using the implicit mechanism provided by Vue).
* Easily support the new properties introduced by the base Module cards - which now can all be configured via the config-
* Simplify the module initialization code.
* Revive some old properties like e.g. 'title', that we're not passed through from the app-config.json into the modules.