### PR TITLE
Background layer switcher autohide

### DIFF
--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -70,9 +70,14 @@
       // https://github.com/vuejs/Discussion/issues/394 .The following works in Firefox and Chrome.
       var slideGroup = this.$refs.slideGroup;
       if (slideGroup) {
-        setTimeout(() => {
+        this.timerHandle = setTimeout(() => {
           slideGroup.onResize();
         }, 10);
+      }
+    },
+    destroyed () {
+      if (this.timerHandle) {
+        clearTimeout(this.timerHandle);
       }
     },
     methods: {

--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -1,7 +1,6 @@
 <template>
   <v-sheet :color="color" :dark="dark" elevation="8">
     <v-slide-group ref="slideGroup"
-      v-if="displayedLayers.length"
       mandatory
       show-arrows
       class="pa-1"
@@ -37,9 +36,6 @@
         </v-card> 
       </v-slide-item>
     </v-slide-group>
-    <v-alert v-else type="info" class="mb-0"> 
-      {{ emptyText }}
-    </v-alert>
   </v-sheet>
 </template>
 
@@ -54,7 +50,6 @@
     },
     mixins: [Mapable],
     props: {
-      emptyText: { type: String, required: true },
       color: { type: String, required: true },
       dark: { type: Boolean, required: true },
       selColor: { type: String, required: true },

--- a/src/components/bglayerswitcher/BgLayerSwitcher.vue
+++ b/src/components/bglayerswitcher/BgLayerSwitcher.vue
@@ -1,9 +1,9 @@
 <template>
-  <div id="wgu-bglayerswitcher-wrapper">
+  <div id="wgu-bglayerswitcher-wrapper" v-if="show">
     <v-menu offset-x nudge-right="15"
       transition="scale-transition"
       :close-on-content-click="false"
-      v-model="show"
+      v-model="open"
       attach="#wgu-bglayerswitcher-wrapper"
       >
       <template v-slot:activator="{on}">
@@ -20,7 +20,7 @@
       </template>
       <!-- Remarks: The layerlist is wrapped by an v-if block to avoid unneccesary image 
            requests when the layerlist is not visible -->
-      <wgu-bglayerlist v-if="show"
+      <wgu-bglayerlist v-if="open"
         color="white"
         :dark="false"
         :selColor="color"
@@ -28,13 +28,13 @@
         :previewIcon="icon"
         :imageWidth="imageWidth"
         :imageHeight="imageHeight"
-        :emptyText="$t('wgu-bglayerswitcher.emptyText')"
         />
     </v-menu>
   </div>
 </template>
 
 <script>
+import { Mapable } from '../../mixins/Mapable';
 import BgLayerList from './BgLayerList';
 
 export default {
@@ -42,6 +42,7 @@ export default {
   components: {
     'wgu-bglayerlist': BgLayerList
   },
+  mixins: [Mapable],
   props: {
     color: { type: String, required: false, default: 'red darken-3' },
     icon: { type: String, required: false, default: 'map' },
@@ -51,7 +52,28 @@ export default {
   },
   data () {
     return {
-      show: false
+      open: false,
+      layers: []
+    }
+  },
+  methods: {
+    /**
+     * This function is executed, after the map is bound (see mixins/Mapable).
+     * Bind to the layers from the OpenLayers map.
+     */
+    onMapBound () {
+      this.layers = this.map.getLayers().getArray();
+    }
+  },
+  computed: {
+    /**
+     * Reactive property to return true, when more than one OpenLayers layer is available,
+     * which is marked as 'isBaseLayer'.
+     */
+    show () {
+      return this.layers
+        .filter(layer => layer.get('isBaseLayer'))
+        .length > 1;
     }
   }
 };

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -30,8 +30,7 @@
   },
 
   "wgu-bglayerswitcher": {
-    "title": "Hintergrundkarte auswählen",
-    "emptyText": "Keine Hintergrund-Layer verfügbar."
+    "title": "Hintergrundkarte auswählen"
   },
 
   "wgu-geocoder": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,8 +30,7 @@
   },
 
   "wgu-bglayerswitcher": {
-    "title": "Change background map",
-    "emptyText": "No background layers available."
+    "title": "Change background map"
   },
 
   "wgu-geocoder": {

--- a/test/unit/specs/components/bglayerswitcher/BgLayerList.spec.js
+++ b/test/unit/specs/components/bglayerswitcher/BgLayerList.spec.js
@@ -5,7 +5,6 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 
 const moduleProps = {
-  'emptyText': 'My empty Text',
   'color': 'white',
   'dark': true,
   'selColor': 'red darken-3',
@@ -35,7 +34,6 @@ describe('bglayerswitcher/BgLayerList.vue', () => {
     });
 
     it('has correct props', () => {
-      expect(vm.emptyText).to.equal('My empty Text');
       expect(vm.color).to.equal('white');
       expect(vm.dark).to.equal(true);
       expect(vm.selColor).to.equal('red darken-3');

--- a/test/unit/specs/components/bglayerswitcher/BgLayerSwitcher.spec.js
+++ b/test/unit/specs/components/bglayerswitcher/BgLayerSwitcher.spec.js
@@ -1,5 +1,8 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import BgLayerSwitcher from '@/components/bglayerswitcher/BgLayerSwitcher';
+import OlMap from 'ol/Map';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
 
 describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
   it('is defined', () => {
@@ -8,16 +11,18 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
 
   describe('props', () => {
     let comp;
+    let vm;
     beforeEach(() => {
       comp = shallowMount(BgLayerSwitcher);
+      vm = comp.vm
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal('red darken-3');
-      expect(comp.vm.icon).to.equal('map');
-      expect(comp.vm.dark).to.equal(true);
-      expect(comp.vm.imageWidth).to.equal(152);
-      expect(comp.vm.imageHeight).to.equal(114);
+      expect(vm.color).to.equal('red darken-3');
+      expect(vm.icon).to.equal('map');
+      expect(vm.dark).to.equal(true);
+      expect(vm.imageWidth).to.equal(152);
+      expect(vm.imageHeight).to.equal(114);
     });
 
     afterEach(() => {
@@ -27,12 +32,53 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
 
   describe('data', () => {
     let comp;
+    let vm;
     beforeEach(() => {
       comp = shallowMount(BgLayerSwitcher);
+      vm = comp.vm;
     });
 
     it('has correct default data', () => {
-      expect(comp.vm.show).to.equal(false);
+      expect(vm.open).to.equal(false);
+      expect(vm.layers).to.be.an('array');
+      expect(vm.layers.length).to.eql(0);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('computed properties', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(BgLayerSwitcher);
+      vm = comp.vm;
+    });
+
+    it('only visible when more than one layer', () => {
+      const layerIn = new VectorLayer({
+        visible: true,
+        isBaseLayer: true,
+        source: new VectorSource()
+      });
+      const layerOut = new VectorLayer({
+        visible: false,
+        isBaseLayer: true,
+        source: new VectorSource()
+      });
+      const map = new OlMap({
+        layers: [layerIn]
+      });
+      vm.map = map;
+      vm.onMapBound();
+
+      expect(vm.show).to.equal(false);
+
+      map.addLayer(layerOut);
+
+      expect(vm.show).to.equal(true);
     });
 
     afterEach(() => {
@@ -42,6 +88,7 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
 
   describe('user interactions', () => {
     let comp;
+    let vm;
 
     // Remarks: The following is necessary to avoid warnings.
     //  For reasons not fully understood the test utils will fail to attach
@@ -55,18 +102,24 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
       comp = mount(BgLayerSwitcher, {
         created () {
           this.$vuetify.theme = { dark: false };
+        },
+        computed: {
+          show () {
+            return true;
+          }
         }
       });
+      vm = comp.vm;
     });
 
-    it('button click switches show', done => {
-      expect(comp.vm.show).to.equal(false);
+    it('button click switches open', done => {
+      expect(vm.open).to.equal(false);
 
       const button = comp.findComponent({ name: 'v-btn' });
       button.trigger('click');
 
-      comp.vm.$nextTick(() => {
-        expect(comp.vm.show).to.equal(true);
+      vm.$nextTick(() => {
+        expect(vm.open).to.equal(true);
         done();
       });
     });


### PR DESCRIPTION
Automatically hide the background layer switcher, if there are less than 2 base layers configured - resolves #227.