### PR TITLE
Apply auto-fixes from eslint to app-starter folder.

### DIFF
--- a/app-starter/components/AppFooter.vue
+++ b/app-starter/components/AppFooter.vue
@@ -16,13 +16,12 @@
 export default {
   name: 'wgu-app-footer',
   props: {
-    color: {type: String, required: false, default: 'red darken-3'},
-    footerTextLeft: {type: String, required: true},
-    footerTextRight: {type: String, required: true},
-    showCopyrightYear: {type: Boolean, required: false, default: true}
+    color: { type: String, required: false, default: 'red darken-3' },
+    footerTextLeft: { type: String, required: true },
+    footerTextRight: { type: String, required: true },
+    showCopyrightYear: { type: Boolean, required: false, default: true }
   }
 }
-
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -76,7 +76,7 @@ export default {
     'wgu-localeswitcher-btn': LocaleSwitcher
   },
   props: {
-    color: {type: String, required: false, default: 'red darken-3'}
+    color: { type: String, required: false, default: 'red darken-3' }
   },
   data () {
     return {


### PR DESCRIPTION
This fixes some warnings on built in conjunction with #242. 

Apparently the app-starter folder is currently excluded from linting. Strangely enough after running app:init, eslint will still not complain but the build will throw some warnings. This should be fixed now, sorry for the oversight.