### PR TITLE
Sidebar configuration

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -126,7 +126,7 @@
     },
     methods: {
       /**
-       * Returns the configuration object for the sidebar from app-config:
+       * Returns the configuration object for the sidebar from app-config.
        * @return {Object} Sidebar configuration object.
        */
       getSidebarConfig () {

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -14,7 +14,7 @@
 
     <slot name="wgu-after-header" />
 
-    <wgu-app-sidebar v-if="sidebarWins.length">
+    <wgu-app-sidebar v-if="sidebarWins.length" v-bind="sidebarConfig">
         <template v-for="(moduleWin, index) in sidebarWins">
           <component
             :is="moduleWin.type" :key="index" :color="baseColor"
@@ -26,9 +26,9 @@
     <slot name="wgu-before-content" />
     <v-content app>
       <v-container id="ol-map-container" fluid fill-height class="pa-0">
-         <wgu-map :color="baseColor" />
-         <!-- layer loading indicator -->
-         <wgu-maploading-status :color="baseColor" />
+        <wgu-map :color="baseColor" />
+        <!-- layer loading indicator -->
+        <wgu-maploading-status :color="baseColor" />
         <slot name="wgu-after-map"> 
         </slot>
         <!-- Portal to overlay the map content from an application module -->
@@ -98,6 +98,7 @@
     data () {
       return {
         isEmbedded: false,
+        sidebarConfig: this.getSidebarConfig(),
         floatingWins: this.getModuleWinData('floating'),
         sidebarWins: this.getModuleWinData('sidebar'),
         showCopyrightYear: Vue.prototype.$appConfig.showCopyrightYear,
@@ -124,6 +125,14 @@
       WguEventBus.$emit('app-mounted');
     },
     methods: {
+      /**
+       * Returns the configuration object for the sidebar from app-config:
+       * @return {Object} Sidebar configuration object.
+       */
+      getSidebarConfig () {
+        const appConfig = Vue.prototype.$appConfig || {};
+        return appConfig['sidebar'];
+      },
       /**
        * Determines the module window configuration objects from app-config:
        *     moduleWins: [

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -3,7 +3,8 @@
       class="wgu-app-sidebar"
       app
       clipped
-      width="400"
+      :width=width
+      :color=color
       v-model="sidebarOpen"
       >
       <!-- Forward the default slot for sidebar content. -->
@@ -14,7 +15,7 @@
           class="wgu-app-sidebar-toggle-btn px0"
           absolute
           top
-          color="white"
+          :color=color
           width="20" min-width="20" 
           @click="sidebarOpen = !sidebarOpen"> 
           <v-icon v-if="sidebarOpen">chevron_left</v-icon> 
@@ -30,8 +31,13 @@ export default {
   name: 'wgu-app-sidebar',
   data () {
     return {
-      sidebarOpen: true
+      sidebarOpen: this.visible
     }
+  },
+  props: {
+    color: {type: String, required: false, default: 'white'},
+    width: {type: Number, required: false, default: 400},
+    visible: {type: Boolean, required: false, default: true}
   }
 }
 </script>

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -11,12 +11,11 @@
       <slot></slot>
       <!-- Sidebar toggle button -->
       <template v-slot:prepend>
-        <v-btn 
+        <v-btn small
           class="wgu-app-sidebar-toggle-btn px0"
           absolute
           top
           :color=color
-          width="20" min-width="20" 
           @click="sidebarOpen = !sidebarOpen"> 
           <v-icon v-if="sidebarOpen">chevron_left</v-icon> 
           <v-icon v-else>chevron_right</v-icon> 

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -26,7 +26,7 @@
 
 <script>
 
-import { WguEventBus } from '../../WguEventBus'
+import { WguEventBus } from '../../src/WguEventBus'
 
 export default {
   name: 'wgu-app-sidebar',

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -26,6 +26,8 @@
 
 <script>
 
+import { WguEventBus } from '../../WguEventBus'
+
 export default {
   name: 'wgu-app-sidebar',
   data () {
@@ -34,9 +36,33 @@ export default {
     }
   },
   props: {
-    color: {type: String, required: false, default: 'white'},
-    width: {type: Number, required: false, default: 400},
-    visible: {type: Boolean, required: false, default: true}
+    color: { type: String, required: false, default: 'white' },
+    width: { type: Number, required: false, default: 400 },
+    visible: { type: Boolean, required: false, default: true },
+    autoScroll: { type: Boolean, required: false, default: true },
+    scrollDuration: { type: Number, required: false, default: 500 }
+  },
+  /**
+   * Initialize the sidebar.
+   */
+  created () {
+    WguEventBus.$on('sidebar-scroll', comp => {
+      this.scrollTo(comp);
+    });
+  },
+  methods: {
+    /**
+     * Scroll to a module, if the 'autoScroll' option is enabled.
+     * @param {string | HTMLElement | Vue} comp The component to scroll to.
+     */
+    scrollTo (comp) {
+      if (this.autoScroll) {
+        this.$vuetify.goTo(comp, {
+          container: '.wgu-app-sidebar > .v-navigation-drawer__content',
+          duration: this.scrollDuration
+        });
+      }
+    }
   }
 }
 </script>

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -30,17 +30,17 @@ import { WguEventBus } from '../../WguEventBus'
 
 export default {
   name: 'wgu-app-sidebar',
-  data () {
-    return {
-      sidebarOpen: this.visible
-    }
-  },
   props: {
     color: { type: String, required: false, default: 'white' },
     width: { type: Number, required: false, default: 400 },
     visible: { type: Boolean, required: false, default: true },
     autoScroll: { type: Boolean, required: false, default: true },
     scrollDuration: { type: Number, required: false, default: 500 }
+  },
+  data () {
+    return {
+      sidebarOpen: this.visible
+    }
   },
   /**
    * Initialize the sidebar.

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -37,7 +37,9 @@
   "sidebar": {
     "visible": true,
     "width": 400,
-    "color": "white"
+    "color": "white",
+    "autoScroll": true,
+    "scrollDuration": 500
   },
 
   "mapLayers": [

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -34,6 +34,12 @@
     "history": true
   },
 
+  "sidebar": {
+    "visible": true,
+    "width": 400,
+    "color": "white"
+  },
+
   "mapLayers": [
 
     {

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -138,6 +138,8 @@ The `sidebar` object supports the following properties:
 | color              | Background color of the sidebar. Defaults to white. | `"color": "white"` |
 | width              | Width of the sidebar in pixels. Defaults to 400px.  | `"width": 400` |
 | visible            | Specifies whether the sidebar appears in open or closed state on application start. Defaults to true. | `"visible": true` |
+| autoScroll         | Whether to automatically scroll the sidebar to the active module. Defaults to true. | `"autoScroll": true` |
+| scrollDuration     | Animation duration in milliseconds to automatically scroll the sidebar to the active module. Defaults to 500ms. | `"scrollDuration": 500` |
 
 Below is an example for an animation configuration object:
 
@@ -145,7 +147,9 @@ Below is an example for an animation configuration object:
   "sidebar": {
     "visible": true,
     "width": 400,
-    "color": "white"
+    "color": "white",
+    "autoScroll": true,
+    "scrollDuration": 500
   }
 ```
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -141,7 +141,7 @@ The `sidebar` object supports the following properties:
 | autoScroll         | Whether to automatically scroll the sidebar to the active module. Defaults to true. | `"autoScroll": true` |
 | scrollDuration     | Animation duration in milliseconds to automatically scroll the sidebar to the active module. Defaults to 500ms. | `"scrollDuration": 500` |
 
-Below is an example for an animation configuration object:
+Below is an example for a sidebar configuration object:
 
 ```
   "sidebar": {

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -23,6 +23,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
 | projectionDefs     | Array of CRS / projection definition objects compatible to proj4js | See [projectionDefs](wegue-configuration?id=projectiondefs) |
 | tileGridDefs       | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
+| sidebar            | Configuration object for the application sidebar. | See [sidebar](wegue-configuration?id=sidebar) |
 
 ### projectionDefs
 
@@ -124,6 +125,27 @@ Below is an example for such a configuration object:
       "de": "Deutsch"
     },
     "fallback": "en"
+  }
+```
+
+### sidebar
+The optional `sidebar` property customizes the behavior and layout of the application sidebar. Wegue's sidebar will be implicitly enabled, if at least one module is configured to use the sidebar as a window target, as specified by ```"win"="sidebar"``` - see the general section of the [Module Configuration](module-configuration?id=General).
+
+The `sidebar` object supports the following properties:
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| color              | Background color of the sidebar. Defaults to white. | `"color": "white"` |
+| width              | Width of the sidebar in pixels. Defaults to 400px.  | `"width": 400` |
+| visible            | Specifies whether the sidebar appears in open or closed state on application start. Defaults to true. | `"visible": true` |
+
+Below is an example for an animation configuration object:
+
+```
+  "sidebar": {
+    "visible": true,
+    "width": 400,
+    "color": "white"
   }
 ```
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -129,7 +129,7 @@ Below is an example for such a configuration object:
 ```
 
 ### sidebar
-The optional `sidebar` property customizes the behavior and layout of the application sidebar. Wegue's sidebar will be implicitly enabled, if at least one module is configured to use the sidebar as a window target, as specified by ```"win"="sidebar"``` - see the general section of the [Module Configuration](module-configuration?id=General).
+The optional `sidebar` property customizes the behavior and layout of the application sidebar. Wegue's sidebar will be implicitly enabled, if at least one module is configured to use the sidebar as a window target, as specified by `"win"="sidebar"` - see the general section of the [Module Configuration](module-configuration?id=General).
 
 The `sidebar` object supports the following properties:
 

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -85,7 +85,11 @@ html {
 
 .wgu-app-sidebar-toggle-btn {
   left: 100%; 
-  visibility: visible
+  visibility: visible;
+  width: 20px;
+  min-width: 20px !important;
+  height: 45px !important;
+  border-radius: 0px 4px 4px 0px;
 }
 
 /* Temporary fix for buggy word-breaking in vuetify card texts and titles.

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -76,6 +76,11 @@
         this.$emit('visibility-change', visible);
       });
     },
+    updated () {
+      if (this.show && this.win === 'sidebar') {
+        WguEventBus.$emit('sidebar-scroll', this);
+      }
+    },
     computed: {
       cardClasses () {
         return (this.win === 'floating')

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -71,7 +71,7 @@
       }
     },
     created () {
-      WguEventBus.$on(this.moduleName + 'visibility-change', visible => {
+      WguEventBus.$on(this.moduleName + '-visibility-change', visible => {
         this.show = visible;
         this.$emit('visibility-change', visible);
       });
@@ -127,7 +127,7 @@
     },
     methods: {
       toggleUi () {
-        WguEventBus.$emit(this.moduleName + 'visibility-change', !this.show)
+        WguEventBus.$emit(this.moduleName + '-visibility-change', !this.show)
       }
     }
 }

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -26,13 +26,13 @@ export default {
     }
   },
   created () {
-    WguEventBus.$on(this.moduleName + 'visibility-change', visible => {
+    WguEventBus.$on(this.moduleName + '-visibility-change', visible => {
       this.show = visible;
     });
   },
   methods: {
     toggleUi () {
-      WguEventBus.$emit(this.moduleName + 'visibility-change', !this.show)
+      WguEventBus.$emit(this.moduleName + '-visibility-change', !this.show)
     }
   }
 };


### PR DESCRIPTION
This adds a `sidebar` configuration object to the application context, to customize some basic sidebar behavior - closes #217.

```JSON
"sidebar": {
  "visible": true,
  "width": 400,
  "color": "white",
  "autoScroll": true,
  "scrollDuration": 500
}
```

A new sidebar scrolling feature has been implemented, to automatically scroll to the active module, typically after a new module becomes visible.
I also decided to rework the style of the sidebar toggle button to give it a bit nicer appearance.

The documentation has been updated accordingly.