### PR TITLE
Add 'wgu-geolocator-layer' to permalink ignore list

### DIFF
--- a/src/components/ol/PermalinkController.js
+++ b/src/components/ol/PermalinkController.js
@@ -13,7 +13,7 @@ export default class PermalinkController {
   projection = null;
   conf = null;
   urlParams = null;
-  ignoreLayers = ['wgu-measure-layer'];
+  ignoreLayers = ['wgu-measure-layer', 'wgu-geolocator-layer'];
 
   constructor (map, permalinkConf) {
     this.map = map;


### PR DESCRIPTION
This adds the layer to show the geolocation on the map to the ignore layer list of the permalink module, since it makes no sense to have it in the permalink and the modules are (currently) not restored.

/cc @justb4 @fschmenger 