### PR TITLE
Map recorder

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -76,6 +76,7 @@
   import InfoClickWin from '../src/components/infoclick/InfoClickWin'
   import MapLoadingStatus from '../src/components/progress/MapLoadingStatus'
   import AttributeTableWin from '../src/components/attributeTable/AttributeTableWin.vue'
+  import MapRecorderWin from '../src/components/maprecorder/MapRecorderWin'
 
   export default {
     name: 'wgu-app-tpl',
@@ -91,7 +92,8 @@
       'wgu-helpwin-win': HelpWin,
       'wgu-infoclick-win': InfoClickWin,
       'wgu-maploading-status': MapLoadingStatus,
-      'wgu-attributetable-win': AttributeTableWin
+      'wgu-attributetable-win': AttributeTableWin,
+      'wgu-maprecorder-win': MapRecorderWin
     },
     data () {
       return {

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -25,7 +25,8 @@
       "projection": "EPSG:3857",
       "attributions": "<a href='https://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap-Mitwirkende</a>",
       "isBaseLayer": true,
-      "visible": true
+      "visible": true,
+      "crossOrigin": "anonymous"
     }
 
   ],

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -25,8 +25,7 @@
       "projection": "EPSG:3857",
       "attributions": "<a href='https://www.openstreetmap.org/copyright' target='_blank'>© OpenStreetMap-Mitwirkende</a>",
       "isBaseLayer": true,
-      "visible": true,
-      "crossOrigin": "anonymous"
+      "visible": true
     }
 
   ],

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -172,6 +172,17 @@
       "target": "toolbar",
       "darkLayout": true
     },
+    "wgu-maprecorder": {
+      "target": "toolbar",
+      "win": "floating",
+      "icon": "mdi-video",
+      "darkLayout": true,
+      "draggable": false,
+      "initPos": {
+        "left": 8,
+        "top": 230
+      }
+    },
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -87,7 +87,8 @@
       "tileGridRef": "dutch_rd",
       "attributions": "<a href='https://www.pdok.nl' target='_blank'>PDOK</a> by Dutch Kadaster",
       "isBaseLayer": false,
-      "visible": false
+      "visible": false,
+      "crossOrigin": "anonymous"
     },
     {
       "type": "WMS",
@@ -102,7 +103,8 @@
       "tileGridRef": "dutch_rd",
       "attributions": "<a href='https://www.pdok.nl' target='_blank'>PDOK</a> by Dutch Kadaster",
       "isBaseLayer": true,
-      "visible": false
+      "visible": false,
+      "crossOrigin": "anonymous"
     },
     {
       "type": "XYZ",
@@ -113,7 +115,8 @@
       "projection": "EPSG:28992",
       "tileGridRef": "dutch_rd",
       "isBaseLayer": true,
-      "visible": true
+      "visible": true,
+      "crossOrigin": "anonymous"
     }
   ],
 

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -232,6 +232,13 @@
       "target": "toolbar",
       "darkLayout": true
     },
+    "wgu-maprecorder": {
+      "target": "toolbar",
+      "win": "sidebar",
+      "icon": "mdi-video",
+      "darkLayout": true,
+      "minimizable": true
+    },
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -145,8 +145,7 @@
       "attribution": "",
       "isBaseLayer": false,
       "visible": false,
-      "displayInLayerList": true,
-      "crossOrigin": "anonymous"
+      "displayInLayerList": true
     },
 
     {

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -145,7 +145,8 @@
       "attribution": "",
       "isBaseLayer": false,
       "visible": false,
-      "displayInLayerList": true
+      "displayInLayerList": true,
+      "crossOrigin": "anonymous"
     },
 
     {
@@ -168,7 +169,8 @@
       "attributions": "Map data: <a href=\"https://openstreetmap.org/copyright\">©OpenStreetMap</a>-contributors, SRTM | Map representation (Kartendarstellung): © <a href=\"http://opentopomap.org/\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>)",
       "lid": "opentopomap",
       "isBaseLayer": true,
-      "visible": false
+      "visible": false,
+      "crossOrigin": "anonymous"
     },
 
     {
@@ -176,7 +178,8 @@
       "lid": "osm-bg",
       "name": "OSM",
       "isBaseLayer": true,
-      "visible": true
+      "visible": true,
+      "crossOrigin": "anonymous"
     }
 
   ],

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -236,6 +236,17 @@
       "target": "toolbar",
       "darkLayout": true
     },
+    "wgu-maprecorder": {
+      "target": "toolbar",
+      "win": "floating",
+      "icon": "mdi-video",
+      "darkLayout": true,
+      "draggable": false,
+      "initPos": {
+        "left": 8,
+        "top": 230
+      }
+    },
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -145,8 +145,7 @@
       "attribution": "",
       "isBaseLayer": false,
       "visible": false,
-      "displayInLayerList": true,
-      "crossOrigin": "anonymous"
+      "displayInLayerList": true
     },
 
     {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -145,7 +145,8 @@
       "attribution": "",
       "isBaseLayer": false,
       "visible": false,
-      "displayInLayerList": true
+      "displayInLayerList": true,
+      "crossOrigin": "anonymous"
     },
 
     {
@@ -168,7 +169,8 @@
       "attributions": "Map data: <a href=\"https://openstreetmap.org/copyright\">©OpenStreetMap</a>-contributors, SRTM | Map representation (Kartendarstellung): © <a href=\"http://opentopomap.org/\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>)",
       "lid": "opentopomap",
       "isBaseLayer": true,
-      "visible": false
+      "visible": false,
+      "crossOrigin": "anonymous"
     },
 
     {
@@ -176,7 +178,8 @@
       "lid": "osm-bg",
       "name": "OSM",
       "isBaseLayer": true,
-      "visible": true
+      "visible": true,
+      "crossOrigin": "anonymous"
     }
 
   ],

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -47,7 +47,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        include: [resolve('app'), resolve('src'), resolve('test'), resolve('node_modules/ol')],
+        include: [resolve('app'), resolve('src'), resolve('test'), resolve('node_modules/ol'), resolve('node_modules/canvas-record')],
         options: {
           presets: ['@babel/preset-env']
         }

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -25,6 +25,7 @@ The following properties can be applied to all map layer types
 | Property           | Meaning | Example |
 |--------------------|:---------:|---------|
 | **type**           | Indicator that the layer is a OpenStreetMap tile server layer, always `OSM` here  | `"type": "OSM"` |
+| crossOrigin        | Provides support for CORS, defining how the layers source handles crossorigin requests. For more information and the supported values see [HTML attribute: crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)  | `"crossOrigin": "anonymous"` |
 
 ## VECTOR
 
@@ -82,6 +83,7 @@ The following properties can be applied to all map layer types
 | transparent        | Boolean value, whether the WMS layer should be queried with a transparent background  | `"transparent": true` |
 | singleTile         | Boolean value, whether the WMS layer should be queried in single tile mode | `"singleTile": false` |
 | tileGridRef        | Identifier of the tile grid to use for this layer (has to be defined in `tileGridDefs` | `"tileGridRef": "dutch_rd"` |
+| crossOrigin        | Provides support for CORS, defining how the layers source handles crossorigin requests. For more information and the supported values see [HTML attribute: crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)  | `"crossOrigin": "anonymous"` |
 
 ## XYZ
 
@@ -90,6 +92,7 @@ The following properties can be applied to all map layer types
 | **type**           | Indicator that the layer is a XYZ tiled image layer, always `XYZ` here  | `"type": "XYZ"` |
 | **url**            | The URL of the service providing the image tiles | `"url": "https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaart/EPSG:28992/{z}/{x}/{y}.png"` |
 | tileGridRef        | Identifier of the tile grid to use for this layer (has to be defined in `tileGridDefs` | `"tileGridRef": "dutch_rd"` |
+| crossOrigin        | Provides support for CORS, defining how the layers source handles crossorigin requests. For more information and the supported values see [HTML attribute: crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)  | `"crossOrigin": "anonymous"` |
 
 ## Style for Vectorlayers
 

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -129,3 +129,12 @@ Module identifier: `wgu-attributetable`
 |--------------------|:---------:|---------|
 | selectorLabel      | Override the placeholder text for the layer selection combo box.  | `"selectorLabel": "Choose a layer"` |
 | syncTableMapSelection | Clicking on a row zooms to the respective feature. If the layer is `selectable` the feature will also be selected. Selecting a feature on the map selects the corresponsing row in the table. | `"syncTableMapSelection": true` |
+
+## MapRecorder
+
+Module identifier: `wgu-maprecorder`
+
+No additional config options besides the general ones.
+
+**Important:**
+For [WMS](map-layer-configuration?id=wms), [XYZ](map-layer-configuration?id=xyz) and [OSM](map-layer-configuration?id=xyz) layers requested from cross origin sources you have to enable CORS via the layers `crossOrigin` attribute, in order to grant the required capturing privileges to the map recorders canvas.

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -263,7 +263,8 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "attribution": "",
       "isBaseLayer": false,
       "visible": false,
-      "displayInLayerList": true
+      "displayInLayerList": true,
+      "crossOrigin": "anonymous"
     },
 
     {
@@ -286,7 +287,8 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "attributions": "Map data: <a href=\"https://openstreetmap.org/copyright\">©OpenStreetMap</a>-contributors, SRTM | Map representation (Kartendarstellung): © <a href=\"http://opentopomap.org/\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>)",
       "lid": "opentopomap",
       "isBaseLayer": true,
-      "visible": false
+      "visible": false,
+      "crossOrigin": "anonymous"
     },
 
     {
@@ -294,7 +296,8 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "lid": "osm-bg",
       "name": "OSM",
       "isBaseLayer": true,
-      "visible": true
+      "visible": true,
+      "crossOrigin": "anonymous"
     }
 
   ],
@@ -349,6 +352,17 @@ Example configurations can be found in the `app-starter/static` directory. Below
     "wgu-zoomtomaxextent": {
       "target": "toolbar",
       "darkLayout": true
+    },
+    "wgu-maprecorder": {
+      "target": "toolbar",
+      "win": "floating",
+      "icon": "mdi-video",
+      "darkLayout": true,
+      "draggable": false,
+      "initPos": {
+        "left": 8,
+        "top": 230
+      }
     },
     "wgu-helpwin": {
       "target": "toolbar",

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -263,8 +263,7 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "attribution": "",
       "isBaseLayer": false,
       "visible": false,
-      "displayInLayerList": true,
-      "crossOrigin": "anonymous"
+      "displayInLayerList": true
     },
 
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3058,6 +3058,14 @@
       "integrity": "sha512-XuMzGxlFYXDEm+e/6ti7ThqQki/hRXHw4aaFMQXtFHYoj2XNn92zZ5aH75AADfQ1tnXoZTOvS2+NbaaWWPypIw==",
       "dev": true
     },
+    "canvas-record": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canvas-record/-/canvas-record-3.0.0.tgz",
+      "integrity": "sha512-sKZVpzVy6GYGR5IfqMXLnxA8NVAjsrmImqUGQ+FH3YIu06V1sQPS0MSSQotynDfeLRtaExDNuT7rZ3amnfy3fw==",
+      "requires": {
+        "file-extension": "^4.0.5"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -5436,6 +5444,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-extension": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/file-extension/-/file-extension-4.0.5.tgz",
+      "integrity": "sha512-l0rOL3aKkoi6ea7MNZe6OHgqYYpn48Qfflr8Pe9G9JPPTx5A+sfboK91ZufzIs59/lPqh351l0eb6iKU9J5oGg=="
     },
     "file-loader": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "init:app": "node util/init-app.js"
   },
   "dependencies": {
+    "canvas-record": "^3.0.0",
     "ol": "6.4.3",
     "proj4": "2.5.0",
     "vue": "2.6.11",

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -181,7 +181,8 @@ export default {
      */
     drawCanvas () {
       var me = this;
-      me.mapContext.clearRect(0, 0, me.mapCanvas.width, me.mapCanvas.height);
+      me.mapContext.fillStyle = 'white';
+      me.mapContext.fillRect(0, 0, me.mapCanvas.width, me.mapCanvas.height);
 
       Array.prototype.forEach.call(
         document.querySelectorAll('.ol-layer canvas'),

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -81,8 +81,8 @@
           fab
           outlined 
           @click="toggleRecord">
-          <v-icon v-if="recording">mdi-video-off</v-icon> 
-          <v-icon v-else>mdi-video</v-icon> 
+          <v-icon v-if="recording">stop</v-icon> 
+          <v-icon v-else color="red darken-4">fiber_manual_record</v-icon> 
         </v-btn>
         <v-flex fill-height grow> 
           <v-progress-linear

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -1,0 +1,298 @@
+<template>
+  <wgu-module-card v-bind="$attrs"
+      :moduleName="moduleName"
+      class="wgu-maprecorder-win" 
+      :icon="icon" 
+      :title="title"
+      width=350>
+    
+    <v-expansion-panels :multiple="true" :accordion="true" class="overflow-y-auto">
+      <v-expansion-panel>
+        <v-expansion-panel-header> 
+          <v-layout align-center>
+            <v-icon class="mr-4">settings</v-icon>
+            Optionen
+          </v-layout>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <v-card
+            flat
+            color="transparent"
+          >
+          <v-subheader>Videoformat</v-subheader>
+            <v-card-text class="pt-0">
+              <v-select
+                  v-model="mimeType"
+                  :items="mimeTypes"
+                  prepend-icon="mdi-video-image"
+                  menu-props="auto"
+                  dense
+                  hide-details>
+              </v-select>
+            </v-card-text>
+
+            <v-subheader>Bildrate (Bilder/s)</v-subheader>
+            <v-card-text class="pt-0">
+              <v-slider
+                  prepend-icon="mdi-iframe-variable-outline"
+                  v-model.number="frameRate"
+                  min="20"
+                  max="50"
+                  step="1"
+                  thumb-label
+                  hide-details>
+              </v-slider>
+            </v-card-text>
+
+            <v-subheader>Bitrate (MBits/s)</v-subheader>
+            <v-card-text class="pt-0">
+              <v-slider
+                  prepend-icon="mdi-quality-high"
+                  v-model.number="videoMBitsPerSecond"
+                  min="1.0"
+                  max="10.0"
+                  step="0.1"
+                  thumb-label
+                  hide-details>
+              </v-slider>
+            </v-card-text>
+
+            <v-subheader>Dateiname</v-subheader>
+            <v-card-text class="pt-0">
+              <v-text-field
+                v-model="filename"
+                prepend-icon="mdi-rename-box"
+                label="YYYY-MM-DD at HH.MM.SS"
+                dense
+                single-line
+                hide-details
+              ></v-text-field>
+            </v-card-text>
+          </v-card>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+
+    <v-card-actions>
+      <v-layout align-center>
+        <v-btn
+          class="mr-3"
+          icon 
+          fab
+          outlined 
+          @click="toggleRecord">
+          <v-icon v-if="recording">mdi-video-off</v-icon> 
+          <v-icon v-else>mdi-video</v-icon> 
+        </v-btn>
+        <v-flex fill-height grow> 
+          <v-progress-linear
+            :active="recording"
+            buffer-value="0"
+            stream
+          ></v-progress-linear>
+        </v-flex>
+        <v-flex fill-height shrink>
+           <v-alert
+            v-model="error"
+            type="error" 
+            dismissible>
+            Starten der Aufnahme fehlgeschlagen.
+          </v-alert>
+        </v-flex>
+      </v-layout>
+    </v-card-actions>
+  </wgu-module-card>
+</template>
+
+<script>
+import ModuleCard from './../modulecore/ModuleCard';
+import { Mapable } from '../../mixins/Mapable';
+import createCanvasRecorder from 'canvas-record';
+
+export default {
+  name: 'wgu-maprecorder-win',
+  inheritAttrs: false,
+  mixins: [Mapable],
+  components: {
+    'wgu-module-card': ModuleCard
+  },
+  props: {
+    icon: {type: String, required: false, default: 'mdi-video'},
+    title: {type: String, required: false, default: 'Map-recorder'}
+  },
+  data () {
+    const mimeTypes = this.getSupportedMimeTypes();
+
+    return {
+      moduleName: 'wgu-maprecorder',
+
+      /**
+      * Custom canvas element for drawing the Open layers map.
+      */
+      mapCanvas: null,
+      /**
+       * Context of the custom canvas element.
+       */
+      mapContext: null,
+      /**
+       * Canvas recorder.
+       */
+      recorder: null,
+      /**
+       * Recording state
+       */
+      recording: false,
+      /**
+       * Filename of the video. Defaults to 'Recording YYYY-MM-DD'.
+       */
+      filename: undefined,
+      /**
+       * The frame rate used by the MediaRecorder.
+       */
+      frameRate: 25,
+      /**
+       * The video encoding bit rate in MBits/s.
+       */
+      videoMBitsPerSecond: 2.5,
+      /**
+       * The selected video codec.
+       */
+      mimeType: mimeTypes.length > 0 ? mimeTypes[0] : undefined,
+      /**
+       * The video codecs supported by the browser.
+       */
+      mimeTypes: mimeTypes,
+      /**
+       * Timer handle for canvas draw callbacks.
+       */
+      timerHandle: null,
+      /**
+       * An error occured on recording.
+       */
+      error: false
+    }
+  },
+  methods: {
+    /**
+     * Starting from OpenLayers 6, layers are no longer composed to a single
+     * Canvas element. The following function does custom rendering of all map
+     * layers, code is taken from this example:
+     * https://openlayers.org/en/latest/examples/export-map.html
+     */
+    drawCanvas () {
+      var me = this;
+      me.mapContext.clearRect(0, 0, me.mapCanvas.width, me.mapCanvas.height);
+
+      Array.prototype.forEach.call(
+        document.querySelectorAll('.ol-layer canvas'),
+        function (canvas) {
+          if (canvas.width > 0) {
+            var opacity = canvas.parentNode.style.opacity;
+            me.mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity);
+
+            // Get the transform parameters from the style's transform matrix
+            // and apply the transform to the export map context.
+            var transform = canvas.style.transform;
+            /* eslint-disable-next-line no-useless-escape */
+            var matrix = transform.match(/^matrix\(([^\(]*)\)$/)[1]
+              .split(',').map(Number);
+            CanvasRenderingContext2D.prototype.setTransform.apply(
+              me.mapContext,
+              matrix
+            );
+            me.mapContext.drawImage(canvas, 0, 0);
+          }
+        }
+      );
+    },
+
+    /**
+     * Starts / stops recording
+     */
+    toggleRecord () {
+      var me = this;
+      if (me.recording) {
+        me.stopRecording();
+      } else {
+        me.startRecording();
+      }
+    },
+
+    /**
+     * Resize the canvas when the map changes. Only happens when recording
+     * is active.
+     */
+    mapSizeChanged () {
+      var me = this;
+      var size = me.map.getSize();
+      me.mapCanvas.width = size[0];
+      me.mapCanvas.height = size[1];
+    },
+
+    /**
+     * Create a custom canvas to render into, a map recorder and start the
+     * capturing process.
+     */
+    startRecording () {
+      var me = this;
+      me.mapCanvas = document.createElement('canvas');
+      me.mapSizeChanged();
+      me.mapContext = me.mapCanvas.getContext('2d');
+      me.drawCanvas();
+      me.map.on('change:size', me.mapSizeChanged);
+      me.timerHandle = setInterval(me.drawCanvas, 1000 / me.frameRate);
+
+      try {
+        me.recorder = createCanvasRecorder(me.mapCanvas, {
+          filename: me.filename,
+          frameRate: me.frameRate,
+          recorderOptions: {
+            videoBitsPerSecond: me.videoMBitsPerSecond * 1048576,
+            mimeType: me.mimeType
+          }
+        });
+        me.recorder.start();
+      } catch (e) {
+        me.error = true;
+        me.stopRecording();
+        return;
+      }
+
+      me.error = false;
+      me.recording = true;
+    },
+
+    /**
+     * Stop recording and free all associated resources.
+     */
+    stopRecording () {
+      var me = this;
+      if (me.recorder) {
+        me.recorder.stop();
+        me.recorder.dispose();
+        me.recorder = null;
+      }
+      clearInterval(me.timerHandle);
+      me.timerHandle = null;
+      me.map.un('change:size', me.mapSizeChanged)
+      me.mapContext = me.mapCanvas = null;
+      me.recording = false;
+    },
+
+    /**
+     * Returns video codecs supported by the browser. See
+     * https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers
+     */
+    getSupportedMimeTypes () {
+      return [
+        'video/webm',
+        'video/mp4',
+        'video/ogg',
+        'video/x-matroska',
+        'video/quicktime',
+        'video/3gpp'
+      ].filter(mimeType => MediaRecorder.isTypeSupported(mimeType));
+    }
+  }
+};
+</script>

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -127,8 +127,8 @@ export default {
       moduleName: 'wgu-maprecorder',
 
       /**
-      * Custom canvas element for drawing the Open layers map.
-      */
+       * Custom canvas element for drawing the OpenLayers map.
+       */
       mapCanvas: null,
       /**
        * Context of the custom canvas element.
@@ -139,7 +139,7 @@ export default {
        */
       recorder: null,
       /**
-       * Recording state
+       * Recording state.
        */
       recording: false,
       /**

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -11,7 +11,7 @@
         <v-expansion-panel-header> 
           <v-layout align-center>
             <v-icon class="mr-4">settings</v-icon>
-            Optionen
+            Options
           </v-layout>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
@@ -19,7 +19,7 @@
             flat
             color="transparent"
           >
-          <v-subheader>Videoformat</v-subheader>
+          <v-subheader>Video format</v-subheader>
             <v-card-text class="pt-0">
               <v-select
                   v-model="mimeType"
@@ -31,7 +31,7 @@
               </v-select>
             </v-card-text>
 
-            <v-subheader>Bildrate (Bilder/s)</v-subheader>
+            <v-subheader>Frame rate (frames/s)</v-subheader>
             <v-card-text class="pt-0">
               <v-slider
                   prepend-icon="mdi-iframe-variable-outline"
@@ -44,7 +44,7 @@
               </v-slider>
             </v-card-text>
 
-            <v-subheader>Bitrate (MBits/s)</v-subheader>
+            <v-subheader>Bit rate (MBits/s)</v-subheader>
             <v-card-text class="pt-0">
               <v-slider
                   prepend-icon="mdi-quality-high"
@@ -57,7 +57,7 @@
               </v-slider>
             </v-card-text>
 
-            <v-subheader>Dateiname</v-subheader>
+            <v-subheader>Filename</v-subheader>
             <v-card-text class="pt-0">
               <v-text-field
                 v-model="filename"
@@ -96,7 +96,7 @@
             v-model="error"
             type="error" 
             dismissible>
-            Starten der Aufnahme fehlgeschlagen.
+            Failed to start recording.
           </v-alert>
         </v-flex>
       </v-layout>
@@ -118,7 +118,7 @@ export default {
   },
   props: {
     icon: {type: String, required: false, default: 'mdi-video'},
-    title: {type: String, required: false, default: 'Map-recorder'}
+    title: {type: String, required: false, default: 'Map recorder'}
   },
   data () {
     const mimeTypes = this.getSupportedMimeTypes();

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -107,7 +107,8 @@ export const LayerFactory = {
         serverType: lConf.serverType,
         attributions: lConf.attributions,
         tileGrid: lConf.tileGrid,
-        projection: lConf.projection
+        projection: lConf.projection,
+        crossOrigin: lConf.crossOrigin
       })
     });
 
@@ -219,7 +220,8 @@ export const LayerFactory = {
         url: lConf.url,
         attributions: lConf.attributions,
         tileGrid: lConf.tileGrid,
-        projection: lConf.projection
+        projection: lConf.projection,
+        crossOrigin: lConf.crossOrigin
       })
     });
 
@@ -241,7 +243,9 @@ export const LayerFactory = {
       displayInLayerList: lConf.displayInLayerList,
       visible: lConf.visible,
       opacity: lConf.opacity,
-      source: new OsmSource()
+      source: new OsmSource({
+        crossOrigin: lConf.crossOrigin
+      })
     });
 
     return layer;

--- a/test/unit/specs/components/maprecorder/MapRecorderWin.spec.js
+++ b/test/unit/specs/components/maprecorder/MapRecorderWin.spec.js
@@ -1,0 +1,108 @@
+import MapRecorderWin from '@/components/maprecorder/MapRecorderWin'
+import { shallowMount } from '@vue/test-utils';
+import OlMap from 'ol/Map';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+
+describe('maprecorder/MapRecorderWin.vue', () => {
+  it('is defined', () => {
+    expect(MapRecorderWin).to.not.be.an('undefined');
+  });
+
+  describe('props', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(MapRecorderWin);
+      vm = comp.vm
+    });
+
+    it('has correct default props', () => {
+      expect(vm.icon).to.equal('mdi-video');
+      expect(vm.title).to.equal('Map recorder');
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('data', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(MapRecorderWin);
+      vm = comp.vm
+    });
+
+    it('has correct default data', () => {
+      expect(vm.moduleName).to.equal('wgu-maprecorder');
+      expect(vm.mapCanvas).to.be.null;
+      expect(vm.mapContext).to.be.null;
+      expect(vm.recorder).to.be.null;
+      expect(vm.recording).to.equal(false);
+      expect(vm.filename).to.be.undefined;
+      expect(vm.frameRate).to.equal(25);
+      expect(vm.videoMBitsPerSecond).to.equal(2.5);
+      expect(vm.timerHandle).to.be.null;
+      expect(vm.error).to.equal(false);
+      // Supported codecs under chrome.
+      expect(vm.mimeType).to.equal('video/webm');
+      expect(vm.mimeTypes.length).to.equal(2);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('methods', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(MapRecorderWin);
+      vm = comp.vm
+    });
+
+    it('correct supported mime types under chrome', () => {
+      const mimeTypes = vm.getSupportedMimeTypes();
+      expect(mimeTypes.length).to.equal(2);
+      expect(mimeTypes[0]).to.equal('video/webm');
+      expect(mimeTypes[1]).to.equal('video/x-matroska');
+    });
+
+    it('start / stop recording sets correct states', () => {
+      const layer = new VectorLayer({
+        visible: true,
+        source: new VectorSource()
+      });
+      const map = new OlMap({
+        layers: [layer]
+      });
+      map.setSize([1024, 768]);
+      vm.map = map;
+
+      vm.startRecording();
+      expect(vm.mapCanvas).not.to.be.null;
+      expect(vm.mapCanvas.width).to.equal(1024);
+      expect(vm.mapCanvas.height).to.equal(768);
+      expect(vm.mapContext).not.to.be.null;
+      expect(vm.recorder).not.to.be.null;
+      expect(vm.recording).to.equal(true);
+      expect(vm.timerHandle).not.to.be.null;
+      expect(vm.error).to.equal(false);
+
+      vm.stopRecording();
+      expect(vm.mapCanvas).to.be.null;
+      expect(vm.mapContext).to.be.null;
+      expect(vm.recorder).to.be.null;
+      expect(vm.recording).to.equal(false);
+      expect(vm.timerHandle).to.be.null;
+      expect(vm.error).to.equal(false);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+});


### PR DESCRIPTION
This adds a new component to Wegue, which is capable of capturing all visible map layers and creates a video from it.
Video codecs supported by the browser are automatically detected, and the control allows for adjusting video quality related parameters like frame- and bit rate.

![wegue_maprecorder](https://user-images.githubusercontent.com/46027124/124154101-70a86b00-da95-11eb-938a-78813f79a56d.png)

Technical notes:
* The control does not support IE. For browser compatibility see the following [MDN chart](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder#browser_compatibility).
* Due to the [tainted canvas problem](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases) captured layers have to be compliant to the same origin policy. Therefore I added support for the crossOrigin attribute in the layer configuration. All layers with CORS enabled sources have been declared with "crossOrigin"="anonymous" attribute (This is currently all but http://ows.terrestris.de/osm-gray/service and https://ahocevar.com/geoserver/wms - the latter seems to be broken anyway)