### PR TITLE
View animations

### DIFF
--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -31,6 +31,15 @@
     ]
   ],
 
+  "viewAnimation": {
+    "type": "fly",
+    "options": {
+      "duration": 3000,
+      "zoom": 15,
+      "maxZoom": 15
+    }
+  },
+
   "permalink": {
     "location": "search",
     "layers": true,
@@ -153,7 +162,6 @@
       "darkLayout": true,
       "minChars": 4,
       "queryDelay": 200,
-      "selectZoom": 16,
       "debug": false,
       "provider": "osm",
       "providerOptions": {

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -25,6 +25,15 @@
     "displayInLayerList": true
   },
 
+  "viewAnimation": {
+    "type": "fly",
+    "options": {
+      "duration": 3000,
+      "zoom": 15,
+      "maxZoom": 15
+    }
+  },
+
   "permalink": {
     "location": "hash",
     "layers": true,
@@ -210,7 +219,6 @@
       "darkLayout": true,
       "minChars": 2,
       "queryDelay": 200,
-      "selectZoom": 16,
       "debug": false,
       "provider": "osm",
       "providerOptions": {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -25,6 +25,15 @@
     "displayInLayerList": true
   },
 
+  "viewAnimation": {
+    "type": "fly",
+    "options": {
+      "duration": 3000,
+      "zoom": 15,
+      "maxZoom": 15
+    }
+  },
+
   "permalink": {
     "location": "hash",
     "layers": true,
@@ -214,7 +223,6 @@
       "darkLayout": true,
       "minChars": 2,
       "queryDelay": 200,
-      "selectZoom": 16,
       "debug": false,
       "provider": "osm",
       "providerOptions": {

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -52,7 +52,6 @@ Module identifier: `wgu-geocoder`
 | persistentHint     | Forces hint to always be visible.  | `"persistentHint": true` |
 | minChars           | Minimum number of characters which has to be entered so the query is triggered  | `"minChars": 2` |
 | queryDelay         | Delay in MS before a query is triggered | `"queryDelay": 200` |
-| selectZoom         | Zoom level which is set when a result entry is selected | `"selectZoom": 16` |
 | debug              | Boolean value to enable debug logs | `"debug": false` |
 | provider           | Key defining which geocoder provider should be used. Could be `osm`, `photon` or `opencage` | `"provider": "osm"` |
 | providerOptions    | Optional options which are passed to the geocoder provider | `"providerOptions": {"lang": "en-US", "countrycodes": "", "limit": 6}` |
@@ -63,9 +62,6 @@ Module identifier: `wgu-geolocator`
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| zoomAnimation             | Use a zoom animation. | `"zoomAnimation": true` |
-| zoomAnimationDuration     | Duration of the zoom animation. | `"zoomAnimationDuration": 2400` |
-| maxZoom                   | Max zoom level for the zoom animation. | `"maxZoom": 15` |
 | markerColor               | Fill color of the geolocation marker. | `"markerColor": blue` |
 | markerText                | Style of the geolocation marker. | `"markerText": "person_pin_circle"` |
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -23,6 +23,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
 | projectionDefs     | Array of CRS / projection definition objects compatible to proj4js | See [projectionDefs](wegue-configuration?id=projectiondefs) |
 | tileGridDefs       | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
+| viewAnimation      | Configuration object for view animations | See [viewAnimation](wegue-configuration?id=viewAnimation) |
 
 ### projectionDefs
 
@@ -127,6 +128,40 @@ Below is an example for such a configuration object:
   }
 ```
 
+### viewAnimation
+
+Map views can be animated, to zoom or pan from the current to a target location, typically after a user action takes place. This can be configured by the property `viewAnimation` in the main Wegue configuration. Per default animations are disabled.
+
+The following configurations can be set:
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| type               | The animation type. Supported values are `"none"`, `"fly"`, `"pan"` and `"bounce"`. Defaults to `"none"` | `"type": "fly"` |
+| options            | Configuration object to customize the behavior of the animation. | See the [options](wegue-configuration?id=options) below |
+
+#### options
+
+Animations can be customized by specific options. Not all options are supported by each animation type.
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| duration        | Duration of the animation in ms. Ignored if the animation type is `"none"`. Currently defaults to 3000 ms for all other animations. | `"duration": 3000` |
+| zoom | The final zoom level when moving to a coordinate or point. This setting is ignored if the destination of the animation is an extent or non-point geometry.  | `"zoom": 15` |
+| maxZoom | The maximum zoom level that the animation is allowed to zoom in on the destination. | `"maxZoom": 15` |
+
+Below is an example for an animation configuration object:
+
+```
+  "viewAnimation": {
+    "type": "fly",
+    "options": {
+      "duration": 3000,
+      "zoom": 15,
+      "maxZoom": 15
+    }
+  }
+```
+
 ## Example configuration
 
 Example configurations can be found in the `app-starter/static` directory. Below an example as used in the Demo:
@@ -157,6 +192,15 @@ Example configurations can be found in the `app-starter/static` directory. Below
     "zoomToData": true,
     "replaceData": true,
     "displayInLayerList": true
+  },
+
+  "viewAnimation": {
+    "type": "fly",
+    "options": {
+      "duration": 3000,
+      "zoom": 15,
+      "maxZoom": 15
+    }
   },
 
   "permalink": {
@@ -348,7 +392,6 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "darkLayout": true,
       "minChars": 2,
       "queryDelay": 200,
-      "selectZoom": 16,
       "debug": false,
       "provider": "osm",
       "providerOptions": {

--- a/src/components/attributeTable/AttributeTable.vue
+++ b/src/components/attributeTable/AttributeTable.vue
@@ -29,6 +29,7 @@ import { Mapable } from '../../mixins/Mapable';
 import LayerUtil from '../../util/Layer';
 import { WguEventBus } from '../../WguEventBus';
 import MapInteractionUtil from '../../util/MapInteraction';
+import ViewAnimationUtil from '../../util/ViewAnimation';
 
 export default {
   name: 'wgu-attributetable',
@@ -54,9 +55,6 @@ export default {
 
     /** If map and table should be synced */
     syncTableMapSelection: { type: Boolean, required: false, default: true },
-
-    /** The maximum zoom level when clicking on a row */
-    maxZoomOnFeature: { type: Number, required: false, default: 15 },
 
     /** A list of column names that should not be displayed. */
     forbiddenColumnNames: {
@@ -226,9 +224,7 @@ export default {
       }
 
       // zoom to feature
-      this.map.getView().fit(foundFeature.getGeometry(), {
-        maxZoom: this.maxZoomOnFeature
-      });
+      ViewAnimationUtil.to(this.map.getView(), foundFeature.getGeometry());
 
       const correspondingInteraction = MapInteractionUtil.getSelectInteraction(this.map, this.layerId);
 

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -32,10 +32,11 @@
 </template>
 
 <script>
-  import { Mapable } from '../../mixins/Mapable';
-  import { GeocoderController } from './GeocoderController';
-  import { applyTransform } from 'ol/extent';
-  import { getTransform, fromLonLat } from 'ol/proj';
+  import {Mapable} from '../../mixins/Mapable';
+  import {GeocoderController} from './GeocoderController';
+  import {applyTransform} from 'ol/extent';
+  import {getTransform, fromLonLat} from 'ol/proj';
+  import ViewAnimationUtil from '../../util/ViewAnimation';
 
   export default {
     name: 'wgu-geocoder-input',
@@ -50,7 +51,6 @@
       debug: { type: Boolean, required: false, default: false },
       minChars: { type: Number, required: false, default: 3 },
       queryDelay: { type: Number, required: false, default: 300 },
-      selectZoom: { type: Number, required: false, default: 16 },
       provider: { type: String, required: false, default: 'osm' },
       providerOptions: { type: Object, required: false, default: function () { return {}; } }
 
@@ -163,12 +163,11 @@
           // Result with bounding box.
           // bbox is in EPSG:4326, needs to be transformed to Map Projection (e.g. EPSG:3758)
           const extent = applyTransform(result.boundingbox, getTransform('EPSG:4326', mapProjection));
-          this.map.getView().fit(extent);
+          ViewAnimationUtil.to(this.map.getView(), extent);
         } else {
           // No bbox in result: center on lon/lat from result and zoom in
-          this.map.getView().setZoom(this.selectZoom);
+          ViewAnimationUtil.to(this.map.getView(), coords);
         }
-        this.map.getView().setCenter(coords);
         this.selecting = false;
       }
     },

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -32,10 +32,10 @@
 </template>
 
 <script>
-  import {Mapable} from '../../mixins/Mapable';
-  import {GeocoderController} from './GeocoderController';
-  import {applyTransform} from 'ol/extent';
-  import {getTransform, fromLonLat} from 'ol/proj';
+  import { Mapable } from '../../mixins/Mapable';
+  import { GeocoderController } from './GeocoderController';
+  import { applyTransform } from 'ol/extent';
+  import { getTransform, fromLonLat } from 'ol/proj';
   import ViewAnimationUtil from '../../util/ViewAnimation';
 
   export default {

--- a/src/components/geolocator/Geolocator.vue
+++ b/src/components/geolocator/Geolocator.vue
@@ -19,13 +19,11 @@ import { Vector as VectorSource } from 'ol/source'
 import { Fill, Style, Text } from 'ol/style';
 
 import { WguEventBus } from '../../WguEventBus'
+import ViewAnimationUtil from '../../util/ViewAnimation';
 
 export default {
   name: 'wgu-geolocator',
   props: {
-    zoomAnimation: { type: Boolean, required: false, default: true },
-    zoomAnimationDuration: { type: Number, required: false, default: 2400 },
-    maxZoom: { type: Number, required: false, default: 15 },
     markerColor: { type: String, required: false, default: 'blue' },
     markerText: { type: String, required: false, default: 'person_pin_circle' }
   },
@@ -94,16 +92,8 @@ export default {
             geolocLayer.getSource().addFeature(new Feature({ geometry: currentPosGeom }));
             this.map.addLayer(geolocLayer);
 
-            // collect zooming options
-            const zoomOpts = {
-              maxZoom: this.maxZoom,
-              padding: [50, 50, 50, 50]
-            };
-            if (this.zoomAnimation) {
-              zoomOpts.duration = this.zoomAnimationDuration;
-            }
             // zoom to geolocation position
-            this.map.getView().fit(currentPosGeom, zoomOpts);
+            ViewAnimationUtil.to(this.map.getView(), currentPosGeom);
           } else {
             console.error('The map is not defined in the getCurrentPosition callback');
           }

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -10,6 +10,7 @@
 <script>
 
 import { Mapable } from '../../mixins/Mapable';
+import ViewAnimationUtil from '../../util/ViewAnimation';
 
 export default {
   name: 'wgu-zoomtomaxextent-btn',
@@ -22,9 +23,11 @@ export default {
     onClick () {
       // derive correct initial zoom and center
       const initialCenter = this.$appConfig.mapCenter;
-      const initalZoom = this.$appConfig.mapZoom
-      this.map.getView().setCenter(initialCenter);
-      this.map.getView().setZoom(initalZoom);
+      const initalZoom = this.$appConfig.mapZoom;
+      ViewAnimationUtil.to(this.map.getView(), initialCenter, null, {
+        zoom: initalZoom,
+        maxZoom: initalZoom
+      });
     }
   }
 }

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -28,6 +28,7 @@ import ColorUtil from '../../util/Color';
 import LayerUtil from '../../util/Layer';
 import PermalinkController from './PermalinkController';
 import MapInteractionUtil from '../../util/MapInteraction';
+import ViewAnimationUtil from '../../util/ViewAnimation';
 
 export default {
   name: 'wgu-map',
@@ -351,7 +352,7 @@ export default {
         ddSource.addFeatures(event.features);
 
         if (mapDdConf.zoomToData === true) {
-          this.map.getView().fit(ddSource.getExtent());
+          ViewAnimationUtil.to(this.map.getView(), ddSource.getExtent());
         }
       }, this);
 

--- a/src/main.js
+++ b/src/main.js
@@ -135,6 +135,29 @@ const migrateAppConfig = function (appConfig) {
     });
   }
 
+  // Create warnings, if one of the module specific animation properties is declared,
+  // which are no longer supported due to global view animation configuration.
+  /* eslint-disable no-useless-escape */
+  const deprecatedAnimProps = {
+    'modules\\.wgu-geolocator\\.zoomAnimation': 'viewAnimation.type',
+    'modules\\.wgu-geolocator\\.zoomAnimationDuration': 'viewAnimation.options.duration',
+    'modules\\.wgu-geolocator\\.maxZoom': 'viewAnimation.options.maxZoom',
+    'modules\\.wgu-geocoder\\.selectZoom': 'viewAnimation.options.zoom'
+  };
+  /* eslint-enable no-useless-escape */
+
+  for (const path of configPaths) {
+    const match = Object.keys(deprecatedAnimProps).find(pattern => {
+      const regex = new RegExp('^\\.' + pattern + '$', 'g');
+      return regex.test(path);
+    });
+    if (match) {
+      console.warn('The configuration path "' + path + '" is deprecated, ' +
+        'instead declare the "viewAnimation" option and configure the "' + deprecatedAnimProps[match] +
+        '" property');
+    }
+  };
+
   return appConfig;
 }
 

--- a/src/util/Layer.js
+++ b/src/util/Layer.js
@@ -1,3 +1,5 @@
+import ViewAnimationUtil from './ViewAnimation';
+
 /**
  * Util class for OL layers
  */
@@ -48,7 +50,7 @@ const LayerUtil = {
       return;
     }
     const extent = vecLayer.getSource().getExtent();
-    olMap.getView().fit(extent);
+    ViewAnimationUtil.to(olMap.getView(), extent);
   }
 }
 

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -76,11 +76,13 @@ const PanAnimation = {
    * @param {Object} options Configuration object for the animation, supported attributes are:
    * * {Number} duration An optional animation duration.
    * * {Number} zoom An optional final zoom level.
+   * * {Number} maxZoom An optional maximal zoom level.
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
     const duration = options.duration || 3000;
     const zoom = options.zoom || view.getZoom();
+    const maxZoom = options.maxZoom || Infinity;
 
     // Pan / zoom to the location.
     function callback (complete) {
@@ -92,7 +94,7 @@ const PanAnimation = {
     view.animate({
       center: location,
       duration: duration,
-      zoom: zoom
+      zoom: Math.min(zoom, maxZoom)
     }, callback);
   },
 
@@ -103,10 +105,12 @@ const PanAnimation = {
    * @param {function(complete)} completionCallback An optional notification that the animation has completed.
    * @param {Object} options Configuration object for the animation, supported attributes are:
    * * {Number} duration An optional animation duration.
+   * * {Number} maxZoom An optional maximal zoom level.
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
     const duration = options.duration || 3000;
+    const maxZoom = options.maxZoom || Infinity;
 
     // Then zoom to the given extent.
     const resolution = view.getResolutionForExtent(extent);
@@ -115,7 +119,8 @@ const PanAnimation = {
     const location = Extent.getCenter(extent);
     this.toLocation(view, location, completionCallback, {
       duration: duration,
-      zoom: zoom
+      zoom: zoom,
+      maxZoom: maxZoom
     });
   }
 }
@@ -135,12 +140,14 @@ const FlyAnimation = {
    * * {Number} duration An optional animation duration.
    * * {Number} zoomOut An optional zoom out level.
    * * {Number} zoom An optional final zoom level.
+   * * {Number} maxZoom An optional maximal zoom level.
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
+    const duration = options.duration || 3000;
     const zoomOut = options.zoomOut || view.getZoom() - 1;
     const zoom = options.zoom || view.getZoom();
-    const duration = options.duration || 3000;
+    const maxZoom = options.maxZoom || Infinity;
 
     // The animation consist of 2 simultaneous parts:
     // Zoom out then zoom in, while moving to the center location.
@@ -169,7 +176,7 @@ const FlyAnimation = {
       zoom: zoomOut,
       duration: duration / 2
     }, {
-      zoom: zoom,
+      zoom: Math.min(zoom, maxZoom),
       duration: duration / 2
     }, callback);
   },
@@ -181,10 +188,12 @@ const FlyAnimation = {
    * @param {function(complete)} completionCallback An optional notification that the animation has completed.
    * @param {Object} options Configuration object for the animation, supported attributes are:
    * * {Number} duration An optional animation duration.
+   * * {Number} maxZoom An optional maximal zoom level.
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
     const duration = options.duration || 3000;
+    const maxZoom = options.maxZoom || Infinity;
 
     // Zoom out to have both locations visible
     const extentOut = view.calculateExtent();
@@ -200,7 +209,8 @@ const FlyAnimation = {
     this.toLocation(view, location, completionCallback, {
       duration: duration,
       zoomOut: zoomOut,
-      zoom: zoom
+      zoom: zoom,
+      maxZoom: maxZoom
     });
   }
 };
@@ -229,11 +239,13 @@ const BounceAnimation =
    * @param {Object} options Configuration object for the animation, supported attributes are:
    * * {Number} duration An optional animation duration.
    * * {Number} zoom An optional final zoom level.
+   * * {Number} maxZoom An optional maximal zoom level.
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
     const duration = options.duration || 3000;
     const zoom = options.zoom || view.getZoom();
+    const maxZoom = options.maxZoom || Infinity;
 
     // The animation consist of 2 simultaneous parts:
     // Zoom in or out, while moving to the center location.
@@ -260,7 +272,7 @@ const BounceAnimation =
     }, callback);
 
     view.animate({
-      zoom: zoom,
+      zoom: Math.min(zoom, maxZoom),
       duration: duration
     }, callback);
   },
@@ -272,10 +284,12 @@ const BounceAnimation =
    * @param {function(complete)} completionCallback An optional notification that the animation has completed.
    * @param {Object} options Configuration object for the animation, supported attributes are:
    * * {Number} duration An optional animation duration.
+   * * {Number} maxZoom An optional maximal zoom level.
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
     const duration = options.duration || 3000;
+    const maxZoom = options.maxZoom || Infinity;
 
     // Then zoom to the given extent.
     const resolution = view.getResolutionForExtent(extent);
@@ -284,7 +298,8 @@ const BounceAnimation =
     const location = Extent.getCenter(extent);
     this.toLocation(view, location, completionCallback, {
       duration: duration,
-      zoom: zoom
+      zoom: zoom,
+      maxZoom: maxZoom
     });
   }
 };

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -101,8 +101,8 @@ const NoAnimation = {
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const zoom = options.zoom || view.getZoom();
-    const maxZoom = options.maxZoom || Infinity;
+    const zoom = options.zoom ?? view.getZoom();
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // Move to the location.
     view.fit(new Point(location), {
@@ -121,7 +121,7 @@ const NoAnimation = {
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const maxZoom = options.maxZoom || Infinity;
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // Then zoom to the given extent.
     const resolution = view.getResolutionForExtent(extent);
@@ -154,9 +154,9 @@ const PanAnimation = {
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const duration = options.duration || 3000;
-    const zoom = options.zoom || view.getZoom();
-    const maxZoom = options.maxZoom || Infinity;
+    const duration = options.duration ?? 3000;
+    const zoom = options.zoom ?? view.getZoom();
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // Pan / zoom to the location.
     function callback (complete) {
@@ -183,8 +183,8 @@ const PanAnimation = {
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const duration = options.duration || 3000;
-    const maxZoom = options.maxZoom || Infinity;
+    const duration = options.duration ?? 3000;
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // Then zoom to the given extent.
     const resolution = view.getResolutionForExtent(extent);
@@ -218,10 +218,10 @@ const FlyAnimation = {
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const duration = options.duration || 3000;
-    const zoomOut = options.zoomOut || view.getZoom() - 1;
-    const zoom = options.zoom || view.getZoom();
-    const maxZoom = options.maxZoom || Infinity;
+    const duration = options.duration ?? 3000;
+    const zoomOut = options.zoomOut ?? view.getZoom() - 1;
+    const zoom = options.zoom ?? view.getZoom();
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // The animation consist of 2 simultaneous parts:
     // Zoom out then zoom in, while moving to the center location.
@@ -266,8 +266,8 @@ const FlyAnimation = {
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const duration = options.duration || 3000;
-    const maxZoom = options.maxZoom || Infinity;
+    const duration = options.duration ?? 3000;
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // Zoom out to have both locations visible
     const extentOut = view.calculateExtent();
@@ -317,9 +317,9 @@ const BounceAnimation =
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const duration = options.duration || 3000;
-    const zoom = options.zoom || view.getZoom();
-    const maxZoom = options.maxZoom || Infinity;
+    const duration = options.duration ?? 3000;
+    const zoom = options.zoom ?? view.getZoom();
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // The animation consist of 2 simultaneous parts:
     // Zoom in or out, while moving to the center location.
@@ -362,8 +362,8 @@ const BounceAnimation =
    */
   toExtent (view, extent, completionCallback, options) {
     // Set defaults if arguments are not provided.
-    const duration = options.duration || 3000;
-    const maxZoom = options.maxZoom || Infinity;
+    const duration = options.duration ?? 3000;
+    const maxZoom = options.maxZoom ?? Infinity;
 
     // Then zoom to the given extent.
     const resolution = view.getResolutionForExtent(extent);

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -1,9 +1,10 @@
 import * as Extent from 'ol/extent';
+import Point from 'ol/geom/Point';
+import Geometry from 'ol/geom/Geometry';
 import Vue from 'vue';
 
 /**
- * A collection of pan and bounce animations to zoom an
- * OpenLayers view to a given location or extent.
+ * A collection of view animations to zoom an OpenLayers view to a given location or extent.
  * Inspired by http://openlayers.org/en/latest/examples/animation.html
  */
 const ViewAnimationUtil = {
@@ -39,7 +40,29 @@ const ViewAnimationUtil = {
   },
 
   /**
-   *
+   * Zoom to the given destination.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Coordinate | ol.Extent | ol.geom.Geometry} destination
+   *  The destination coordinate, point, geometry or extent to zoom to.
+   * @param {*} completionCallback An optional notification that the animation has completed.
+   * @param {*} options Optional configuration object for the animation.
+   */
+  to (view, destination, completionCallback, options) {
+    if (destination instanceof Point) {
+      this.toLocation(view, destination.getCoordinates(), completionCallback, options);
+    } else if (destination instanceof Geometry) {
+      this.toExtent(view, destination.getExtent(), completionCallback, options);
+    } else if (Array.isArray(destination) && destination.length === 2) {
+      this.toLocation(view, destination, completionCallback, options);
+    } else if (Array.isArray(destination) && destination.length === 4) {
+      this.toExtent(view, destination, completionCallback, options);
+    } else {
+      console.error('Unsupported type for destination.');
+    }
+  },
+
+  /**
+   * Zoom to the given location.
    * @param {ol.View} view The `ol.View` of the map.
    * @param {ol.Coordinate} location The destination center point to zoom to.
    * @param {function(complete)} completionCallback An optional notification that the animation has completed.
@@ -50,7 +73,7 @@ const ViewAnimationUtil = {
   },
 
   /**
-   *
+   * Zoom to the given extent.
    * @param {ol.View} view The `ol.View` of the map.
    * @param {ol.Extent} extent The destination extent to zoom to.
    * @param {function(complete)} completionCallback An optional notification that the animation has completed.

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -212,19 +212,64 @@ const FlyAnimation = {
    * @param {function(complete)} completionCallback An optional notification that the animation has completed.
    * @param {Object} options Configuration object for the animation, supported attributes are:
    * * {Number} duration An optional animation duration.
-   * * {Number} zoomOut An optional zoom out level.
    * * {Number} zoom An optional final zoom level.
    * * {Number} maxZoom An optional maximal zoom level.
    */
   toLocation (view, location, completionCallback, options) {
     // Set defaults if arguments are not provided.
     const duration = options.duration ?? 3000;
-    const zoomOut = options.zoomOut ?? view.getZoom() - 1;
     const zoom = options.zoom ?? view.getZoom();
     const maxZoom = options.maxZoom ?? Infinity;
 
-    // The animation consist of 2 simultaneous parts:
-    // Zoom out then zoom in, while moving to the center location.
+    // Zoom out to have both locations visible.
+    const extentOut = view.calculateExtent();
+    Extent.extend(extentOut, Extent.boundingExtent([location]));
+    const resolutionOut = view.getResolutionForExtent(extentOut);
+    const zoomOut = view.getZoomForResolution(resolutionOut) - 1;
+
+    this.animate(view, location, completionCallback, duration, zoomOut, zoom, maxZoom);
+  },
+
+  /**
+   * Zoom to fit the given extent by using a "fly" animation.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Extent} extent The destination extent to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} duration An optional animation duration.
+   * * {Number} maxZoom An optional maximal zoom level.
+   */
+  toExtent (view, extent, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const duration = options.duration ?? 3000;
+    const maxZoom = options.maxZoom ?? Infinity;
+
+    // Zoom out to have both locations visible.
+    const extentOut = view.calculateExtent();
+    Extent.extend(extentOut, extent);
+    const resolutionOut = view.getResolutionForExtent(extentOut);
+    const zoomOut = view.getZoomForResolution(resolutionOut) - 1;
+
+    // Then zoom in to the given extent.
+    const resolutionIn = view.getResolutionForExtent(extent);
+    const zoom = view.getZoomForResolution(resolutionIn) - 0.2;
+
+    const location = Extent.getCenter(extent);
+    this.animate(view, location, completionCallback, duration, zoomOut, zoom, maxZoom);
+  },
+
+  /**
+   * The animation consist of 2 simultaneous parts:
+   * Zoom out then zoom in, while moving to the center location.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Coordinate} location The destination center point to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Number} duration The animation duration.
+   * @param {Number} zoomOut The zoom out level.
+   * @param {Number} zoom The final zoom level.
+   * @param {Number} maxZoom The maximal zoom level.
+   */
+  animate (view, location, completionCallback, duration, zoomOut, zoom, maxZoom) {
     var parts = 2;
     var finished = false;
 
@@ -253,39 +298,6 @@ const FlyAnimation = {
       zoom: Math.min(zoom, maxZoom),
       duration: duration / 2
     }, callback);
-  },
-
-  /**
-   * Zoom to fit the given extent by using a "fly" animation.
-   * @param {ol.View} view The `ol.View` of the map.
-   * @param {ol.Extent} extent The destination extent to zoom to.
-   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
-   * @param {Object} options Configuration object for the animation, supported attributes are:
-   * * {Number} duration An optional animation duration.
-   * * {Number} maxZoom An optional maximal zoom level.
-   */
-  toExtent (view, extent, completionCallback, options) {
-    // Set defaults if arguments are not provided.
-    const duration = options.duration ?? 3000;
-    const maxZoom = options.maxZoom ?? Infinity;
-
-    // Zoom out to have both locations visible
-    const extentOut = view.calculateExtent();
-    Extent.extend(extentOut, extent);
-    const resolutionOut = view.getResolutionForExtent(extentOut);
-    const zoomOut = view.getZoomForResolution(resolutionOut) - 1;
-
-    // Then zoom in to the given extent.
-    const resolutionIn = view.getResolutionForExtent(extent);
-    const zoom = view.getZoomForResolution(resolutionIn) - 0.2;
-
-    const location = Extent.getCenter(extent);
-    this.toLocation(view, location, completionCallback, {
-      duration: duration,
-      zoomOut: zoomOut,
-      zoom: zoom,
-      maxZoom: maxZoom
-    });
   }
 };
 

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -1,0 +1,230 @@
+import * as Extent from 'ol/extent';
+import Vue from 'vue';
+
+/**
+ * A collection of pan and bounce animations to zoom an
+ * OpenLayers view to a given location or extent.
+ * Inspired by http://openlayers.org/en/latest/examples/animation.html
+ */
+const ViewAnimationUtil = {
+  /**
+   * Returns the animation object configured in the application context.
+   * @returns The animation object.
+   */
+  getAnimation () {
+    const animations = {
+      'fly': FlyAnimation,
+      'bounce': BounceAnimation,
+      'default': BounceAnimation /* BounceAnimation */
+    };
+
+    const appConfig = Vue.prototype.$appConfig;
+    const animType = appConfig.viewAnimation?.type;
+    return animations[animType] || animations['default'];
+  },
+
+  /**
+   * Returns the configuration object for the animation. If options have been provided by the caller,
+   * these options will be returned, otherwise return the options configured in the application
+   * context.
+   * @param {Object} options Optional options for the animation.
+   * @returns An object containing the animation configuration.
+   */
+  getOptions (options) {
+    const appConfig = Vue.prototype.$appConfig;
+    return options || appConfig.viewAnimation?.options || {};
+  },
+
+  /**
+   *
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Coordinate} location The destination center point to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Optional configuration object for the animation.
+   */
+  toLocation (view, location, completionCallback, options) {
+    this.getAnimation().toLocation(view, location, completionCallback, this.getOptions(options));
+  },
+
+  /**
+   *
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Extent} extent The destination extent to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Optional configuration object for the animation.
+   */
+  toExtent (view, extent, completionCallback, options) {
+    this.getAnimation().toExtent(view, extent, completionCallback, this.getOptions(options));
+  }
+};
+
+/**
+ * A fly animation.
+ * @private
+ */
+const FlyAnimation = {
+
+  /**
+   * Zoom to the given location by using a "fly" animation.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Coordinate} location The destination center point to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} duration An optional animation duration.
+   * * {Number} zoomOut An optional zoom out level.
+   * * {Number} zoom An optional final zoom level.
+   */
+  toLocation (view, location, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const zoomOut = options.zoomOut || view.getZoom() - 1;
+    const zoom = options.zoom || view.getZoom();
+    const duration = options.duration || 3000;
+
+    // The animation consist of 2 simultaneous parts:
+    // Zoom out then zoom in, while moving to the center location.
+    var parts = 2;
+    var finished = false;
+
+    function callback (complete) {
+      --parts;
+      if (finished) {
+        return;
+      }
+      if (parts === 0 || !complete) {
+        finished = true;
+        if (completionCallback) {
+          completionCallback(complete);
+        }
+      }
+    }
+
+    view.animate({
+      center: location,
+      duration: duration
+    }, callback);
+
+    view.animate({
+      zoom: zoomOut,
+      duration: duration / 2
+    }, {
+      zoom: zoom,
+      duration: duration / 2
+    }, callback);
+  },
+
+  /**
+   * Zoom to fit the given extent by using a "fly" animation.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Extent} extent The destination extent to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} duration An optional animation duration.
+   */
+  toExtent (view, extent, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const duration = options.duration || 3000;
+
+    // Zoom out to have both locations visible
+    const extentOut = view.calculateExtent();
+    Extent.extend(extentOut, extent);
+    const resolutionOut = view.getResolutionForExtent(extentOut);
+    const zoomOut = view.getZoomForResolution(resolutionOut) - 1;
+
+    // Then zoom in to the given extent.
+    const resolutionIn = view.getResolutionForExtent(extent);
+    const zoom = view.getZoomForResolution(resolutionIn) - 0.2;
+
+    const location = Extent.getCenter(extent);
+    this.toLocation(view, location, completionCallback, {
+      duration: duration,
+      zoomOut: zoomOut,
+      zoom: zoom
+    });
+  }
+};
+
+/**
+ * A bounce animation.
+ * @private
+ */
+const BounceAnimation =
+{
+  /**
+   * An elastic easing method
+   * (from https://github.com/DmitryBaranovskiy/raphael).
+   * @private
+   */
+  elastic (t) {
+    return Math.pow(2, -10 * t) * Math.sin((t - 0.075) *
+              (2 * Math.PI) / 0.3) + 1;
+  },
+
+  /**
+   * Zoom to the given location by using a "bounce" animation.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Coordinate} location The destination center point to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} duration An optional animation duration.
+   * * {Number} zoom An optional final zoom level.
+   */
+  toLocation (view, location, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const duration = options.duration || 3000;
+    const zoom = options.zoom || view.getZoom();
+
+    // The animation consist of 2 simultaneous parts:
+    // Zoom in or out, while moving to the center location.
+    var parts = 2;
+    var finished = false;
+
+    function callback (complete) {
+      --parts;
+      if (finished) {
+        return;
+      }
+      if (parts === 0 || !complete) {
+        finished = true;
+        if (completionCallback) {
+          completionCallback(complete);
+        }
+      }
+    }
+
+    view.animate({
+      center: location,
+      duration: duration,
+      easing: this.elastic
+    }, callback);
+
+    view.animate({
+      zoom: zoom,
+      duration: duration
+    }, callback);
+  },
+
+  /**
+   * Zoom to fit the given extent by using a "bounce" animation.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Extent} extent The destination extent to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} duration An optional animation duration.
+   */
+  toExtent (view, extent, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const duration = options.duration || 3000;
+
+    // Then zoom to the given extent.
+    const resolution = view.getResolutionForExtent(extent);
+    const zoom = view.getZoomForResolution(resolution) - 0.2;
+
+    const location = Extent.getCenter(extent);
+    this.toLocation(view, location, completionCallback, {
+      duration: duration,
+      zoom: zoom
+    });
+  }
+};
+
+export default ViewAnimationUtil;

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -15,10 +15,11 @@ const ViewAnimationUtil = {
    */
   getAnimation () {
     const animations = {
+      'none': NoAnimation,
       'pan': PanAnimation,
       'fly': FlyAnimation,
       'bounce': BounceAnimation,
-      'default': PanAnimation
+      'default': NoAnimation
     };
 
     const appConfig = Vue.prototype.$appConfig;
@@ -83,6 +84,56 @@ const ViewAnimationUtil = {
     this.getAnimation().toExtent(view, extent, completionCallback, this.getOptions(options));
   }
 };
+
+/**
+ * No animation.
+ * @private
+ */
+const NoAnimation = {
+  /**
+   * Zoom to the given location by not using animations.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Coordinate} location The destination center point to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} zoom An optional final zoom level.
+   * * {Number} maxZoom An optional maximal zoom level.
+   */
+  toLocation (view, location, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const zoom = options.zoom || view.getZoom();
+    const maxZoom = options.maxZoom || Infinity;
+
+    // Move to the location.
+    view.fit(new Point(location), {
+      maxZoom: Math.min(zoom, maxZoom),
+      callback: completionCallback
+    })
+  },
+
+  /**
+   * Zoom to fit the given extentby not using animations.
+   * @param {ol.View} view The `ol.View` of the map.
+   * @param {ol.Extent} extent The destination extent to zoom to.
+   * @param {function(complete)} completionCallback An optional notification that the animation has completed.
+   * @param {Object} options Configuration object for the animation, supported attributes are:
+   * * {Number} maxZoom An optional maximal zoom level.
+   */
+  toExtent (view, extent, completionCallback, options) {
+    // Set defaults if arguments are not provided.
+    const maxZoom = options.maxZoom || Infinity;
+
+    // Then zoom to the given extent.
+    const resolution = view.getResolutionForExtent(extent);
+    const zoom = view.getZoomForResolution(resolution) - 0.2;
+
+    const location = Extent.getCenter(extent);
+    this.toLocation(view, location, completionCallback, {
+      zoom: zoom,
+      maxZoom: maxZoom
+    });
+  }
+}
 
 /**
  * A pan animation.

--- a/test/unit/specs/components/attributeTable/AttributeTable.spec.js
+++ b/test/unit/specs/components/attributeTable/AttributeTable.spec.js
@@ -69,7 +69,6 @@ describe('attributeTable/AttributeTable.vue', () => {
       expect(comp.vm.rowsPerPage).to.be.a('number');
       expect(comp.vm.tableHeight).to.be.a('number');
       expect(comp.vm.syncTableMapSelection).to.be.a('boolean');
-      expect(comp.vm.maxZoomOnFeature).to.be.a('number');
       expect(comp.vm.forbiddenColumnNames).to.be.an.instanceof(Array);
     });
 

--- a/test/unit/specs/components/geocoder/Geocoder.spec.js
+++ b/test/unit/specs/components/geocoder/Geocoder.spec.js
@@ -45,7 +45,6 @@ describe('geocoder/Geocoder.vue', () => {
       expect(vm.hideSearch).to.equal(true);
       expect(vm.minChars).to.equal(3);
       expect(vm.queryDelay).to.equal(300);
-      expect(vm.selectZoom).to.equal(16);
       expect(vm.geocoderController !== undefined).to.equal(true);
       expect(vm.geocoderController.provider instanceof OpenStreetMap).to.equal(true);
     });
@@ -61,7 +60,6 @@ describe('geocoder/Geocoder.vue', () => {
         'darkLayout': true,
         'minChars': 5,
         'queryDelay': 200,
-        'selectZoom': 17,
         'debug': false,
         'provider': 'photon'
       };
@@ -75,7 +73,6 @@ describe('geocoder/Geocoder.vue', () => {
       expect(vm.hideSearch).to.equal(true);
       expect(vm.minChars).to.equal(5);
       expect(vm.queryDelay).to.equal(200);
-      expect(vm.selectZoom).to.equal(17);
       expect(vm.geocoderController !== undefined).to.equal(true);
       expect(vm.geocoderController.provider instanceof Photon).to.equal(true);
     });
@@ -91,7 +88,6 @@ describe('geocoder/Geocoder.vue', () => {
         'darkLayout': true,
         'minChars': 6,
         'queryDelay': 200,
-        'selectZoom': 15,
         'debug': false,
         'provider': 'opencage'
       };
@@ -105,7 +101,6 @@ describe('geocoder/Geocoder.vue', () => {
       expect(vm.hideSearch).to.equal(true);
       expect(vm.minChars).to.equal(6);
       expect(vm.queryDelay).to.equal(200);
-      expect(vm.selectZoom).to.equal(15);
       expect(vm.geocoderController !== undefined).to.equal(true);
       expect(vm.geocoderController.provider instanceof OpenCage).to.equal(true);
     });
@@ -119,13 +114,11 @@ describe('geocoder/Geocoder.vue', () => {
     // let requests = [];
     const queryString = 'Heerstraße 52 bonn';
     let selectionItems;
-    const selectZoom = 15;
 
     beforeEach(() => {
       const moduleProps = {
         'target': 'toolbar',
         'queryDelay': 2,
-        'selectZoom': selectZoom,
         'provider': 'osm'
       };
       comp = shallowMount(Geocoder, {
@@ -199,7 +192,6 @@ describe('geocoder/Geocoder.vue', () => {
           vm.map.getView().getProjection());
         expect(mapCenter[0] === coords[0]);
         expect(mapCenter[1] === coords[1]);
-        expect(selectZoom === vm.map.getView().getZoom());
         done();
       });
     });

--- a/test/unit/specs/components/maxextentbutton/ZoomToMaxExtentButton.spec.js
+++ b/test/unit/specs/components/maxextentbutton/ZoomToMaxExtentButton.spec.js
@@ -2,35 +2,43 @@ import Vue from 'vue'
 import ZoomToMaxExtentButton from '@/components/maxextentbutton/ZoomToMaxExtentButton'
 import OlMap from 'ol/Map';
 import OlView from 'ol/View';
+import { shallowMount } from '@vue/test-utils';
 
 describe('maxextentbutton/ZoomToMaxExtentButton.vue', () => {
-  // Check methods
-  it('has a method onClick', () => {
-    const Constructor = Vue.extend(ZoomToMaxExtentButton);
-    const ztmeb = new Constructor({
-    }).$mount();
-    expect(typeof ztmeb.onClick).to.equal('function');
-  });
-
-  it('onClick sets correct center and zoom', () => {
-    const Constructor = Vue.extend(ZoomToMaxExtentButton);
-    const ztmeb = new Constructor({
-    }).$mount();
-
-    ztmeb.$appConfig = {
+  let comp;
+  let vm;
+  beforeEach(() => {
+    Vue.prototype.$appConfig = {
       mapCenter: [0, 0],
       mapZoom: 0
     };
-    ztmeb.map = new OlMap({
+    comp = shallowMount(ZoomToMaxExtentButton);
+    vm = comp.vm;
+  });
+
+  // Check methods
+  it('has a method onClick', () => {
+    expect(typeof vm.onClick).to.equal('function');
+  });
+
+  it('onClick sets correct center and zoom', () => {
+    vm.map = new OlMap({
       view: new OlView({
         center: [1, 1],
         zoom: 1
       })
     });
 
-    ztmeb.onClick();
-    expect(ztmeb.map.getView().getCenter()[0]).to.equal(0);
-    expect(ztmeb.map.getView().getCenter()[1]).to.equal(0);
-    expect(ztmeb.map.getView().getZoom()).to.equal(0);
+    // Remarks: This works synchronously, if no animation is used.
+    vm.onClick();
+
+    expect(vm.map.getView().getCenter()[0]).to.equal(0);
+    expect(vm.map.getView().getCenter()[1]).to.equal(0);
+    expect(vm.map.getView().getZoom()).to.equal(0);
+  });
+
+  afterEach(() => {
+    comp.destroy();
+    Vue.prototype.$appConfig = undefined;
   });
 });

--- a/test/unit/specs/util/ViewAnimation.spec.js
+++ b/test/unit/specs/util/ViewAnimation.spec.js
@@ -1,0 +1,77 @@
+import Vue from 'vue';
+import ViewAnimationUtil from '@/util/ViewAnimation';
+import View from 'ol/View';
+import {getCenter, containsExtent} from 'ol/extent';
+
+const options = {
+  duration: 20,
+  zoom: 12,
+  maxZoom: 13
+};
+
+const animTypes = ['none', 'pan', 'fly', 'bounce'];
+
+const view = new View({
+  center: [0, 0],
+  zoom: 0
+});
+
+const extent = [966000, 6341000, 967000, 6342000];
+const coordinate = [966000, 6341000];
+
+describe('ViewAnimationUtil', () => {
+  it('is defined', () => {
+    expect(typeof ViewAnimationUtil).to.not.equal(undefined);
+  });
+
+  it('has the correct functions', () => {
+    expect(typeof ViewAnimationUtil.getAnimation).to.equal('function');
+    expect(typeof ViewAnimationUtil.getOptions).to.equal('function');
+    expect(typeof ViewAnimationUtil.to).to.equal('function');
+    expect(typeof ViewAnimationUtil.toLocation).to.equal('function');
+    expect(typeof ViewAnimationUtil.toExtent).to.equal('function');
+  });
+
+  for (const animType of animTypes) {
+    describe('animation type ' + animType, () => {
+      beforeEach(() => {
+        Vue.prototype.$appConfig = {
+          viewAnimation: {type: animType, options: options}
+        };
+      });
+
+      it('zooms to extent correctly', done => {
+        ViewAnimationUtil.to(view, extent, (complete) => {
+          expect(complete).to.equal(true);
+          expect(containsExtent(view.calculateExtent(), extent)).to.equal(true);
+          expect(view.getZoom()).to.equal(options.maxZoom);
+
+          // Validate that the center points match.
+          // Due to numeric issues, the values are rounded before comparison.
+          const viewCenter = view.getCenter().map(v => Math.round(v));
+          expect(viewCenter).to.eql(getCenter(extent));
+
+          done();
+        });
+      });
+
+      it('zooms to location correctly', done => {
+        ViewAnimationUtil.to(view, coordinate, (complete) => {
+          expect(complete).to.equal(true);
+          expect(view.getZoom()).to.equal(options.zoom);
+
+          // Validate that the views center point matches the location.
+          // Due to numeric issues, the values are rounded before comparison.
+          const viewCenter = view.getCenter().map(v => Math.round(v));
+          expect(viewCenter).to.eql(coordinate);
+
+          done();
+        });
+      });
+
+      afterEach(() => {
+        Vue.prototype.$appConfig = undefined;
+      });
+    });
+  }
+});

--- a/test/unit/specs/util/ViewAnimation.spec.js
+++ b/test/unit/specs/util/ViewAnimation.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import ViewAnimationUtil from '@/util/ViewAnimation';
 import View from 'ol/View';
-import {getCenter, containsExtent} from 'ol/extent';
+import { getCenter, containsExtent } from 'ol/extent';
 
 const options = {
   duration: 20,
@@ -36,7 +36,7 @@ describe('ViewAnimationUtil', () => {
     describe('animation type ' + animType, () => {
       beforeEach(() => {
         Vue.prototype.$appConfig = {
-          viewAnimation: {type: animType, options: options}
+          viewAnimation: { type: animType, options: options }
         };
       });
 


### PR DESCRIPTION
This branch adds generalized view animations to Wegue - implements and resolves #238 proposal.

A new configuration option `viewAnimation` is introduced, to configure animations on application level, e.g.
```JSON
"viewAnimation": {
  "type": "fly",
  "options": {
    "duration": 3000,
    "zoom": 15,
    "maxZoom": 15
  }
}
```

All view zoom / animate / fit invocations are now pooled into a new utility module `ViewAnimations`.
The only exception is permalink, which initially sets the map extent and is left unchanged. 
I worked a little on the signature of `ViewAnimation.to` method, to keep matters simple and support a broad range of uses cases:
* Various types are now accepted as destination.
* Animation options are wrapped by an object, so they can be specific to each animation type. Modules can choose to override the global app-conf options, if they really need to.

```
 /**
   * Zoom to the given destination.
   * @param {ol.View} view The `ol.View` of the map.
   * @param {ol.Coordinate | ol.Extent | ol.geom.Geometry} destination
   *  The destination coordinate, point, geometry or extent to zoom to.
   * @param {*} completionCallback An optional notification that the animation has completed.
   * @param {*} options Optional configuration object for the animation.
   */
  to (view, destination, completionCallback, options) {
  }
```
  
For a first draft, ViewAnimation supports 4 animation types (`'fly'`, `'pan'`, `'bounce'` and `'none'`) and the set can be enhanced easily later on.


Regarding backward compability:
Some of the individual animation options for modules are now deprecated in favor of the `viewAnimation` option. I added migration warnings, if the following are still declared:
* `modules.wgu-geolocator.zoomAnimation`
* ` modules.wgu-geolocator.zoomAnimationDuration`
* `modules.wgu-geolocator.maxZoom`
* `modules.wgu-geocoder.selectZoom`

For more details please refer to the updated documentation and example app-conf templates.