### PR TITLE
Add support for vuetify theming

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -26,15 +26,15 @@
     <slot name="wgu-before-content" />
     <v-content app>
       <v-container id="ol-map-container" fluid fill-height class="pa-0">
-        <wgu-map color="secondary onsecondary--text" />
+        <wgu-map />
         <!-- layer loading indicator -->
-        <wgu-maploading-status color="secondary" />
+        <wgu-maploading-status />
         <slot name="wgu-after-map"> 
         </slot>
         <!-- Portal to overlay the map content from an application module -->
         <portal-target name="map-overlay" />
         <wgu-app-logo />
-        <wgu-bglayerswitcher color="secondary"/>
+        <wgu-bglayerswitcher />
       </v-container>
     </v-content>
 

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -3,7 +3,7 @@
 
     <slot name="wgu-app-begin" />
 
-    <wgu-app-header :color="baseColor">
+    <wgu-app-header color="primary">
       <!-- forward the slots of AppHeader -->
       <slot name="wgu-tb-start" slot="wgu-tb-start" />
       <slot name="wgu-tb-after-title" slot="wgu-tb-after-title" />
@@ -17,7 +17,7 @@
     <wgu-app-sidebar v-if="sidebarWins.length" v-bind="sidebarConfig">
         <template v-for="(moduleWin, index) in sidebarWins">
           <component
-            :is="moduleWin.type" :key="index" :color="baseColor"
+            :is="moduleWin.type" :key="index" color="primary"
             v-bind="moduleWin"
           />
       </template>
@@ -26,21 +26,21 @@
     <slot name="wgu-before-content" />
     <v-content app>
       <v-container id="ol-map-container" fluid fill-height class="pa-0">
-        <wgu-map :color="baseColor" />
+        <wgu-map color="primary" />
         <!-- layer loading indicator -->
-        <wgu-maploading-status :color="baseColor" />
+        <wgu-maploading-status color="primary" />
         <slot name="wgu-after-map"> 
         </slot>
         <!-- Portal to overlay the map content from an application module -->
         <portal-target name="map-overlay" />
         <wgu-app-logo />
-        <wgu-bglayerswitcher :color="baseColor"/>
+        <wgu-bglayerswitcher color="primary"/>
       </v-container>
     </v-content>
 
     <template v-for="(moduleWin, index) in floatingWins">
       <component
-        :is="moduleWin.type" :key="index" :color="baseColor"
+        :is="moduleWin.type" :key="index" color="primary"
         v-bind="moduleWin"
       />
     </template>
@@ -48,7 +48,7 @@
     <slot name="wgu-before-footer" />
 
     <wgu-app-footer
-      :color="baseColor"
+      color="primary"
       :footerTextLeft="$t('app.footerTextLeft')"
       :footerTextRight="$t('app.footerTextRight')"
       :showCopyrightYear="showCopyrightYear"
@@ -101,8 +101,7 @@
         sidebarConfig: this.getSidebarConfig(),
         floatingWins: this.getModuleWinData('floating'),
         sidebarWins: this.getModuleWinData('sidebar'),
-        showCopyrightYear: Vue.prototype.$appConfig.showCopyrightYear,
-        baseColor: Vue.prototype.$appConfig.baseColor
+        showCopyrightYear: Vue.prototype.$appConfig.showCopyrightYear
       }
     },
     created () {

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -17,7 +17,7 @@
     <wgu-app-sidebar v-if="sidebarWins.length" v-bind="sidebarConfig">
         <template v-for="(moduleWin, index) in sidebarWins">
           <component
-            :is="moduleWin.type" :key="index" color="secondary"
+            :is="moduleWin.type" :key="index"
             v-bind="moduleWin"
           />
       </template>
@@ -40,7 +40,7 @@
 
     <template v-for="(moduleWin, index) in floatingWins">
       <component
-        :is="moduleWin.type" :key="index" color="secondary"
+        :is="moduleWin.type" :key="index"
         v-bind="moduleWin"
       />
     </template>

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -17,7 +17,7 @@
     <wgu-app-sidebar v-if="sidebarWins.length" v-bind="sidebarConfig">
         <template v-for="(moduleWin, index) in sidebarWins">
           <component
-            :is="moduleWin.type" :key="index" color="primary"
+            :is="moduleWin.type" :key="index" color="secondary"
             v-bind="moduleWin"
           />
       </template>
@@ -26,21 +26,21 @@
     <slot name="wgu-before-content" />
     <v-content app>
       <v-container id="ol-map-container" fluid fill-height class="pa-0">
-        <wgu-map color="primary" />
+        <wgu-map color="secondary onsecondary--text" />
         <!-- layer loading indicator -->
-        <wgu-maploading-status color="primary" />
+        <wgu-maploading-status color="secondary" />
         <slot name="wgu-after-map"> 
         </slot>
         <!-- Portal to overlay the map content from an application module -->
         <portal-target name="map-overlay" />
         <wgu-app-logo />
-        <wgu-bglayerswitcher color="primary"/>
+        <wgu-bglayerswitcher color="secondary"/>
       </v-container>
     </v-content>
 
     <template v-for="(moduleWin, index) in floatingWins">
       <component
-        :is="moduleWin.type" :key="index" color="primary"
+        :is="moduleWin.type" :key="index" color="secondary"
         v-bind="moduleWin"
       />
     </template>

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -3,7 +3,7 @@
 
     <slot name="wgu-app-begin" />
 
-    <wgu-app-header color="primary">
+    <wgu-app-header>
       <!-- forward the slots of AppHeader -->
       <slot name="wgu-tb-start" slot="wgu-tb-start" />
       <slot name="wgu-tb-after-title" slot="wgu-tb-after-title" />
@@ -48,7 +48,6 @@
     <slot name="wgu-before-footer" />
 
     <wgu-app-footer
-      color="primary"
       :footerTextLeft="$t('app.footerTextLeft')"
       :footerTextRight="$t('app.footerTextRight')"
       :showCopyrightYear="showCopyrightYear"

--- a/app-starter/components/AppFooter.vue
+++ b/app-starter/components/AppFooter.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-footer :color="color" class="onprimary--text" app>
+  <v-footer color="primary" class="onprimary--text" app>
     <span class="wgu-footer-left" v-html="footerTextLeft"></span>
     <v-spacer></v-spacer>
     <div class="wgu-footer-right">
@@ -16,7 +16,6 @@
 export default {
   name: 'wgu-app-footer',
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     footerTextLeft: { type: String, required: true },
     footerTextRight: { type: String, required: true },
     showCopyrightYear: { type: Boolean, required: false, default: true }

--- a/app-starter/components/AppFooter.vue
+++ b/app-starter/components/AppFooter.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-footer :color="color" class="white--text" app>
+  <v-footer :color="color" class="onprimary--text" app>
     <span class="wgu-footer-left" v-html="footerTextLeft"></span>
     <v-spacer></v-spacer>
     <div class="wgu-footer-right">

--- a/app-starter/components/AppFooter.vue
+++ b/app-starter/components/AppFooter.vue
@@ -33,8 +33,8 @@ export default {
     }
   }
   /* avoid special color for links in footer */
-  .v-application a {
-    color: inherit;
+  .v-footer a {
+    color: inherit !important;
   }
 
 </style>

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app-bar
     class="wgu-app-toolbar onprimary--text"
-    :color="color"
+    color="primary"
     fixed
     app
     clipped-left
@@ -79,9 +79,7 @@ export default {
     'wgu-localeswitcher-btn': LocaleSwitcher,
     'wgu-themeswitcher-btn': ThemeSwitcher
   },
-  props: {
-    color: { type: String, required: false, default: 'red darken-3' }
-  },
+  props: {},
   data () {
     return {
       menuButtons: this.getModuleButtons('menu'),

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -40,7 +40,7 @@
         <v-icon medium>menu</v-icon>
       </v-btn>
       </template>
-      <v-list>
+      <v-list color="primary">
           <template v-for="(tbButton, index) in menuButtons">
             <v-list-item :key="index">
               <component 
@@ -109,7 +109,7 @@ export default {
           buttons.push({
             type: moduleOpts.win ? 'wgu-toggle-btn' : key + '-btn',
             moduleName: key,
-            color: target === 'toolbar' ? 'onprimary' : 'secondary',
+            color: 'onprimary',
             ...moduleOpts
           });
         }

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -45,7 +45,6 @@
             <v-list-item :key="index">
               <component 
                   :is="tbButton.type" :key="index"
-                  color="secondary"
                   v-bind="tbButton"
                />
               </v-list-item>
@@ -110,7 +109,7 @@ export default {
           buttons.push({
             type: moduleOpts.win ? 'wgu-toggle-btn' : key + '-btn',
             moduleName: key,
-            color: 'onprimary',
+            color: target === 'toolbar' ? 'onprimary' : 'secondary',
             ...moduleOpts
           });
         }

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -39,11 +39,12 @@
         <v-icon medium>menu</v-icon>
       </v-btn>
       </template>
-      <v-list :color="color">
+      <v-list>
           <template v-for="(tbButton, index) in menuButtons">
             <v-list-item :key="index">
               <component 
                   :is="tbButton.type" :key="index"
+                  color="secondary"
                   v-bind="tbButton"
                />
               </v-list-item>

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -112,8 +112,6 @@ export default {
           buttons.push({
             type: moduleOpts.win ? 'wgu-toggle-btn' : key + '-btn',
             moduleName: key,
-            // TODO For further simplifications we should revise the config property 'darkLayout'.
-            dark: moduleOpts.darkLayout,
             color: 'onprimary',
             ...moduleOpts
           });

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -109,7 +109,6 @@ export default {
           buttons.push({
             type: moduleOpts.win ? 'wgu-toggle-btn' : key + '-btn',
             moduleName: key,
-            color: 'onprimary',
             ...moduleOpts
           });
         }

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -65,6 +65,7 @@ import ZoomToMaxExtentButton from '../../src/components/maxextentbutton/ZoomToMa
 import Geocoder from '../../src/components/geocoder/Geocoder'
 import Geolocator from '../../src/components/geolocator/Geolocator'
 import LocaleSwitcher from '../../src/components/localeswitcher/LocaleSwitcher'
+import ThemeSwitcher from '../../src/components/themeswitcher/ThemeSwitcher'
 
 export default {
   name: 'wgu-app-header',
@@ -73,7 +74,8 @@ export default {
     'wgu-geocoder-btn': Geocoder,
     'wgu-zoomtomaxextent-btn': ZoomToMaxExtentButton,
     'wgu-geolocator-btn': Geolocator,
-    'wgu-localeswitcher-btn': LocaleSwitcher
+    'wgu-localeswitcher-btn': LocaleSwitcher,
+    'wgu-themeswitcher-btn': ThemeSwitcher
   },
   props: {
     color: { type: String, required: false, default: 'red darken-3' }

--- a/app-starter/components/AppHeader.vue
+++ b/app-starter/components/AppHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app-bar
-    class="wgu-app-toolbar white--text"
+    class="wgu-app-toolbar onprimary--text"
     :color="color"
     fixed
     app
@@ -34,7 +34,8 @@
     <v-menu v-if="menuButtons.length" offset-y nudge-bottom="15">
       <template v-slot:activator="{on}">
 
-      <v-btn icon dark v-on="on"
+      <v-btn icon v-on="on"
+        color="onprimary"
         :title="$t('wgu-toolbar-menu.title')">
         <v-icon medium>menu</v-icon>
       </v-btn>
@@ -113,6 +114,7 @@ export default {
             moduleName: key,
             // TODO For further simplifications we should revise the config property 'darkLayout'.
             dark: moduleOpts.darkLayout,
+            color: 'onprimary',
             ...moduleOpts
           });
         }

--- a/app-starter/components/AppSidebar.vue
+++ b/app-starter/components/AppSidebar.vue
@@ -4,7 +4,6 @@
       app
       clipped
       :width=width
-      :color=color
       v-model="sidebarOpen"
       >
       <!-- Forward the default slot for sidebar content. -->
@@ -15,10 +14,10 @@
           class="wgu-app-sidebar-toggle-btn px0"
           absolute
           top
-          :color=color
+          color="secondary"
           @click="sidebarOpen = !sidebarOpen"> 
-          <v-icon v-if="sidebarOpen">chevron_left</v-icon> 
-          <v-icon v-else>chevron_right</v-icon> 
+          <v-icon color="onsecondary" v-if="sidebarOpen">chevron_left</v-icon> 
+          <v-icon color="onsecondary" v-else>chevron_right</v-icon> 
         </v-btn>
       </template>
   </v-navigation-drawer>
@@ -31,7 +30,6 @@ import { WguEventBus } from '../../src/WguEventBus'
 export default {
   name: 'wgu-app-sidebar',
   props: {
-    color: { type: String, required: false, default: 'white' },
     width: { type: Number, required: false, default: 400 },
     visible: { type: Boolean, required: false, default: true },
     autoScroll: { type: Boolean, required: false, default: true },

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -1,6 +1,9 @@
 {
 
-  "baseColor": "green darken-3",
+  "theme": {
+    "dark": false
+  },
+
   "showCopyrightYear": true,
 
   "lang": {

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -38,8 +38,7 @@
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",
-      "icon": "help",
-      "darkLayout": true
+      "icon": "help"
     }
   }
 

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -1,7 +1,15 @@
 {
 
   "colorTheme": {
-    "dark": false
+    "dark": false,
+    "themes": {
+      "light": {
+        "primary": "#2E7D32"
+      },
+      "dark": {
+        "secondary": "#A5D6A7"
+      }
+    }
   },
 
   "showCopyrightYear": true,

--- a/app-starter/static/app-conf-minimal.json
+++ b/app-starter/static/app-conf-minimal.json
@@ -1,6 +1,6 @@
 {
 
-  "theme": {
+  "colorTheme": {
     "dark": false
   },
 

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -4,7 +4,9 @@
     "dark": false,
     "themes": {
       "light": {
-        "primary": "#EF6C00"
+        "primary": "#EF6C00",
+        "onprimary": "#FFFFFF",
+        "onsecondary": "#FFFFFF"
       },
       "dark": {
         "secondary": "#FFCC80"

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -132,14 +132,12 @@
       "target": "menu",
       "win": "floating",
       "icon": "layers",
-      "darkLayout": true,
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
       "win": "floating",
       "icon": "photo_size_select_small",
-      "darkLayout": true,
       "draggable": false,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
@@ -152,7 +150,6 @@
       "target": "menu",
       "win":"floating",
       "icon": "info",
-      "darkLayout": true,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -161,7 +158,6 @@
     },
     "wgu-geocoder": {
       "target": "toolbar",
-      "darkLayout": true,
       "minChars": 4,
       "queryDelay": 200,
       "debug": false,
@@ -174,14 +170,12 @@
       }
     },
     "wgu-zoomtomaxextent": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-maprecorder": {
       "target": "toolbar",
       "win": "floating",
       "icon": "mdi-video",
-      "darkLayout": true,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -191,12 +185,10 @@
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",
-      "icon": "help",
-      "darkLayout": true
+      "icon": "help"
     },
     "wgu-localeswitcher": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     }
   }
 

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -1,7 +1,15 @@
 {
 
   "colorTheme": {
-    "dark": false
+    "dark": false,
+    "themes": {
+      "light": {
+        "primary": "#EF6C00"
+      },
+      "dark": {
+        "secondary": "#FFCC80"
+      }
+    }
   },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -1,6 +1,8 @@
 {
 
-  "baseColor": "orange darken-3",
+  "theme": {
+    "dark": false
+  },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
   "logoSize": "100",

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -1,6 +1,6 @@
 {
 
-  "theme": {
+  "colorTheme": {
     "dark": false
   },
 

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -200,7 +200,6 @@
       "target": "menu",
       "win": "sidebar",
       "icon": "layers",
-      "darkLayout": true,
       "visible": true,
       "minimizable": true
     },
@@ -208,7 +207,6 @@
       "target": "menu",
       "win": "sidebar",
       "icon": "photo_size_select_small",
-      "darkLayout": true,
       "minimizable": true,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
@@ -221,12 +219,10 @@
       "target": "menu",
       "win": "sidebar",
       "icon": "info",
-      "darkLayout": true,
       "minimizable": true
     },
     "wgu-geocoder": {
       "target": "toolbar",
-      "darkLayout": true,
       "minChars": 2,
       "queryDelay": 200,
       "debug": false,
@@ -238,37 +234,31 @@
       }
     },
     "wgu-zoomtomaxextent": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-maprecorder": {
       "target": "toolbar",
       "win": "sidebar",
       "icon": "mdi-video",
-      "darkLayout": true,
       "minimizable": true
     },
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",
-      "icon": "help",
-      "darkLayout": true
+      "icon": "help"
     },
     "wgu-geolocator": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-attributetable": {
       "target": "menu",
       "win": "sidebar",
       "icon": "table_chart",
-      "darkLayout": true,
       "minimizable": true,
       "syncTableMapSelection": true
     },
     "wgu-localeswitcher": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     }
   }
 }

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -250,7 +250,8 @@
       "target": "toolbar"
     },
     "wgu-themeswitcher": {
-      "target": "toolbar"
+      "target": "toolbar",
+      "icon": "dark_mode"
     },
     "wgu-attributetable": {
       "target": "menu",

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -48,7 +48,6 @@
   "sidebar": {
     "visible": true,
     "width": 400,
-    "color": "white",
     "autoScroll": true,
     "scrollDuration": 500
   },
@@ -248,6 +247,9 @@
       "icon": "help"
     },
     "wgu-geolocator": {
+      "target": "toolbar"
+    },
+    "wgu-themeswitcher": {
       "target": "toolbar"
     },
     "wgu-attributetable": {

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -1,6 +1,8 @@
 {
 
-  "baseColor": "red darken-3",
+  "theme": {
+    "dark": false
+  },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
   "logoWidth": "100",

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -1,6 +1,6 @@
 {
 
-  "theme": {
+  "colorTheme": {
     "dark": false
   },
 

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -1,7 +1,30 @@
 {
 
   "theme": {
-    "dark": true
+    "dark": false,
+    "themes": {
+      "light": {
+        "primary": "#af2622",
+        "onprimary": "#ffffff",
+        "secondary": "#ec483b",
+        "onsecondary": "#ffffff",
+        "onsurface": "#bf302d",
+        "accent": "#ffffff",
+        "error": "#b00020"
+      },
+      "dark": {
+        "primary": "#272727",
+        "onprimary": "#ffffff",
+        "secondary": "#ea9b9b",
+        "onsecondary": "#272727",
+        "onsurface": "#1e1e1e",
+        "accent": "#ea9b9b",
+        "error": "#cf6679"
+      }
+    },
+    "options": {
+      "customProperties": true
+    }
   },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
@@ -192,14 +215,14 @@
       "target": "menu",
       "win": "floating",
       "icon": "layers",
-      "darkLayout": true,
+      "darkLayout": false,
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
       "win": "floating",
       "icon": "photo_size_select_small",
-      "darkLayout": true,
+      "darkLayout": false,
       "draggable": false,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
@@ -212,7 +235,7 @@
       "target": "menu",
       "win": "floating",
       "icon": "info",
-      "darkLayout": true,
+      "darkLayout": false,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -266,7 +289,7 @@
       "target": "menu",
       "win": "floating",
       "icon": "table_chart",
-      "darkLayout": true,
+      "darkLayout": false,
       "syncTableMapSelection": true
     },
     "wgu-localeswitcher": {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -1,6 +1,6 @@
 {
 
-  "theme": {
+  "colorTheme": {
     "dark": false,
     "themes": {
       "light": {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -192,14 +192,12 @@
       "target": "menu",
       "win": "floating",
       "icon": "layers",
-      "darkLayout": false,
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
       "win": "floating",
       "icon": "photo_size_select_small",
-      "darkLayout": false,
       "draggable": false,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
@@ -212,7 +210,6 @@
       "target": "menu",
       "win": "floating",
       "icon": "info",
-      "darkLayout": false,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -222,7 +219,6 @@
     },
     "wgu-geocoder": {
       "target": "toolbar",
-      "darkLayout": true,
       "minChars": 2,
       "queryDelay": 200,
       "debug": false,
@@ -234,14 +230,12 @@
       }
     },
     "wgu-zoomtomaxextent": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-maprecorder": {
       "target": "toolbar",
       "win": "floating",
       "icon": "mdi-video",
-      "darkLayout": true,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -251,27 +245,22 @@
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",
-      "icon": "help",
-      "darkLayout": true
+      "icon": "help"
     },
     "wgu-geolocator": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-themeswitcher": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-attributetable": {
       "target": "menu",
       "win": "floating",
       "icon": "table_chart",
-      "darkLayout": false,
       "syncTableMapSelection": true
     },
     "wgu-localeswitcher": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     }
   }
 }

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -21,9 +21,6 @@
         "accent": "#ea9b9b",
         "error": "#ff6f00"
       }
-    },
-    "options": {
-      "customProperties": true
     }
   },
 

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -258,6 +258,10 @@
       "target": "toolbar",
       "darkLayout": true
     },
+    "wgu-themeswitcher": {
+      "target": "toolbar",
+      "darkLayout": true
+    },
     "wgu-attributetable": {
       "target": "menu",
       "win": "floating",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -10,7 +10,7 @@
         "onsecondary": "#ffffff",
         "onsurface": "#bf302d",
         "accent": "#ffffff",
-        "error": "#b00020"
+        "error": "#ff6f00"
       },
       "dark": {
         "primary": "#272727",
@@ -19,7 +19,7 @@
         "onsecondary": "#272727",
         "onsurface": "#1e1e1e",
         "accent": "#ea9b9b",
-        "error": "#cf6679"
+        "error": "#ff6f00"
       }
     },
     "options": {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -1,6 +1,8 @@
 {
 
-  "baseColor": "red darken-3",
+  "theme": {
+    "dark": true
+  },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
   "logoWidth": "100",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -1,27 +1,7 @@
 {
 
   "colorTheme": {
-    "dark": false,
-    "themes": {
-      "light": {
-        "primary": "#af2622",
-        "onprimary": "#ffffff",
-        "secondary": "#ec483b",
-        "onsecondary": "#ffffff",
-        "onsurface": "#bf302d",
-        "accent": "#ffffff",
-        "error": "#ff6f00"
-      },
-      "dark": {
-        "primary": "#272727",
-        "onprimary": "#ffffff",
-        "secondary": "#ea9b9b",
-        "onsecondary": "#272727",
-        "onsurface": "#1e1e1e",
-        "accent": "#ea9b9b",
-        "error": "#ff6f00"
-      }
-    }
+    "dark": false
   },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -251,7 +251,8 @@
       "target": "toolbar"
     },
     "wgu-themeswitcher": {
-      "target": "toolbar"
+      "target": "toolbar",
+      "icon": "dark_mode"
     },
     "wgu-attributetable": {
       "target": "menu",

--- a/docs/module-configuration.md
+++ b/docs/module-configuration.md
@@ -23,7 +23,6 @@ The following properties can be applied to all module types:
 | icon               | Provide a customized icon for the module. | `"icon": "info"` |
 | minimizable        | Indicates whether the module window can be minimized. Only applies if a module window is present as indicated by the `win` parameter. | `"minimizable": true` |
 | backgroundImage    | Optional background image for the window header. Only applies if a module window is present as indicated by the `win` parameter. | `"backgroundImage": "static/icon/myImage.png"}` |
-| darkLayout         | Boolean value to ensure that your module element (mostly a button) is rendered bright since your basic theme color is dark.  | `"darkLayout": true` |
 | visible            | Configures the initial visiblity of a module window on application start. Only applies if a module window is present as indicated by the `win` parameter.  | `"visible": true` |
 
 The following positioning and sizing properties can be assigned to all module types, which are associated with a floating window - This is when the `win` parameter is set to `floating`:

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -40,7 +40,6 @@ Example:
       "onprimary": "#ffffff",
       "secondary": "#ec483b",
       "onsecondary": "#ffffff",
-      "accent": "#ffffff",
       "error": "#ff6f00"
     },
     "dark": {    // Dark theme configuration
@@ -48,7 +47,6 @@ Example:
       "onprimary": "#ffffff",
       "secondary": "#ea9b9b",
       "onsecondary": "#272727",
-      "accent": "#ea9b9b",
       "error": "#ff6f00"
     }
   }
@@ -60,16 +58,18 @@ Each theme configuration contains the following classes of colors:
 | Color         | Description         | Example       |
 | ------------- |:-------------------:| ------------- |
 | primary       | color for main UI components             | Header, Footer |
-| secondary     | color to accent selected parts of the UI | Floating buttons, selection controls, progress bars |
-| accent        | accent selected parts of the UI          | Mainly used to accent components in dark mode  |
-| error         | semantic color for errors                | Used in components that display error messages  |
+| secondary     | color to accent selected parts of the UI | Floating buttons, selection controls, progress bars   |
+| info          | semantic color for information           | Used in components that display information messages  |
+| success       | semantic color for success               | Used in components that display success messages      |
+| warning       | semantic color for warning               | Used in components that display warning messages      |
+| error         | semantic color for error                 | Used in components that display error messages        |
 
 
 In addition, Wegue also supports the following "on" colors:
 
 | Color         | Description         | Example       |
 | ------------- |:-------------------:| ------------- |
-| onprimary     | color over primary color   | typography/icons over primary color |
+| onprimary     | color over primary color   | typography/icons over primary color   |
 | onsecondary   | color over secondary color | typography/icons over secondary color |
 
 To simplify the theming configuration, if the "themes" property isn't configured, Wegue will fallback to the default colors in the example above. Otherwise, both the "light" and "dark" themes will be built based on the respective configured colors. The following tables specify which colors are mandatory and their respective default values.
@@ -79,19 +79,23 @@ To simplify the theming configuration, if the "themes" property isn't configured
 | ------------- |:---------:|:-------------------:|
 | primary       | yes |       - |
 | secondary     |  no | primary |
-| accent        |  no | primary |
+| information   |  no | #2196F3 |
+| success       |  no | #4CAF50 |
+| warning       |  no | #FFC107 |
 | error         |  no | #FF5252 |
-| onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color |
+| onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color     |
 | onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
 
 #### Dark theme:
 | Color         | Mandatory | Default             |
 | ------------- |:---------:|:-------------------:|
-| primary       |   - |   #272727 |
-| secondary     | yes |         - |
-| accent        |  no | secondary |
-| error         |  no |   #FF5252 |
-| onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color |
+| primary       |   - | #272727 |
+| secondary     | yes |       - |
+| information   |  no | #2196F3 |
+| success       |  no | #4CAF50 |
+| warning       |  no | #FFC107 |
+| error         |  no | #FF5252 |
+| onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color     |
 | onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
 
 Note that there is a clear asymmetry in the "light" and "dark" theme configuration. In the "light" theme, the primary color is mandatory and all the 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -40,7 +40,6 @@ Example:
       "onprimary": "#ffffff",
       "secondary": "#ec483b",
       "onsecondary": "#ffffff",
-      "onsurface": "#bf302d",
       "accent": "#ffffff",
       "error": "#ff6f00"
     },
@@ -49,7 +48,6 @@ Example:
       "onprimary": "#ffffff",
       "secondary": "#ea9b9b",
       "onsecondary": "#272727",
-      "onsurface": "#1e1e1e",
       "accent": "#ea9b9b",
       "error": "#ff6f00"
     }
@@ -73,7 +71,6 @@ In addition, Wegue also supports the following "on" colors:
 | ------------- |:---------:|:-------------------:| ------------- |
 | onprimary     | yes | color over primary color   | typography/icons over primary color |
 | onsecondary   | yes | color over secondary color | typography/icons over secondary color |
-| onsurface     | yes | color over surface color   | background for selection controls over primary color  |
 
 
 ### projectionDefs

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -94,6 +94,8 @@ To simplify the theming configuration, if the "themes" property isn't configured
 | onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color |
 | onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
 
+Note that there is a clear asymmetry in the "light" and "dark" theme configuration. In the "light" theme, the primary color is mandatory and all the 
+others are derived from that. In the "dark" theme, the predominant color must be a shade of black (to comply with the [material design specification](https://material.io/design/color/dark-theme.html)), so the primary color is locked to `#272727`. Therefore, in this case the colors are derived from the second predominant color.
 
 ### projectionDefs
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -75,6 +75,7 @@ In addition, Wegue also supports the following "on" colors:
 To simplify the theming configuration, if the "themes" property isn't configured, Wegue will fallback to the default colors in the example above. Otherwise, both the "light" and "dark" themes will be built based on the respective configured colors. The following tables specify which colors are mandatory and their respective default values.
 
 #### Light theme:
+
 | Color         | Mandatory | Default             |
 | ------------- |:---------:|:-------------------:|
 | primary       | yes |       - |
@@ -87,6 +88,7 @@ To simplify the theming configuration, if the "themes" property isn't configured
 | onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
 
 #### Dark theme:
+
 | Color         | Mandatory | Default             |
 | ------------- |:---------:|:-------------------:|
 | primary       |   - | #272727 |

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -243,7 +243,6 @@ The `sidebar` object supports the following properties:
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| color              | Background color of the sidebar. Defaults to white. | `"color": "white"` |
 | width              | Width of the sidebar in pixels. Defaults to 400px.  | `"width": 400` |
 | visible            | Specifies whether the sidebar appears in open or closed state on application start. Defaults to true. | `"visible": true` |
 | autoScroll         | Whether to automatically scroll the sidebar to the active module. Defaults to true. | `"autoScroll": true` |
@@ -255,7 +254,6 @@ Below is an example for a sidebar configuration object:
   "sidebar": {
     "visible": true,
     "width": 400,
-    "color": "white",
     "autoScroll": true,
     "scrollDuration": 500
   }

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -244,7 +244,9 @@ Example configurations can be found in the `app-starter/static` directory. Below
 ```json
 {
 
-  "baseColor": "red darken-3",
+  "colorTheme": {
+    "dark": false,
+  },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
   "logoWidth": "100",

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -8,7 +8,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| theme          | Vuetify theme configuration | See [theme](#theme) |
+| colorTheme          | Vuetify theme configuration | See [colorTheme](#colorTheme) |
 | logo               | URL to an image shown as application logo | ` "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue"`
 | logoWidth          | Width of the application logo defined in `logo` | `"logoWidth": "200"`|
 | logoHeight         | Height of the application logo defined in `logo` | `"logoWidth": "100"` |
@@ -26,13 +26,13 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | viewAnimation      | Configuration object for view animations | See [viewAnimation](wegue-configuration?id=viewAnimation) |
 | sidebar            | Configuration object for the application sidebar. | See [sidebar](wegue-configuration?id=sidebar) |
 
-### theme
+### colorTheme
 
 Wegue supports the Vuetify (light and dark) theme configuration out of the box. This property expects a json object with the same format described in the [vuetify documentation](https://vuetifyjs.com/en/features/theme/#customizing).
 
 Example:
 ```json
-"theme": {
+"colorTheme": {
   "dark": false, // Start with dark theme on
   "themes": {    // Configuration for themes
     "light": {   // Light theme configuration
@@ -57,20 +57,42 @@ Example:
 
 Each theme configuration contains the following classes of colors:
 
-| Color         | Mandatory | Description         | Example       |
-| ------------- |:---------:|:-------------------:| ------------- |
-| primary       | yes | color for main UI components             | Header, Footer |
-| secondary     | yes | color to accent selected parts of the UI | Floating buttons, selection controls, progress bars |
-| accent        | yes | accent selected parts of the UI          | Mainly used to accent components in dark mode  |
-| error         |  no | semantic color for errors                | Used in components that display error messages  |
+| Color         | Description         | Example       |
+| ------------- |:-------------------:| ------------- |
+| primary       | color for main UI components             | Header, Footer |
+| secondary     | color to accent selected parts of the UI | Floating buttons, selection controls, progress bars |
+| accent        | accent selected parts of the UI          | Mainly used to accent components in dark mode  |
+| error         | semantic color for errors                | Used in components that display error messages  |
 
 
 In addition, Wegue also supports the following "on" colors:
 
-| Color         | Mandatory | Description         | Example       |
-| ------------- |:---------:|:-------------------:| ------------- |
-| onprimary     | yes | color over primary color   | typography/icons over primary color |
-| onsecondary   | yes | color over secondary color | typography/icons over secondary color |
+| Color         | Description         | Example       |
+| ------------- |:-------------------:| ------------- |
+| onprimary     | color over primary color   | typography/icons over primary color |
+| onsecondary   | color over secondary color | typography/icons over secondary color |
+
+To simplify the theming configuration, if the "themes" property isn't configured, Wegue will fallback to the default colors in the example above. Otherwise, both the "light" and "dark" themes will be built based on the respective configured colors. The following tables specify which colors are mandatory and their respective default values.
+
+#### Light theme:
+| Color         | Mandatory | Default             |
+| ------------- |:---------:|:-------------------:|
+| primary       | yes |       - |
+| secondary     |  no | primary |
+| accent        |  no | primary |
+| error         |  no | #FF5252 |
+| onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color |
+| onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
+
+#### Dark theme:
+| Color         | Mandatory | Default             |
+| ------------- |:---------:|:-------------------:|
+| primary       |   - |   #272727 |
+| secondary     | yes |         - |
+| accent        |  no | secondary |
+| error         |  no |   #FF5252 |
+| onprimary     |  no | white if primary is a dark color. <br/> black if primary is a light color |
+| onsecondary   |  no | white if secondary is a dark color. <br/> black if secondary is a light color |
 
 
 ### projectionDefs

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -8,7 +8,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 
 | Property           | Meaning   | Example |
 |--------------------|:---------:|---------|
-| baseColor          | Main colour of the UI elements | `"baseColor": "red darken-3"` or `"baseColor": "#ff3388"` |
+| theme          | Vuetify theme configuration | See [theme](#theme) |
 | logo               | URL to an image shown as application logo | ` "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue"`
 | logoWidth          | Width of the application logo defined in `logo` | `"logoWidth": "200"`|
 | logoHeight         | Height of the application logo defined in `logo` | `"logoWidth": "100"` |
@@ -25,6 +25,56 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | tileGridDefs       | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
 | viewAnimation      | Configuration object for view animations | See [viewAnimation](wegue-configuration?id=viewAnimation) |
 | sidebar            | Configuration object for the application sidebar. | See [sidebar](wegue-configuration?id=sidebar) |
+
+### theme
+
+Wegue supports the Vuetify (light and dark) theme configuration out of the box. This property expects a json object with the same format described in the [vuetify documentation](https://vuetifyjs.com/en/features/theme/#customizing).
+
+Example:
+```json
+"theme": {
+  "dark": false, // Start with dark theme on
+  "themes": {    // Configuration for themes
+    "light": {   // Light theme configuration
+      "primary": "#af2622",
+      "onprimary": "#ffffff",
+      "secondary": "#ec483b",
+      "onsecondary": "#ffffff",
+      "onsurface": "#bf302d",
+      "accent": "#ffffff",
+      "error": "#ff6f00"
+    },
+    "dark": {    // Dark theme configuration
+      "primary": "#272727",
+      "onprimary": "#ffffff",
+      "secondary": "#ea9b9b",
+      "onsecondary": "#272727",
+      "onsurface": "#1e1e1e",
+      "accent": "#ea9b9b",
+      "error": "#ff6f00"
+    }
+  }
+},
+```
+
+Each theme configuration contains the following classes of colors:
+
+| Color         | Mandatory | Description         | Example       |
+| ------------- |:---------:|:-------------------:| ------------- |
+| primary       | yes | color for main UI components             | Header, Footer |
+| secondary     | yes | color to accent selected parts of the UI | Floating buttons, selection controls, progress bars |
+| accent        | yes | accent selected parts of the UI          | Mainly used to accent components in dark mode  |
+| error         |  no | semantic color for errors                | Used in components that display error messages  |
+
+
+In addition, Wegue also supports the following "on" colors:
+
+| Color         | Mandatory | Description         | Example       |
+| ------------- |:---------:|:-------------------:| ------------- |
+| onprimary     | yes | color over primary color   | typography/icons over primary color |
+| onsecondary   | yes | color over secondary color | typography/icons over secondary color |
+| onsurface     | yes | color over surface color   | background for selection controls over primary color  |
+
 
 ### projectionDefs
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -101,6 +101,44 @@ To simplify the theming configuration, if the "themes" property isn't configured
 Note that there is a clear asymmetry in the "light" and "dark" theme configuration. In the "light" theme, the primary color is mandatory and all the 
 others are derived from that. In the "dark" theme, the predominant color must be a shade of black (to comply with the [material design specification](https://material.io/design/color/dark-theme.html)), so the primary color is locked to `#272727`. Therefore, in this case the colors are derived from the second predominant color.
 
+#### Tips on creating a color theme
+
+In this section we offer a couple of tips on choosing colors for Wegue while meeting the [material design principles](https://material.io/design/color/the-color-system.html#color-usage-and-palettes) (hierarchy/legibility/expressiveness).
+
+For simplicity, we will prioritize the colors for the "light" theme and adapt the "dark" theme accordingly. To select colors, we advise the use of [this material design color picker](https://material.io/design/color/the-color-system.html#tools-for-picking-colors) as it shows the color tone levels (the scale underneath each palette). This scale is the key to adjust the contrast of colors for better legibility.
+
+And last but not least, building a theme is a very opinionated matter and therefore the following tips serve only as guidelines for Wegue.
+
+#### Choosing the primary color:
+
+Being the predominant color, the primary color is used to express the "story" that Wegue should tell. Our suggestion is to evaluate the nature of the geographical data that Wegue will display and then pick a color that balances well with that nature.
+
+| Light theme | Dark theme |
+| ----------- | ---------- |
+| Any tone in the color palette is valid. | As referred in the previous section ([colorTheme](#colorTheme)), the primary color in the dark theme is locked to `#272727` to meet the material design standards. |
+
+#### Choosing the secondary color:
+
+Wegue uses the secondary color to accent selected parts of the UI. Everything between selection controls, floating buttons, progress bars and any component that can be interacted with. The idea is to pick a color that has a good balance with the primary, in a way that creates a sense of hierarchy for the UI components.
+
+| Light theme | Dark theme |
+| ----------- | ---------- |
+| A tone from the same scale as the primary (for a monotone scheme). <br/> Or a "complementary", "analogous" or "triadic" color from the color picker tool. | We suggest picking the 200 tone of the primary color. Picking a light variant will contrast well with the dark interface in most cases. |
+
+#### Choosing the "on" colors:
+
+The "on" colors are additional UI colors placed over the main colors. Wegue uses this class of colors to improve the legibility of typography/iconography over primary and secondary colors.
+
+The rule of thumb is simple: 
+* if the main color is a dark tone, white or the 50 tone of the main color are safe choices;
+* if the main color is a light tone, black or the 700 tone of the main color.
+
+#### Edge cases:
+
+In some cases, the primary/secondary color may collide with the semantic colors (information, success, warning, error). This is undesirable as the UI will not be able to sufficiently stand out relevant messages from the surrounding components.
+
+The idea is the override the collided colors with a different tone that will deliver the same semantic feeling. As an example, the default color theme of Wegue is built based on a red tone, which collides with the semantic color for errors. To avoid collision, Wegue adapts the same strategy as in the [Crane material study](https://material.io/design/material-studies/crane.html#color) and sets an orange tone for errors.
+
 ### projectionDefs
 
 The property `projectionDefs` is a nested array holding several [proj4js](https://proj4js.org) compatible projection definitions. For each array element the first item is the projection code and the second item is the [proj4](https://proj4.org) definition string. For example:

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -436,14 +436,12 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "target": "menu",
       "win": "floating",
       "icon": "layers",
-      "darkLayout": true,
       "draggable": false
     },
     "wgu-measuretool": {
       "target": "menu",
       "win": "floating",
       "icon": "photo_size_select_small",
-      "darkLayout": true,
       "draggable": false,
       "strokeColor": "#c62828",
       "fillColor": "rgba(198,40,40,0.2)",
@@ -456,7 +454,6 @@ Example configurations can be found in the `app-starter/static` directory. Below
       "target": "menu",
       "win": "floating",
       "icon": "info",
-      "darkLayout": true,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -466,7 +463,6 @@ Example configurations can be found in the `app-starter/static` directory. Below
     },
     "wgu-geocoder": {
       "target": "toolbar",
-      "darkLayout": true,
       "minChars": 2,
       "queryDelay": 200,
       "debug": false,
@@ -478,14 +474,12 @@ Example configurations can be found in the `app-starter/static` directory. Below
       }
     },
     "wgu-zoomtomaxextent": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-maprecorder": {
       "target": "toolbar",
       "win": "floating",
       "icon": "mdi-video",
-      "darkLayout": true,
       "draggable": false,
       "initPos": {
         "left": 8,
@@ -495,23 +489,19 @@ Example configurations can be found in the `app-starter/static` directory. Below
     "wgu-helpwin": {
       "target": "toolbar",
       "win": "floating",
-      "icon": "help",
-      "darkLayout": true
+      "icon": "help"
     },
     "wgu-geolocator": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     },
     "wgu-attributetable": {
       "target": "menu",
       "win": "floating",
       "icon": "table_chart",
-      "darkLayout": true,
       "syncTableMapSelection": true
     },
     "wgu-localeswitcher": {
-      "target": "toolbar",
-      "darkLayout": true
+      "target": "toolbar"
     }
   }
 }

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -39,6 +39,28 @@ html {
   background-color: rgba(255,255,255,0.6) !important;
 }
 
+/*
+  TODO Review ccs colorization.
+  Used to force the onprimary color for solo fields (light theme only).
+  Components affected:
+    - wgu-geocoder-combo
+    - wgu-vector-layer-select
+
+  More on material design for solo fields:
+  https://material.io/archive/guidelines/components/text-fields.html#text-fields-field-variations
+*/
+.wgu-geocoder-combo.theme--light > .v-input__control fieldset,
+.wgu-geocoder-combo.theme--light > .v-input__control .v-icon, 
+.wgu-geocoder-combo.theme--light > .v-input__control .v-label,
+.wgu-geocoder-combo.theme--light > .v-input__control input,
+.wgu-vector-layer-select.theme--light > .v-input__control fieldset,
+.wgu-vector-layer-select.theme--light > .v-input__control .v-icon,
+.wgu-vector-layer-select.theme--light > .v-input__control .v-label,
+.wgu-vector-layer-select.theme--light > .v-input__control .v-select__selection
+{
+  color: var(--v-onprimary-base) !important;
+}
+
 /* TODO 
   Generalize the positioning concept for windows,
   this interferes with positioning and draggable settings in the app.conf */

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -49,14 +49,11 @@ html {
   More on material design for solo fields:
   https://material.io/archive/guidelines/components/text-fields.html#text-fields-field-variations
 */
-.wgu-geocoder-combo.theme--light > .v-input__control fieldset,
-.wgu-geocoder-combo.theme--light > .v-input__control .v-icon, 
-.wgu-geocoder-combo.theme--light > .v-input__control .v-label,
-.wgu-geocoder-combo.theme--light > .v-input__control input,
-.wgu-vector-layer-select.theme--light > .v-input__control fieldset,
-.wgu-vector-layer-select.theme--light > .v-input__control .v-icon,
-.wgu-vector-layer-select.theme--light > .v-input__control .v-label,
-.wgu-vector-layer-select.theme--light > .v-input__control .v-select__selection
+.wgu-solo-field.theme--light > .v-input__control fieldset,
+.wgu-solo-field.theme--light > .v-input__control .v-icon, 
+.wgu-solo-field.theme--light > .v-input__control .v-label,
+.wgu-solo-field.theme--light > .v-input__control input,
+.wgu-solo-field.theme--light > .v-input__control .v-select__selection
 {
   color: var(--v-onprimary-base) !important;
 }

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -9,6 +9,7 @@
       <v-select
         v-model="selLayer"
         color="accent"
+        :dark="dark"
         item-color="secondary"
         background-color="onsurface"
         outlined
@@ -47,6 +48,7 @@ export default {
   inheritAttrs: false,
 
   props: {
+    dark: { type: Boolean, required: false, default: true },
     icon: { type: String, required: false, default: 'table_chart' },
     syncTableMapSelection: { type: Boolean, required: false, default: false }
   },

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -9,6 +9,7 @@
       <v-select
         v-model="selLayer"
         color="accent"
+        item-color="secondary"
         background-color="onsurface"
         outlined
         class="wgu-vector-layer-select"

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -8,9 +8,16 @@
     <template v-slot:wgu-win-toolbar>
       <v-select
         v-model="selLayer"
+        color="accent"
+        background-color="onsurface"
+        outlined
         class="wgu-vector-layer-select"
         :items="displayedLayers"
 		    :item-text="item => item.get('name')"
+        :menu-props="{
+          bottom: true,
+          'offset-y': true,
+        }"
         dense
         return-object
         hide-details

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -53,7 +53,6 @@ export default {
   inheritAttrs: false,
 
   props: {
-    dark: { type: Boolean, required: false, default: true },
     icon: { type: String, required: false, default: 'table_chart' },
     syncTableMapSelection: { type: Boolean, required: false, default: false }
   },

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -9,13 +9,10 @@
       <v-select
         v-model="selLayer"
         color="accent"
-        :dark="forceDark"
         item-color="secondary"
-        :style='{
-            background: isDark
-              ? "hsla(0, 0%, 0%, 0.16)"
-              : "hsla(0, 0%, 100%, 0.04)"
-        }'
+        :dark="isPrimaryDark"
+        :solo="isDarkTheme"
+        :filled="!isDarkTheme"
         outlined
         class="wgu-vector-layer-select"
         :items="displayedLayers"
@@ -44,9 +41,9 @@
 <script>
 import ModuleCard from './../modulecore/ModuleCard';
 import { Mapable } from '../../mixins/Mapable';
+import { ColorTheme } from '../../mixins/ColorTheme';
 import VectorLayer from 'ol/layer/Vector'
 import AttributeTable from './AttributeTable';
-import Color from '../../util/Color'
 
 export default {
   name: 'wgu-attributetable-win',
@@ -63,7 +60,7 @@ export default {
       selLayer: null
     }
   },
-  mixins: [Mapable],
+  mixins: [Mapable, ColorTheme],
   components: {
     'wgu-module-card': ModuleCard,
     'wgu-attributetable': AttributeTable
@@ -112,29 +109,6 @@ export default {
           layer.get('lid') !== 'wgu-geolocator-layer'
         )
         .reverse();
-    },
-
-    // Checks if the vuetify dark theme is active
-    isDark: function () {
-      return this.$vuetify.theme.dark;
-    },
-
-    // Checks the luminance level of the primary color.
-    // This is used to set the v-combobox to dark mode if
-    // luminance is low.
-    // Remove this if the "color" property of v-combobox
-    // starts controlling the text/icon color when the
-    // field isn't focused.
-    forceDark: function () {
-      const theme = this.$vuetify.theme.currentTheme;
-
-      let primary = theme.primary;
-
-      if (typeof primary === 'object') {
-        primary = primary.base;
-      }
-
-      return Color.checkLuminance(primary);
     }
   }
 };

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -9,7 +9,7 @@
       <v-select
         v-model="selLayer"
         color="accent"
-        :dark="dark"
+        :dark="forceDark"
         item-color="secondary"
         :style='{
             background: isDark
@@ -46,6 +46,7 @@ import ModuleCard from './../modulecore/ModuleCard';
 import { Mapable } from '../../mixins/Mapable';
 import VectorLayer from 'ol/layer/Vector'
 import AttributeTable from './AttributeTable';
+import Color from '../../util/Color'
 
 export default {
   name: 'wgu-attributetable-win',
@@ -117,6 +118,24 @@ export default {
     // Checks if the vuetify dark theme is active
     isDark: function () {
       return this.$vuetify.theme.dark;
+    },
+
+    // Checks the luminance level of the primary color.
+    // This is used to set the v-combobox to dark mode if
+    // luminance is low.
+    // Remove this if the "color" property of v-combobox
+    // starts controlling the text/icon color when the
+    // field isn't focused.
+    forceDark: function () {
+      const theme = this.$vuetify.theme.currentTheme;
+
+      let primary = theme.primary;
+
+      if (typeof primary === 'object') {
+        primary = primary.base;
+      }
+
+      return Color.checkLuminance(primary);
     }
   }
 };

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -11,7 +11,11 @@
         color="accent"
         :dark="dark"
         item-color="secondary"
-        background-color="onsurface"
+        :style='{
+            background: isDark
+              ? "hsla(0, 0%, 0%, 0.16)"
+              : "hsla(0, 0%, 100%, 0.04)"
+        }'
         outlined
         class="wgu-vector-layer-select"
         :items="displayedLayers"
@@ -108,6 +112,11 @@ export default {
           layer.get('lid') !== 'wgu-geolocator-layer'
         )
         .reverse();
+    },
+
+    // Checks if the vuetify dark theme is active
+    isDark: function () {
+      return this.$vuetify.theme.dark;
     }
   }
 };

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -13,7 +13,7 @@
         :dark="isPrimaryDark"
         filled
         outlined
-        class="wgu-vector-layer-select"
+        class="wgu-vector-layer-select wgu-solo-field"
         :items="displayedLayers"
 		    :item-text="item => item.get('name')"
         :menu-props="{

--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -11,8 +11,7 @@
         color="accent"
         item-color="secondary"
         :dark="isPrimaryDark"
-        :solo="isDarkTheme"
-        :filled="!isDarkTheme"
+        filled
         outlined
         class="wgu-vector-layer-select"
         :items="displayedLayers"

--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -13,29 +13,38 @@
         :value="layer"
         v-slot:default="{ active, toggle }"
       >
-        <v-card
-          hover
-          :width="imageWidth"
-          :class="{
-            'ma-1': true,
-            'secondary': active,
-            'onsecondary--text': active
-          }"
-          @click="toggle"
-        >
-          <wgu-layerpreviewimage
-            :layer="layer"
-            :mapView="map.getView()"
+        <v-hover v-slot="{ hover }">
+          <v-card
+            hover
             :width="imageWidth"
-            :height="imageHeight"
-            :previewIcon="previewIcon"
-          />
-          <v-card-title class="caption">
-            <span class="d-inline-block text-truncate">
-              {{ layer.get('name') }}
-            </span>
-          </v-card-title>
-        </v-card> 
+            :class="{
+              'ma-1': true,
+              'secondary': active,
+              'onsecondary--text': active
+            }"
+            @click="toggle"
+          >
+            <wgu-layerpreviewimage
+              :layer="layer"
+              :mapView="map.getView()"
+              :width="imageWidth"
+              :height="imageHeight"
+              :previewIcon="previewIcon"
+            />
+            <v-card-title class="caption">
+              <span class="d-inline-block text-truncate">
+                {{ layer.get('name') }}
+              </span>
+            </v-card-title>
+
+            <v-overlay
+              absolute
+              opacity="0.2"
+              color="grey"
+              :value="hover"
+            />
+          </v-card> 
+        </v-hover>
       </v-slide-item>
     </v-slide-group>
   </v-sheet>

--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -52,10 +52,6 @@
     },
     mixins: [Mapable],
     props: {
-      color: { type: String, required: true },
-      dark: { type: Boolean, required: true },
-      selColor: { type: String, required: true },
-      selDark: { type: Boolean, required: true },
       imageWidth: { type: Number, required: true },
       imageHeight: { type: Number, required: true },
       previewIcon: { type: String, required: true }

--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -13,38 +13,29 @@
         :value="layer"
         v-slot:default="{ active, toggle }"
       >
-        <v-hover v-slot="{ hover }">
-          <v-card
-            hover
+        <v-card
+          hover
+          :width="imageWidth"
+          :class="{
+            'ma-1': true,
+            'secondary': active,
+            'onsecondary--text': active
+          }"
+          @click="toggle"
+        >
+          <wgu-layerpreviewimage
+            :layer="layer"
+            :mapView="map.getView()"
             :width="imageWidth"
-            :class="{
-              'ma-1': true,
-              'secondary': active,
-              'onsecondary--text': active
-            }"
-            @click="toggle"
-          >
-            <wgu-layerpreviewimage
-              :layer="layer"
-              :mapView="map.getView()"
-              :width="imageWidth"
-              :height="imageHeight"
-              :previewIcon="previewIcon"
-            />
-            <v-card-title class="caption">
-              <span class="d-inline-block text-truncate">
-                {{ layer.get('name') }}
-              </span>
-            </v-card-title>
-
-            <v-overlay
-              absolute
-              opacity="0.2"
-              color="grey"
-              :value="hover"
-            />
-          </v-card> 
-        </v-hover>
+            :height="imageHeight"
+            :previewIcon="previewIcon"
+          />
+          <v-card-title class="caption">
+            <span class="d-inline-block text-truncate">
+              {{ layer.get('name') }}
+            </span>
+          </v-card-title>
+        </v-card> 
       </v-slide-item>
     </v-slide-group>
   </v-sheet>

--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-sheet :color="color" :dark="dark" elevation="8">
+  <v-sheet elevation="8">
     <v-slide-group ref="slideGroup"
       mandatory
       show-arrows
@@ -14,11 +14,13 @@
         v-slot:default="{ active, toggle }"
       >
         <v-card
-          :color="active ? selColor : color"
-          :dark="active? selDark : dark"
           hover
           :width="imageWidth"
-          class="ma-1"
+          :class="{
+            'ma-1': true,
+            'secondary': active,
+            'onsecondary--text': active
+          }"
           @click="toggle"
         >
           <wgu-layerpreviewimage

--- a/src/components/bglayerswitcher/BgLayerSwitcher.vue
+++ b/src/components/bglayerswitcher/BgLayerSwitcher.vue
@@ -14,7 +14,7 @@
             fab
             :title="$t('wgu-bglayerswitcher.title')"
             >
-            <v-icon medium>{{icon}}</v-icon>
+            <v-icon color="onsecondary" medium>{{icon}}</v-icon>
           </v-btn>
         </v-sheet>
       </template>

--- a/src/components/bglayerswitcher/BgLayerSwitcher.vue
+++ b/src/components/bglayerswitcher/BgLayerSwitcher.vue
@@ -9,8 +9,7 @@
       <template v-slot:activator="{on}">
         <v-sheet class="wgu-bglayerswitcher">
           <v-btn v-on="on"
-            :color="color" 
-            :dark="dark"
+            color="secondary"
             fab
             :title="$t('wgu-bglayerswitcher.title')"
             >
@@ -21,10 +20,6 @@
       <!-- Remarks: The layerlist is wrapped by an v-if block to avoid unneccesary image 
            requests when the layerlist is not visible -->
       <wgu-bglayerlist v-if="open"
-        color="white"
-        :dark="false"
-        :selColor="color"
-        :selDark="dark"
         :previewIcon="icon"
         :imageWidth="imageWidth"
         :imageHeight="imageHeight"
@@ -44,9 +39,7 @@ export default {
   },
   mixins: [Mapable],
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     icon: { type: String, required: false, default: 'map' },
-    dark: { type: Boolean, required: false, default: true },
     imageWidth: { type: Number, required: false, default: 152 },
     imageHeight: { type: Number, required: false, default: 114 }
   },

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -5,6 +5,7 @@
     outlined
     dense
     color="accent"
+    :dark="dark"
     :style='{ display: (hideSearch ? "none" : "block" ) }'
     return-object
     hide-details

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -209,14 +209,3 @@
     }
   }
 </script>
-
-<!-- Add "scoped" attribute to limit CSS to this component only -->
-<style>
-
-  .v-input.wgu-geocoder-combo {
-    /* have to be reset here since .v-toolbar .v-input overwrites this */
-    /* padding-top: 12px;
-    margin-top: 4px; */
-  }
-
-</style>

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -201,4 +201,9 @@
     margin-top: 4px; */
   }
 
+  /* override default color for unfocused field */
+  .wgu-geocoder-combo >>> fieldset {
+    color: currentColor;
+  }
+
 </style>

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -5,7 +5,7 @@
     outlined
     dense
     color="accent"
-    :dark="dark"
+    :dark="forceDark"
     :style='{ 
       display: (hideSearch ? "none" : "block" ),
       background: isDark
@@ -45,6 +45,7 @@
   import { applyTransform } from 'ol/extent';
   import { getTransform, fromLonLat } from 'ol/proj';
   import ViewAnimationUtil from '../../util/ViewAnimation';
+  import Color from '../../util/Color'
 
   export default {
     name: 'wgu-geocoder-input',
@@ -96,6 +97,24 @@
       // Checks if the vuetify dark theme is active
       isDark: function () {
         return this.$vuetify.theme.dark;
+      },
+
+      // Checks the luminance level of the primary color.
+      // This is used to set the v-combobox to dark mode if
+      // luminance is low.
+      // Remove this if the "color" property of v-combobox
+      // starts controlling the text/icon color when the
+      // field isn't focused.
+      forceDark: function () {
+        const theme = this.$vuetify.theme.currentTheme;
+
+        let primary = theme.primary;
+
+        if (typeof primary === 'object') {
+          primary = primary.base;
+        }
+
+        return Color.checkLuminance(primary);
       }
     },
     methods: {
@@ -199,11 +218,6 @@
     /* have to be reset here since .v-toolbar .v-input overwrites this */
     /* padding-top: 12px;
     margin-top: 4px; */
-  }
-
-  /* override default color for unfocused field */
-  .wgu-geocoder-combo >>> fieldset {
-    color: currentColor;
   }
 
 </style>

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -1,34 +1,36 @@
 <template>
-<v-toolbar-items>
-    <v-combobox
-      class="wgu-geocoder-combo"
-      :style='{ display: (hideSearch ? "none" : "block" ) }'
-      return-object
-      :no-filter="noFilter"
-      v-model="selected"
-      :autofocus="autofocus"
-      :items="resultItems"
-      :label="$t('wgu-geocoder.placeHolder')"
-      :clearable="clearable"
-      :dark="dark"
-      :color="dark ? 'white': ''"
-      :persistent-hint="persistentHint"
-      :hidden="hideSearch"
-      :rounded="rounded"
-      :search-input.sync="search"
-    ></v-combobox>
+<v-toolbar-items class="d-flex align-center justify-center">
+  <v-combobox
+    class="wgu-geocoder-combo"
+    outlined
+    dense
+    color="accent"
+    :style='{ display: (hideSearch ? "none" : "block" ) }'
+    return-object
+    hide-details
+    :no-filter="noFilter"
+    v-model="selected"
+    :autofocus="autofocus"
+    :items="resultItems"
+    :label="$t('wgu-geocoder.placeHolder')"
+    :clearable="clearable"
+    :dark="dark"
+    background-color="onsurface"
+    :persistent-hint="persistentHint"
+    :hidden="hideSearch"
+    :rounded="rounded"
+    :search-input.sync="search"
+  ></v-combobox>
 
-  <v-toolbar-items>
+  <div>
 
     <v-btn @click='toggle()' icon :dark="dark"
       :title="$t('wgu-geocoder.title')">
       <v-icon medium>{{icon}}</v-icon>
     </v-btn>
 
-  </v-toolbar-items>
-  </v-toolbar-items>
-
-
+  </div>
+</v-toolbar-items>
 </template>
 
 <script>
@@ -183,8 +185,8 @@
 
   .v-input.wgu-geocoder-combo {
     /* have to be reset here since .v-toolbar .v-input overwrites this */
-    padding-top: 12px;
-    margin-top: 4px;
+    /* padding-top: 12px;
+    margin-top: 4px; */
   }
 
 </style>

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -56,7 +56,6 @@
       autofocus: { type: Boolean, required: false, default: true },
       clearable: { type: Boolean, required: false, default: true },
       color: { type: String, required: false, default: null },
-      dark: { type: Boolean, required: false, default: false },
       persistentHint: { type: Boolean, required: false, default: true },
       debug: { type: Boolean, required: false, default: false },
       minChars: { type: Number, required: false, default: 3 },

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -7,8 +7,7 @@
     dense
     color="accent"
     :dark="isPrimaryDark"
-    :solo="isDarkTheme"
-    :filled="!isDarkTheme"
+    filled
     return-object
     hide-details
     :no-filter="noFilter"

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -1,17 +1,14 @@
 <template>
 <v-toolbar-items class="d-flex align-center justify-center">
   <v-combobox
+    v-show="!hideSearch"
     class="wgu-geocoder-combo"
     outlined
     dense
     color="accent"
-    :dark="forceDark"
-    :style='{ 
-      display: (hideSearch ? "none" : "block" ),
-      background: isDark
-        ? "hsla(0, 0%, 0%, 0.16)"
-        : "hsla(0, 0%, 100%, 0.04)"
-    }'
+    :dark="isPrimaryDark"
+    :solo="isDarkTheme"
+    :filled="!isDarkTheme"
     return-object
     hide-details
     :no-filter="noFilter"
@@ -41,15 +38,15 @@
 
 <script>
   import { Mapable } from '../../mixins/Mapable';
+  import { ColorTheme } from '../../mixins/ColorTheme';
   import { GeocoderController } from './GeocoderController';
   import { applyTransform } from 'ol/extent';
   import { getTransform, fromLonLat } from 'ol/proj';
   import ViewAnimationUtil from '../../util/ViewAnimation';
-  import Color from '../../util/Color'
 
   export default {
     name: 'wgu-geocoder-input',
-    mixins: [Mapable],
+    mixins: [Mapable, ColorTheme],
     props: {
       icon: { type: String, required: false, default: 'search' },
       rounded: { type: Boolean, required: false, default: true },
@@ -91,29 +88,6 @@
         });
 
         return items;
-      },
-
-      // Checks if the vuetify dark theme is active
-      isDark: function () {
-        return this.$vuetify.theme.dark;
-      },
-
-      // Checks the luminance level of the primary color.
-      // This is used to set the v-combobox to dark mode if
-      // luminance is low.
-      // Remove this if the "color" property of v-combobox
-      // starts controlling the text/icon color when the
-      // field isn't focused.
-      forceDark: function () {
-        const theme = this.$vuetify.theme.currentTheme;
-
-        let primary = theme.primary;
-
-        if (typeof primary === 'object') {
-          primary = primary.base;
-        }
-
-        return Color.checkLuminance(primary);
       }
     },
     methods: {

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -25,7 +25,7 @@
   <div>
 
     <v-btn @click='toggle()'
-      :color="color"
+      color="onprimary"
       icon
       :title="$t('wgu-geocoder.title')">
       <v-icon medium>{{icon}}</v-icon>
@@ -51,7 +51,6 @@
       rounded: { type: Boolean, required: false, default: true },
       autofocus: { type: Boolean, required: false, default: true },
       clearable: { type: Boolean, required: false, default: true },
-      color: { type: String, required: false, default: null },
       persistentHint: { type: Boolean, required: false, default: true },
       debug: { type: Boolean, required: false, default: false },
       minChars: { type: Number, required: false, default: 3 },

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -14,7 +14,6 @@
     :items="resultItems"
     :label="$t('wgu-geocoder.placeHolder')"
     :clearable="clearable"
-    :dark="dark"
     background-color="onsurface"
     :persistent-hint="persistentHint"
     :hidden="hideSearch"
@@ -24,7 +23,9 @@
 
   <div>
 
-    <v-btn @click='toggle()' icon :dark="dark"
+    <v-btn @click='toggle()'
+      :color="color"
+      icon
       :title="$t('wgu-geocoder.title')">
       <v-icon medium>{{icon}}</v-icon>
     </v-btn>
@@ -48,6 +49,7 @@
       rounded: { type: Boolean, required: false, default: true },
       autofocus: { type: Boolean, required: false, default: true },
       clearable: { type: Boolean, required: false, default: true },
+      color: { type: String, required: false, default: null },
       dark: { type: Boolean, required: false, default: false },
       persistentHint: { type: Boolean, required: false, default: true },
       debug: { type: Boolean, required: false, default: false },

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -6,7 +6,12 @@
     dense
     color="accent"
     :dark="dark"
-    :style='{ display: (hideSearch ? "none" : "block" ) }'
+    :style='{ 
+      display: (hideSearch ? "none" : "block" ),
+      background: isDark
+        ? "hsla(0, 0%, 0%, 0.16)"
+        : "hsla(0, 0%, 100%, 0.04)"
+    }'
     return-object
     hide-details
     :no-filter="noFilter"
@@ -15,7 +20,6 @@
     :items="resultItems"
     :label="$t('wgu-geocoder.placeHolder')"
     :clearable="clearable"
-    background-color="onsurface"
     :persistent-hint="persistentHint"
     :hidden="hideSearch"
     :rounded="rounded"
@@ -87,6 +91,11 @@
         });
 
         return items;
+      },
+
+      // Checks if the vuetify dark theme is active
+      isDark: function () {
+        return this.$vuetify.theme.dark;
       }
     },
     methods: {

--- a/src/components/geocoder/Geocoder.vue
+++ b/src/components/geocoder/Geocoder.vue
@@ -2,7 +2,7 @@
 <v-toolbar-items class="d-flex align-center justify-center">
   <v-combobox
     v-show="!hideSearch"
-    class="wgu-geocoder-combo"
+    class="wgu-geocoder-combo wgu-solo-field"
     outlined
     dense
     color="accent"

--- a/src/components/geolocator/Geolocator.vue
+++ b/src/components/geolocator/Geolocator.vue
@@ -1,7 +1,7 @@
 <template>
 <span>
    <v-btn @click="geolocateUserAndShowMarkerOnMap" icon
-      :color="color"
+      color="onprimary"
       :title="$t('wgu-geolocator.title')">
       <v-icon v-if='this.isSearchingForGeolocation'>update</v-icon>
       <v-icon v-else-if='this.isGeolocationAPIAvailable && (!this.isGeolocationFound)'>location_searching</v-icon>
@@ -25,7 +25,6 @@ import ViewAnimationUtil from '../../util/ViewAnimation';
 export default {
   name: 'wgu-geolocator',
   props: {
-    color: { type: String, required: false, default: null },
     markerColor: { type: String, required: false, default: 'blue' },
     markerText: { type: String, required: false, default: 'person_pin_circle' }
   },

--- a/src/components/geolocator/Geolocator.vue
+++ b/src/components/geolocator/Geolocator.vue
@@ -1,6 +1,7 @@
 <template>
 <span>
-   <v-btn @click="geolocateUserAndShowMarkerOnMap" icon dark
+   <v-btn @click="geolocateUserAndShowMarkerOnMap" icon
+      :color="color"
       :title="$t('wgu-geolocator.title')">
       <v-icon v-if='this.isSearchingForGeolocation'>update</v-icon>
       <v-icon v-else-if='this.isGeolocationAPIAvailable && (!this.isGeolocationFound)'>location_searching</v-icon>
@@ -24,6 +25,7 @@ import ViewAnimationUtil from '../../util/ViewAnimation';
 export default {
   name: 'wgu-geolocator',
   props: {
+    color: { type: String, required: false, default: null },
     markerColor: { type: String, required: false, default: 'blue' },
     markerText: { type: String, required: false, default: 'person_pin_circle' }
   },

--- a/src/components/helpwin/HelpWin.vue
+++ b/src/components/helpwin/HelpWin.vue
@@ -16,7 +16,7 @@
     </v-card-text>
 
     <v-card-actions>
-      <a class="info-link red--text darken3"
+      <a class="info-link"
         :href="$t('wgu-helpwin.infoLinkUrl')" target="_blank" v-if="$t('wgu-helpwin.infoLinkUrl')">
         {{ $t('wgu-helpwin.infoLinkText') || $t('wgu-helpwin.infoLinkUrl') }}
         </a>

--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <table class="wgu-coordstable" v-if="coordRows" :style="tableStyles">
+  <table class="wgu-coordstable" v-if="coordRows" style="border: 2px solid var(--v-secondary-base);">
     <thead>
       <tr>
         <th v-for="(entry, key) in coordRows" :key="key">
@@ -23,15 +23,12 @@
 
 <script>
 
-import vColors from 'vuetify/es5/util/colors';
-import ColorUtil from '../../util/Color';
 import { transform } from 'ol/proj.js';
 import { toStringHDMS } from 'ol/coordinate';
 
 export default {
   name: 'wgu-coords-table',
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     coordsData: { type: Object },
     showMapPos: { type: Boolean, required: false, default: true },
     showWgsPos: { type: Boolean, required: false, default: true },
@@ -40,23 +37,6 @@ export default {
   data: function () {
     return {
       coordRows: null
-    }
-  },
-  computed: {
-    tableStyles () {
-      // calculate border color of tables due to current color property
-      let borderColor = this.color;
-      if (!ColorUtil.isCssColor(this.color)) {
-        let [colorName, colorModifier] = this.color.toString().trim().split(' ', 2);
-        borderColor = vColors[colorName];
-        if (colorModifier) {
-          colorModifier = colorModifier.replace('-', '');
-          borderColor = vColors[colorName][colorModifier];
-        }
-      }
-      return {
-        'border': '2px solid ' + borderColor
-      };
     }
   },
   methods: {

--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -1,6 +1,14 @@
 <template>
 
-  <table class="wgu-coordstable" v-if="coordRows" style="border: 2px solid var(--v-secondary-base);">
+  <table 
+    :class="{
+      'wgu-coordstable': true,
+      'light-theme': !isDark,
+      'dark-theme': isDark
+    }"
+    v-if="coordRows"
+    style="border: 2px solid var(--v-secondary-base);"
+  >
     <thead>
       <tr>
         <th v-for="(entry, key) in coordRows" :key="key">
@@ -37,6 +45,14 @@ export default {
   data: function () {
     return {
       coordRows: null
+    }
+  },
+  computed: {
+    /**
+     * Checks if color theme is in dark mode
+     */
+    isDark: function () {
+      return this.$vuetify.theme.dark;
     }
   },
   methods: {
@@ -82,11 +98,14 @@ table.wgu-coordstable {
 
 .wgu-coordstable table {
   border-radius: 3px;
-  background-color: #fff;
 }
 
-.wgu-coordstable td {
-  background-color: #f9f9f9;
+.wgu-coordstable.dark-theme td {
+  background-color: hsla(0, 0%, 98%, 0.03);
+}
+
+.wgu-coordstable.light-theme td {
+  background-color: hsla(0, 0%, 98%, 1);
 }
 
 .wgu-coordstable tr {

--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -3,8 +3,8 @@
   <table 
     :class="{
       'wgu-coordstable': true,
-      'light-theme': !isDark,
-      'dark-theme': isDark
+      'light-theme': !isDarkTheme,
+      'dark-theme': isDarkTheme
     }"
     v-if="coordRows"
     style="border: 2px solid var(--v-secondary-base);"
@@ -33,9 +33,11 @@
 
 import { transform } from 'ol/proj.js';
 import { toStringHDMS } from 'ol/coordinate';
+import { ColorTheme } from '../../mixins/ColorTheme';
 
 export default {
   name: 'wgu-coords-table',
+  mixins: [ColorTheme],
   props: {
     coordsData: { type: Object },
     showMapPos: { type: Boolean, required: false, default: true },
@@ -45,14 +47,6 @@ export default {
   data: function () {
     return {
       coordRows: null
-    }
-  },
-  computed: {
-    /**
-     * Checks if color theme is in dark mode
-     */
-    isDark: function () {
-      return this.$vuetify.theme.dark;
     }
   },
   methods: {

--- a/src/components/infoclick/InfoClickWin.vue
+++ b/src/components/infoclick/InfoClickWin.vue
@@ -4,7 +4,6 @@
     :moduleName="moduleName"
     class="wgu-infoclick-win"
     :icon="icon"
-    :color="color"
     v-on:visibility-change="show">
 
     <!-- Show feature properties and position tables -->
@@ -17,10 +16,10 @@
         </v-card-text>
 
         <!-- feature property grid -->
-        <wgu-property-table :properties="attributeData" :color="color" />
+        <wgu-property-table :properties="attributeData" />
 
         <!-- click coodinate info grid -->
-        <wgu-coords-table :coordsData="coordsData" :color="color" />
+        <wgu-coords-table :coordsData="coordsData" />
 
       </v-card-title>
 
@@ -47,7 +46,7 @@
 
       <v-card-actions>
         <v-btn
-          text :color="color"
+          text color="secondary"
           v-if="this.attributeData && this.attributeData[mediaInfoLinkUrlProp]"
           :href="this.attributeData[mediaInfoLinkUrlProp]"
           target="_blank"
@@ -76,7 +75,6 @@ export default {
     'wgu-coords-table': CoordsTable
   },
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     icon: { type: String, required: false, default: 'info' },
     showMedia: { type: Boolean, required: false, default: false },
     // below props only have an effect if showMedia=true

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -1,6 +1,14 @@
 <template>
 
-  <table class="wgu-proptable" v-if="show" style="border: 2px solid var(--v-secondary-base);">
+  <table 
+  :class="{
+      'wgu-proptable': true,
+      'light-theme': !isDark,
+      'dark-theme': isDark
+    }"
+    v-if="show"
+    style="border: 2px solid var(--v-secondary-base);"
+  >
     <thead>
       <tr>
         <th v-for="(entry, key) in properties" :key="key">
@@ -34,6 +42,12 @@ export default {
      */
     show () {
       return this.properties && Object.keys(this.properties).length;
+    },
+    /**
+     * Checks if color theme is in dark mode
+     */
+    isDark: function () {
+      return this.$vuetify.theme.dark;
     }
   }
 };
@@ -48,8 +62,12 @@ table.wgu-proptable {
  width: 100%;
 }
 
-.wgu-proptable td {
- background-color: #f9f9f9;
+.wgu-proptable.dark-theme td {
+  background-color: hsla(0, 0%, 98%, 0.03);
+}
+
+.wgu-proptable.light-theme td {
+  background-color: hsla(0, 0%, 98%, 1);
 }
 
 .wgu-proptable tr {

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -3,8 +3,8 @@
   <table 
   :class="{
       'wgu-proptable': true,
-      'light-theme': !isDark,
-      'dark-theme': isDark
+      'light-theme': !isDarkTheme,
+      'dark-theme': isDarkTheme
     }"
     v-if="show"
     style="border: 2px solid var(--v-secondary-base);"
@@ -30,9 +30,11 @@
 </template>
 
 <script>
+import { ColorTheme } from '../../mixins/ColorTheme';
 
 export default {
   name: 'wgu-property-table',
+  mixins: [ColorTheme],
   props: {
     properties: { type: Object }
   },
@@ -42,12 +44,6 @@ export default {
      */
     show () {
       return this.properties && Object.keys(this.properties).length;
-    },
-    /**
-     * Checks if color theme is in dark mode
-     */
-    isDark: function () {
-      return this.$vuetify.theme.dark;
     }
   }
 };

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <table class="wgu-proptable" v-if="show" :style="tableStyles">
+  <table class="wgu-proptable" v-if="show" style="border: 2px solid var(--v-secondary-base);">
     <thead>
       <tr>
         <th v-for="(entry, key) in properties" :key="key">
@@ -23,31 +23,12 @@
 
 <script>
 
-import vColors from 'vuetify/es5/util/colors';
-import ColorUtil from '../../util/Color';
-
 export default {
   name: 'wgu-property-table',
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     properties: { type: Object }
   },
   computed: {
-    tableStyles () {
-      // calculate border color of tables due to current color property
-      let borderColor = this.color;
-      if (!ColorUtil.isCssColor(this.color)) {
-        let [colorName, colorModifier] = this.color.toString().trim().split(' ', 2);
-        borderColor = vColors[colorName];
-        if (colorModifier) {
-          colorModifier = colorModifier.replace('-', '');
-          borderColor = vColors[colorName][colorModifier];
-        }
-      }
-      return {
-        'border': '2px solid ' + borderColor
-      };
-    },
     /**
      * Display the table control only, if there are properties to show.
      */

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -5,16 +5,18 @@
       v-for="layer in displayedLayers" 
       :key="layer.lid" 
       @click="onItemClick(layer)">
-      <input type="checkbox" 
-        :key="layer.lid" 
-        class="wgu-layer-viz-cb"
-        :checked="layer.getVisible()"
-      />
-      <v-list-item-content class="black--text">
+      <v-list-item-action>
+        <v-checkbox
+          color="secondary"
+          hide-details
+          :input-value="layer.getVisible()"
+        />
+      </v-list-item-action>
+       <v-list-item-content>
           <v-list-item-title>
             {{ layer.get('name') }}
           </v-list-item-title>
-      </v-list-item-content>
+       </v-list-item-content>
     </v-list-item>
   </v-list>
 
@@ -64,11 +66,3 @@
     }
   }
 </script>
-
-<style>
-
-  .wgu-layer-viz-cb {
-    width: 45px;
-  }
-
-</style>

--- a/src/components/localeswitcher/LocaleSwitcher.vue
+++ b/src/components/localeswitcher/LocaleSwitcher.vue
@@ -41,8 +41,7 @@ export default {
   name: 'wgu-localeswitcher',
   props: {
     icon: { type: String, required: false, default: 'language' },
-    color: { type: String, required: false, default: null },
-    dark: { type: Boolean, required: false, default: false }
+    color: { type: String, required: false, default: null }
   },
   data () {
     return {

--- a/src/components/localeswitcher/LocaleSwitcher.vue
+++ b/src/components/localeswitcher/LocaleSwitcher.vue
@@ -19,7 +19,7 @@
           v-for="langCode in Object.keys(lang)" 
           :key="langCode" 
           @click="onItemClick(langCode)">
-          <v-list-item-content class="black--text">
+          <v-list-item-content>
             <v-list-item-title>
               {{ lang[langCode] }} ({{ langCode }})
             </v-list-item-title>

--- a/src/components/localeswitcher/LocaleSwitcher.vue
+++ b/src/components/localeswitcher/LocaleSwitcher.vue
@@ -2,16 +2,21 @@
   <v-menu offset-y nudge-bottom="15"
       transition="scale-transition"
       v-model="show">
-      <template v-slot:activator="{on}">
-        <v-btn-toggle borderless dense 
-          background-color="transparent" :dark="dark"
+      <template v-slot:activator="{ on, attrs}">
+        <v-btn
+          borderless
+          dense 
+          :color="color"
+          background-color="transparent" 
           :title="$t('wgu-localeswitcher.title')"
-          v-model="show">
-          <v-btn class="ma-2" icon :value="true" v-on="on" >
-            <v-icon class="mr-1" medium>{{icon}}</v-icon>
-            {{ $i18n.locale }} 
-          </v-btn>
-        </v-btn-toggle>
+          class="ma-2"
+          icon
+          v-on="on"
+          v-bind="attrs"
+        >
+          <v-icon class="mr-1" medium>{{icon}}</v-icon>
+          {{ $i18n.locale }} 
+        </v-btn>
       </template>
     
       <v-list>
@@ -36,6 +41,7 @@ export default {
   name: 'wgu-localeswitcher',
   props: {
     icon: { type: String, required: false, default: 'language' },
+    color: { type: String, required: false, default: null },
     dark: { type: Boolean, required: false, default: false }
   },
   data () {

--- a/src/components/localeswitcher/LocaleSwitcher.vue
+++ b/src/components/localeswitcher/LocaleSwitcher.vue
@@ -6,7 +6,7 @@
         <v-btn
           borderless
           dense 
-          :color="color"
+          color="onprimary"
           background-color="transparent" 
           :title="$t('wgu-localeswitcher.title')"
           class="ma-2"
@@ -40,8 +40,7 @@ import LocaleUtil from '../../util/Locale'
 export default {
   name: 'wgu-localeswitcher',
   props: {
-    icon: { type: String, required: false, default: 'language' },
-    color: { type: String, required: false, default: null }
+    icon: { type: String, required: false, default: 'language' }
   },
   data () {
     return {

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -21,10 +21,15 @@
           <v-subheader>{{ $t('wgu-maprecorder.videoFormat') }}</v-subheader>
             <v-card-text class="pt-0">
               <v-select
+                  color="secondary"
+                  item-color="secondary"
+                  :menu-props="{
+                    'offset-y': true,
+                    bottom: true,
+                  }"
                   v-model="mimeType"
                   :items="mimeTypes"
                   prepend-icon="mdi-video-image"
-                  menu-props="auto"
                   dense
                   hide-details>
               </v-select>
@@ -33,6 +38,7 @@
             <v-subheader>{{ $t('wgu-maprecorder.frameRate') }}</v-subheader>
             <v-card-text class="pt-0">
               <v-slider
+                  color="secondary"
                   prepend-icon="mdi-iframe-variable-outline"
                   v-model.number="frameRate"
                   min="20"
@@ -46,6 +52,7 @@
             <v-subheader>{{ $t('wgu-maprecorder.bitRate') }}</v-subheader>
             <v-card-text class="pt-0">
               <v-slider
+                  color="secondary"
                   prepend-icon="mdi-quality-high"
                   v-model.number="videoMBitsPerSecond"
                   min="1.0"
@@ -59,6 +66,7 @@
             <v-subheader>{{ $t('wgu-maprecorder.fileName') }}</v-subheader>
             <v-card-text class="pt-0">
               <v-text-field
+                color="secondary"
                 v-model="filename"
                 prepend-icon="mdi-rename-box"
                 label="YYYY-MM-DD at HH.MM.SS"
@@ -73,23 +81,36 @@
     </v-expansion-panels>
 
     <v-card-actions>
-      <v-layout align-center>
+      <v-layout align-center
+          class="px-3 pb-3"
+      >
         <v-btn
-          class="mr-3"
-          icon 
-          fab
-          outlined 
-          @click="toggleRecord">
-          <v-icon v-if="recording">stop</v-icon> 
-          <v-icon v-else color="red darken-4">fiber_manual_record</v-icon> 
+          :block="!recording"
+          :class="{
+            'secondary': true,
+            'onsecondary--text': true  
+          }"
+          @click="toggleRecord"
+        >
+          <template v-if="!recording">
+            <v-icon left>fiber_manual_record</v-icon> 
+              {{ $t('wgu-maprecorder.start') }}
+          </template>
+          <template v-else>
+            <v-icon left>stop</v-icon> 
+              {{ $t('wgu-maprecorder.stop') }}
+          </template>
         </v-btn>
-        <v-flex fill-height grow> 
+
+        <v-flex fill-height grow class="px-2"> 
           <v-progress-linear
+            color="secondary"
             :active="recording"
             buffer-value="0"
             stream
           ></v-progress-linear>
         </v-flex>
+
         <v-flex fill-height shrink>
            <v-alert
             v-model="error"

--- a/src/components/maprecorder/MapRecorderWin.vue
+++ b/src/components/maprecorder/MapRecorderWin.vue
@@ -80,9 +80,12 @@
       </v-expansion-panel>
     </v-expansion-panels>
 
-    <v-card-actions>
-      <v-layout align-center
-          class="px-3 pb-3"
+    <v-card-actions class="pb-5">
+      <v-row
+        align-center
+        justify-center
+        no-gutters
+        class="px-3"
       >
         <v-btn
           :block="!recording"
@@ -94,32 +97,36 @@
         >
           <template v-if="!recording">
             <v-icon left>fiber_manual_record</v-icon> 
-              {{ $t('wgu-maprecorder.start') }}
+            {{ $t('wgu-maprecorder.start') }}
           </template>
           <template v-else>
             <v-icon left>stop</v-icon> 
-              {{ $t('wgu-maprecorder.stop') }}
+            {{ $t('wgu-maprecorder.stop') }}
           </template>
         </v-btn>
 
-        <v-flex fill-height grow class="px-2"> 
+        <v-col class="px-2" align-self="center"> 
           <v-progress-linear
             color="secondary"
             :active="recording"
             buffer-value="0"
             stream
           ></v-progress-linear>
-        </v-flex>
+        </v-col>
 
-        <v-flex fill-height shrink>
-           <v-alert
+        <v-col sm="12" md="12" lg="12">
+          <v-alert
             v-model="error"
             type="error" 
-            dismissible>
+            dismissible
+            dense
+            transition="scroll-y-transition"
+            class="mt-2 mb-0"
+          >
             {{ $t('wgu-maprecorder.error') }}
           </v-alert>
-        </v-flex>
-      </v-layout>
+         </v-col>
+      </v-row>
     </v-card-actions>
   </wgu-module-card>
 </template>

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,10 +1,8 @@
 <template>
-
-  <v-btn icon :dark="dark" @click="onClick"
+  <v-btn icon :color="color" :dark="dark" @click="onClick"
     :title="$t('wgu-zoomtomaxextent.title')">
     <v-icon medium>{{icon}}</v-icon>
   </v-btn>
-
 </template>
 
 <script>
@@ -17,6 +15,7 @@ export default {
   mixins: [Mapable],
   props: {
     icon: { type: String, required: false, default: 'zoom_out_map' },
+    color: { type: String, required: false, default: null },
     dark: { type: Boolean, required: false, default: false }
   },
   methods: {

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn icon :color="color" :dark="dark" @click="onClick"
+  <v-btn icon :color="color" @click="onClick"
     :title="$t('wgu-zoomtomaxextent.title')">
     <v-icon medium>{{icon}}</v-icon>
   </v-btn>
@@ -15,8 +15,7 @@ export default {
   mixins: [Mapable],
   props: {
     icon: { type: String, required: false, default: 'zoom_out_map' },
-    color: { type: String, required: false, default: null },
-    dark: { type: Boolean, required: false, default: false }
+    color: { type: String, required: false, default: null }
   },
   methods: {
     onClick () {

--- a/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
+++ b/src/components/maxextentbutton/ZoomToMaxExtentButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn icon :color="color" @click="onClick"
+  <v-btn icon color="onprimary" @click="onClick"
     :title="$t('wgu-zoomtomaxextent.title')">
     <v-icon medium>{{icon}}</v-icon>
   </v-btn>
@@ -14,8 +14,7 @@ export default {
   name: 'wgu-zoomtomaxextent-btn',
   mixins: [Mapable],
   props: {
-    icon: { type: String, required: false, default: 'zoom_out_map' },
-    color: { type: String, required: false, default: null }
+    icon: { type: String, required: false, default: 'zoom_out_map' }
   },
   methods: {
     onClick () {

--- a/src/components/measuretool/MeasureTypeChooser.vue
+++ b/src/components/measuretool/MeasureTypeChooser.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <v-btn-toggle v-model="measureTypeData" mandatory>
+  <v-btn-toggle color="secondary"  v-model="measureTypeData" mandatory>
      <v-btn large value="distance">
        {{ $t("wgu-measuretool.distance") }}
      </v-btn>

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -121,7 +121,7 @@
           }
           : {
             dark: true,
-            color: this.color
+            color: 'primary'
           }
       }
     },

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -8,7 +8,7 @@
     
     <v-img :src="backgroundImage">
       <v-toolbar v-bind="toolbarAttr">
-        <v-icon class="mr-4">{{ icon }}</v-icon>
+        <v-icon color="onprimary" class="mr-4">{{ icon }}</v-icon>
         <v-toolbar-title class="wgu-win-title">{{ $t(moduleName + '.title') }}</v-toolbar-title>
         <v-spacer></v-spacer>
 
@@ -16,12 +16,12 @@
         <slot name="wgu-win-toolbar"></slot>
 
         <v-spacer></v-spacer>
-        <v-btn v-if="minimizable" icon small 
+        <v-btn color="onprimary" v-if="minimizable" icon small 
           @click="minimized = !minimized">
           <v-icon v-if="minimized">web_asset</v-icon> 
           <v-icon v-else>remove</v-icon>
         </v-btn>
-        <v-btn icon small class="mr-0" 
+        <v-btn color="onprimary" icon small class="mr-0" 
           @click="toggleUi">
           <v-icon>close</v-icon>
         </v-btn>
@@ -120,8 +120,8 @@
             color: 'transparent'
           }
           : {
-            dark: true,
-            color: 'primary'
+            color: 'primary',
+            class: 'onprimary--text'
           }
       }
     },

--- a/src/components/modulecore/ModuleCard.vue
+++ b/src/components/modulecore/ModuleCard.vue
@@ -51,7 +51,6 @@
       icon: { type: String, required: true },
       win: { type: String, required: false, default: 'floating' },
       minimizable: { type: Boolean, required: false, default: false },
-      color: { type: String, required: false, default: 'red darken-3' },
       backgroundImage: { type: String, required: false, default: undefined },
       visible: { type: Boolean, required: false, default: false },
       // Positioning / sizing properties will be ignored for sidebar cards.

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -19,7 +19,6 @@ export default {
     color: { type: String, default: null },
     moduleName: { type: String, required: true },
     icon: { type: String, required: true },
-    dark: { type: Boolean, required: false, default: false },
     visible: { type: Boolean, required: false, default: false }
   },
   data: function () {

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -1,7 +1,7 @@
 <template>
   <v-btn-toggle borderless dense 
    :color="color"
-    background-color="transparent" :dark="dark"
+    background-color="transparent" 
     :title="$t(moduleName + '.title')"
     v-model="show">
     <v-btn icon :value="true" @click="toggleUi">

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -1,6 +1,9 @@
 <template>
-  <v-btn-toggle borderless dense 
-   :color="color"
+  <v-btn-toggle
+    class="wgu-toggle-button"
+    borderless
+    dense 
+    :color="color"
     background-color="transparent" 
     :title="$t(moduleName + '.title')"
     v-model="show">
@@ -38,3 +41,13 @@ export default {
   }
 };
 </script>
+<style>
+/**
+  Required to fix the hover button color.
+  Also fixes the color of any possible text
+  inside the button.
+ */
+.wgu-toggle-button .v-btn {
+  color: inherit !important;
+}
+</style>

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -1,10 +1,11 @@
 <template>
   <v-btn-toggle borderless dense 
+   :color="color"
     background-color="transparent" :dark="dark"
     :title="$t(moduleName + '.title')"
     v-model="show">
     <v-btn icon :value="true" @click="toggleUi">
-      <v-icon medium>{{icon}}</v-icon>
+      <v-icon :color="color" medium>{{icon}}</v-icon>
     </v-btn>
   </v-btn-toggle>
 </template>
@@ -15,6 +16,7 @@ import { WguEventBus } from '../../WguEventBus'
 export default {
   name: 'wgu-toggle-btn',
   props: {
+    color: { type: String, default: null },
     moduleName: { type: String, required: true },
     icon: { type: String, required: true },
     dark: { type: Boolean, required: false, default: false },

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -2,12 +2,12 @@
   <v-btn-toggle
     borderless
     dense 
-    :color="color"
+    color="onprimary"
     background-color="transparent" 
     :title="$t(moduleName + '.title')"
     v-model="show">
-    <v-btn icon :value="true" :color="color" @click="toggleUi">
-      <v-icon :color="color" medium>{{icon}}</v-icon>
+    <v-btn icon :value="true" color="onprimary" @click="toggleUi">
+      <v-icon color="onprimary" medium>{{icon}}</v-icon>
     </v-btn>
   </v-btn-toggle>
 </template>
@@ -18,7 +18,6 @@ import { WguEventBus } from '../../WguEventBus'
 export default {
   name: 'wgu-toggle-btn',
   props: {
-    color: { type: String, default: null },
     moduleName: { type: String, required: true },
     icon: { type: String, required: true },
     visible: { type: Boolean, required: false, default: false }

--- a/src/components/modulecore/ToggleButton.vue
+++ b/src/components/modulecore/ToggleButton.vue
@@ -1,13 +1,12 @@
 <template>
   <v-btn-toggle
-    class="wgu-toggle-button"
     borderless
     dense 
     :color="color"
     background-color="transparent" 
     :title="$t(moduleName + '.title')"
     v-model="show">
-    <v-btn icon :value="true" @click="toggleUi">
+    <v-btn icon :value="true" :color="color" @click="toggleUi">
       <v-icon :color="color" medium>{{icon}}</v-icon>
     </v-btn>
   </v-btn-toggle>
@@ -41,13 +40,3 @@ export default {
   }
 };
 </script>
-<style>
-/**
-  Required to fix the hover button color.
-  Also fixes the color of any possible text
-  inside the button.
- */
-.wgu-toggle-button .v-btn {
-  color: inherit !important;
-}
-</style>

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -24,7 +24,6 @@ import proj4 from 'proj4'
 // import the app-wide EventBus
 import { WguEventBus } from '../../WguEventBus.js';
 import { LayerFactory } from '../../factory/Layer.js';
-import ColorUtil from '../../util/Color';
 import LayerUtil from '../../util/Layer';
 import PermalinkController from './PermalinkController';
 import MapInteractionUtil from '../../util/MapInteraction';
@@ -33,7 +32,6 @@ import ViewAnimationUtil from '../../util/ViewAnimation';
 export default {
   name: 'wgu-map',
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     collapsibleAttribution: { type: Boolean, default: false },
     rotateableMap: { type: Boolean, required: false, default: false }
   },
@@ -227,32 +225,25 @@ export default {
      * Sets the background color of the OL buttons to the color property.
      */
     setOlButtonColor () {
-      var me = this;
+      const colors = 'secondary onsecondary--text'
 
-      if (ColorUtil.isCssColor(me.color)) {
-        // directly apply the given CSS color
-        if (document.querySelector('.ol-zoom')) {
-          document.querySelector('.ol-zoom .ol-zoom-in').style.backgroundColor = me.color;
-          document.querySelector('.ol-zoom .ol-zoom-out').style.backgroundColor = me.color;
-        }
-        if (document.querySelector('.ol-rotate')) {
-          document.querySelector('.ol-rotate .ol-rotate-reset').style.backgroundColor = me.color;
-        }
-      } else {
-        // apply vuetify color by transforming the color to the corresponding
-        // CSS class (see https://vuetifyjs.com/en/framework/colors)
-        const classes = me.color.toString().trim().split(' ');
-        if (document.querySelector('.ol-zoom')) {
-          classes.forEach(function (c) {
-            document.querySelector('.ol-zoom .ol-zoom-in').classList.add(c);
-            document.querySelector('.ol-zoom .ol-zoom-out').classList.add(c);
-          });
-        }
-        if (document.querySelector('.ol-rotate')) {
-          classes.forEach(function (c) {
-            document.querySelector('.ol-rotate .ol-rotate-reset').classList.add(c);
-          });
-        }
+      // apply vuetify color by transforming the color to the corresponding
+      // CSS class (see https://vuetifyjs.com/en/framework/colors)
+      const classes = colors.toString().trim().split(' ');
+
+      // zoom
+      if (document.querySelector('.ol-zoom')) {
+        classes.forEach(function (c) {
+          document.querySelector('.ol-zoom .ol-zoom-in').classList.add(c);
+          document.querySelector('.ol-zoom .ol-zoom-out').classList.add(c);
+        });
+      }
+
+      // rotate
+      if (document.querySelector('.ol-rotate')) {
+        classes.forEach(function (c) {
+          document.querySelector('.ol-rotate .ol-rotate-reset').classList.add(c);
+        });
       }
     },
     /**

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -28,9 +28,11 @@ import LayerUtil from '../../util/Layer';
 import PermalinkController from './PermalinkController';
 import MapInteractionUtil from '../../util/MapInteraction';
 import ViewAnimationUtil from '../../util/ViewAnimation';
+import { ColorTheme } from '../../mixins/ColorTheme'
 
 export default {
   name: 'wgu-map',
+  mixins: [ ColorTheme ],
   props: {
     collapsibleAttribution: { type: Boolean, default: false },
     rotateableMap: { type: Boolean, required: false, default: false }
@@ -261,6 +263,8 @@ export default {
       // create a span to show map tooltip
       overlayEl = document.createElement('span');
       overlayEl.classList.add('wgu-hover-tooltiptext');
+      overlayEl.classList.add('v-sheet');
+      overlayEl.classList.add(this.isDarkTheme ? 'theme--dark' : 'theme--light');
       map.getTarget().append(overlayEl);
 
       me.overlayEl = overlayEl;
@@ -416,6 +420,22 @@ export default {
       layers.forEach(layer => {
         this.updateLocalizedLayerProps(layer);
       });
+    },
+
+    /**
+     * Watch changes on the selected vuetify theme variant (light/dark)
+     * and set the appropriate classes for the tooltip overlay
+     */
+    isDarkTheme: function (value) {
+      const overlayEl = this.overlayEl;
+
+      if (value) {
+        overlayEl.classList.add('theme--dark');
+        overlayEl.classList.remove('theme--light');
+      } else {
+        overlayEl.classList.add('theme--light');
+        overlayEl.classList.remove('theme--dark');
+      }
     }
   }
 
@@ -439,8 +459,6 @@ export default {
   .wgu-hover-tooltiptext {
     float: left; /* needed that max-width has an effect */
     max-width: 200px;
-    background-color: rgba(211, 211, 211, .9);
-    color: #222;
     text-align: center;
     padding: 5px;
     border-radius: 6px;

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -241,16 +241,17 @@ export default {
       } else {
         // apply vuetify color by transforming the color to the corresponding
         // CSS class (see https://vuetifyjs.com/en/framework/colors)
-        const [colorName, colorModifier] = me.color.toString().trim().split(' ', 2);
+        const classes = me.color.toString().trim().split(' ');
         if (document.querySelector('.ol-zoom')) {
-          document.querySelector('.ol-zoom .ol-zoom-in').classList.add(colorName);
-          document.querySelector('.ol-zoom .ol-zoom-in').classList.add(colorModifier);
-          document.querySelector('.ol-zoom .ol-zoom-out').classList.add(colorName);
-          document.querySelector('.ol-zoom .ol-zoom-out').classList.add(colorModifier);
+          classes.forEach(function (c) {
+            document.querySelector('.ol-zoom .ol-zoom-in').classList.add(c);
+            document.querySelector('.ol-zoom .ol-zoom-out').classList.add(c);
+          });
         }
         if (document.querySelector('.ol-rotate')) {
-          document.querySelector('.ol-rotate .ol-rotate-reset').classList.add(colorName);
-          document.querySelector('.ol-rotate .ol-rotate-reset').classList.add(colorModifier);
+          classes.forEach(function (c) {
+            document.querySelector('.ol-rotate .ol-rotate-reset').classList.add(c);
+          });
         }
       }
     },

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -420,22 +420,6 @@ export default {
       layers.forEach(layer => {
         this.updateLocalizedLayerProps(layer);
       });
-    },
-
-    /**
-     * Watch changes on the selected vuetify theme variant (light/dark)
-     * and set the appropriate classes for the tooltip overlay
-     */
-    isDarkTheme: function (value) {
-      const overlayEl = this.overlayEl;
-
-      if (value) {
-        overlayEl.classList.add('theme--dark');
-        overlayEl.classList.remove('theme--light');
-      } else {
-        overlayEl.classList.add('theme--light');
-        overlayEl.classList.remove('theme--dark');
-      }
     }
   }
 

--- a/src/components/progress/MapLoadingStatus.vue
+++ b/src/components/progress/MapLoadingStatus.vue
@@ -21,7 +21,6 @@ import LayerGroup from 'ol/layer/Group';
 export default {
   name: 'wgu-maploading-status',
   mixins: [Mapable],
-  props: {},
   data () {
     return {
       loading: 0,

--- a/src/components/progress/MapLoadingStatus.vue
+++ b/src/components/progress/MapLoadingStatus.vue
@@ -5,7 +5,7 @@
     class="wgu-maploading-status"
     :value="80"
     indeterminate
-    :color="color"
+    color="secondary"
     >
   </v-progress-circular>
 
@@ -21,9 +21,7 @@ import LayerGroup from 'ol/layer/Group';
 export default {
   name: 'wgu-maploading-status',
   mixins: [Mapable],
-  props: {
-    color: { type: String, default: 'red darken-3' }
-  },
+  props: {},
   data () {
     return {
       loading: 0,

--- a/src/components/themeswitcher/ThemeSwitcher.vue
+++ b/src/components/themeswitcher/ThemeSwitcher.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Control to switch between light and dark mode -->
   <span>
     <v-btn @click="switchTheme" icon :color="color" :title="title">
       <v-icon :class="iconCls">dark_mode</v-icon>
@@ -17,16 +18,28 @@ export default {
   },
 
   computed: {
+    /**
+     * Checks if the color theme is in dark mode.
+     * Returns true if dark mode.
+     */
     isDarkMode: function () {
       return this.$vuetify.theme.dark;
     },
 
+    /**
+     * Returns the appropriate button tooltip
+     * for light and dark mode
+     */
     title: function () {
       return this.isDarkMode
         ? this.$t('wgu-themeswitcher.title_dark_mode')
         : this.$t('wgu-themeswitcher.title_light_mode');
     },
 
+    /**
+     * Returns the appropriate button icon
+     * for light and dark mode
+     */
     iconCls: function () {
       return this.isDarkMode ? 'material-icons' : 'material-icons-outlined';
     }
@@ -34,7 +47,7 @@ export default {
 
   methods: {
     /**
-     * Switch between light and dark mode
+     * Switches between light and dark mode
      */
     switchTheme: function () {
       this.$vuetify.theme.dark = !this.isDarkMode;

--- a/src/components/themeswitcher/ThemeSwitcher.vue
+++ b/src/components/themeswitcher/ThemeSwitcher.vue
@@ -1,0 +1,45 @@
+<template>
+  <span>
+    <v-btn @click="switchTheme" icon dark :title="title">
+      <v-icon :class="iconCls">dark_mode</v-icon>
+    </v-btn>
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'wgu-themeswitcher',
+  props: {},
+  data: function () {
+    return {};
+  },
+
+  computed: {
+    isDarkMode: function () {
+      return this.$vuetify.theme.dark;
+    },
+
+    title: function () {
+      return this.isDarkMode
+        ? this.$t('wgu-themeswitcher.title_dark_mode')
+        : this.$t('wgu-themeswitcher.title_light_mode');
+    },
+
+    iconCls: function () {
+      return this.isDarkMode ? 'material-icons' : 'material-icons-outlined';
+    }
+  },
+
+  methods: {
+    /**
+     * Switch between light and dark mode
+     */
+    switchTheme: function () {
+      this.$vuetify.theme.dark = !this.isDarkMode;
+    }
+  }
+};
+</script>
+
+<style scoped>
+</style>

--- a/src/components/themeswitcher/ThemeSwitcher.vue
+++ b/src/components/themeswitcher/ThemeSwitcher.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <v-btn @click="switchTheme" icon dark :title="title">
+    <v-btn @click="switchTheme" icon :color="color" :title="title">
       <v-icon :class="iconCls">dark_mode</v-icon>
     </v-btn>
   </span>
@@ -9,7 +9,9 @@
 <script>
 export default {
   name: 'wgu-themeswitcher',
-  props: {},
+  props: {
+    color: { type: String, required: false, default: null }
+  },
   data: function () {
     return {};
   },

--- a/src/components/themeswitcher/ThemeSwitcher.vue
+++ b/src/components/themeswitcher/ThemeSwitcher.vue
@@ -1,55 +1,38 @@
-<template>
-  <!-- Control to switch between light and dark mode -->
-  <span>
-    <v-btn @click="switchTheme" icon :color="color" :title="title">
-      <v-icon :class="iconCls">dark_mode</v-icon>
-    </v-btn>
-  </span>
-</template>
-
 <script>
+// Control to switch between light and dark mode
+
+import ToggleButton from '../modulecore/ToggleButton.vue';
 import { ColorTheme } from '../../mixins/ColorTheme';
 
 export default {
+  extends: ToggleButton,
+
   name: 'wgu-themeswitcher',
   mixins: [ColorTheme],
-  props: {
-    color: { type: String, required: false, default: null }
-  },
-  data: function () {
-    return {};
-  },
 
-  computed: {
-    /**
-     * Returns the appropriate button tooltip
-     * for light and dark mode
-     */
-    title: function () {
-      return this.isDarkTheme
-        ? this.$t('wgu-themeswitcher.title_dark_mode')
-        : this.$t('wgu-themeswitcher.title_light_mode');
+  watch: {
+    isDarkTheme: {
+      // When dark theme changes via Vuetify
+      handler: function (value) {
+        // update toggle state of this tool
+        if (value !== this.show) {
+          this.show = value;
+        }
+      },
+      immediate: true
     },
 
-    /**
-     * Returns the appropriate button icon
-     * for light and dark mode
-     */
-    iconCls: function () {
-      return this.isDarkTheme ? 'material-icons' : 'material-icons-outlined';
-    }
-  },
-
-  methods: {
-    /**
-     * Switches between light and dark mode
-     */
-    switchTheme: function () {
-      this.$vuetify.theme.dark = !this.isDarkTheme;
+    show: {
+      // When dark theme changes via this tool
+      handler: function (value) {
+        // update Vuetify state
+        if (value !== this.$vuetify.theme.dark) {
+          // untoggled state of v-btn-toggle
+          // returns undefined, so we !!undefined
+          this.$vuetify.theme.dark = !!value;
+        }
+      }
     }
   }
 };
 </script>
-
-<style scoped>
-</style>

--- a/src/components/themeswitcher/ThemeSwitcher.vue
+++ b/src/components/themeswitcher/ThemeSwitcher.vue
@@ -8,8 +8,11 @@
 </template>
 
 <script>
+import { ColorTheme } from '../../mixins/ColorTheme';
+
 export default {
   name: 'wgu-themeswitcher',
+  mixins: [ColorTheme],
   props: {
     color: { type: String, required: false, default: null }
   },
@@ -19,19 +22,11 @@ export default {
 
   computed: {
     /**
-     * Checks if the color theme is in dark mode.
-     * Returns true if dark mode.
-     */
-    isDarkMode: function () {
-      return this.$vuetify.theme.dark;
-    },
-
-    /**
      * Returns the appropriate button tooltip
      * for light and dark mode
      */
     title: function () {
-      return this.isDarkMode
+      return this.isDarkTheme
         ? this.$t('wgu-themeswitcher.title_dark_mode')
         : this.$t('wgu-themeswitcher.title_light_mode');
     },
@@ -41,7 +36,7 @@ export default {
      * for light and dark mode
      */
     iconCls: function () {
-      return this.isDarkMode ? 'material-icons' : 'material-icons-outlined';
+      return this.isDarkTheme ? 'material-icons' : 'material-icons-outlined';
     }
   },
 
@@ -50,7 +45,7 @@ export default {
      * Switches between light and dark mode
      */
     switchTheme: function () {
-      this.$vuetify.theme.dark = !this.isDarkMode;
+      this.$vuetify.theme.dark = !this.isDarkTheme;
     }
   }
 };

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -68,8 +68,8 @@
     "frameRate": "Bildrate (Bilder/s)",
     "bitRate": "Bitrate (MBits/s)",
     "fileName": "Dateiname",
-    "start": "Starten",
-    "stop": "Halt",
+    "start": "Start",
+    "stop": "Stop",
     "error": "Starten der Aufnahme fehlgeschlagen."
   },
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -93,7 +93,6 @@
   },
 
   "wgu-themeswitcher": {
-    "title_light_mode": "In den dunklen Modus wechseln",
-    "title_dark_mode": "In den hellen Modus wechseln"
+    "title": "Dunklen Modus"
   }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -68,6 +68,8 @@
     "frameRate": "Bildrate (Bilder/s)",
     "bitRate": "Bitrate (MBits/s)",
     "fileName": "Dateiname",
+    "start": "",
+    "stop": "",
     "error": "Starten der Aufnahme fehlgeschlagen."
   },
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -88,5 +88,10 @@
 
   "wgu-localeswitcher": {
     "title": "Spracheinstellungen"
+  },
+
+  "wgu-themeswitcher": {
+    "title_light_mode": "In den Dunkelmodus wechseln",
+    "title_dark_mode": "Wechseln Sie in den Lichtmodus"
   }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -68,8 +68,8 @@
     "frameRate": "Bildrate (Bilder/s)",
     "bitRate": "Bitrate (MBits/s)",
     "fileName": "Dateiname",
-    "start": "",
-    "stop": "",
+    "start": "Starten",
+    "stop": "Halt",
     "error": "Starten der Aufnahme fehlgeschlagen."
   },
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -91,7 +91,7 @@
   },
 
   "wgu-themeswitcher": {
-    "title_light_mode": "In den Dunkelmodus wechseln",
-    "title_dark_mode": "Wechseln Sie in den Lichtmodus"
+    "title_light_mode": "In den dunklen Modus wechseln",
+    "title_dark_mode": "In den hellen Modus wechseln"
   }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -93,6 +93,6 @@
   },
 
   "wgu-themeswitcher": {
-    "title": "Dunklen Modus"
+    "title": "Dunkler Modus"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,6 +68,8 @@
     "frameRate": "Frame rate (frames/s)",
     "bitRate": "Bit rate (MBits/s)",
     "fileName": "Filename",
+    "start": "Start",
+    "stop": "Stop",
     "error": "Failed to start recording."
   },
   

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -93,7 +93,6 @@
   },
 
   "wgu-themeswitcher": {
-    "title_light_mode": "Switch to dark mode",
-    "title_dark_mode": "Switch to light mode"
+    "title": "Dark mode"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,5 +88,10 @@
 
   "wgu-localeswitcher": {
     "title": "Language Settings"
+  },
+
+  "wgu-themeswitcher": {
+    "title_light_mode": "Switch to dark mode",
+    "title_dark_mode": "Switch to light mode"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,12 @@ const createVuetify = function (appConfig) {
     if (cfgTheme.themes && typeof cfgTheme.themes === 'object') {
       theme.themes = ColorThemeUtil.mergeThemes(cfgTheme.themes, theme.themes);
     }
+
+    // Set customProperties
+    // creates css colors for each vuetify color class
+    theme.options = {
+      'customProperties': true
+    }
   }
 
   const preset = {

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,7 @@ if (appCtx) {
  */
 const createVuetify = function (appConfig) {
   const preset = {
-    theme: appConfig.theme,
+    theme: appConfig.colorTheme,
     icons: {
       iconfont: 'mdiSvg'
     },

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,7 @@ if (appCtx) {
  */
 const createVuetify = function (appConfig) {
   const preset = {
+    theme: appConfig.theme,
     icons: {
       iconfont: 'mdiSvg'
     },

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import WguApp from '../app/WguApp';
 import UrlUtil from './util/Url';
 import LocaleUtil from './util/Locale';
 import ObjectUtil from './util/Object';
+import ColorThemeUtil from './util/ColorTheme'
 import 'vuetify/dist/vuetify.min.css';
 
 Vue.use(Vuetify);
@@ -69,11 +70,15 @@ const createVuetify = function (appConfig) {
     }
   }
 
+  const cfgTheme = appConfig.colorTheme;
+
   // Override if there is colorTheme
-  if (appConfig.hasOwnProperty('colorTheme') && typeof appConfig.colorTheme === 'object') {
-    theme = {
-      ...theme,
-      ...appConfig.colorTheme
+  if (cfgTheme && typeof cfgTheme === 'object') {
+    theme.dark = !!cfgTheme.dark;
+
+    // If themes is configured
+    if (cfgTheme.themes && typeof cfgTheme.themes === 'object') {
+      theme.themes = ColorThemeUtil.mergeThemes(cfgTheme.themes, theme.themes);
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ require('./assets/css/wegue.css');
 // try to load an optional app specific CSS file (set project-specific styles)
 try {
   require('../app/static/css/app.css');
-} catch (e) {}
+} catch (e) { }
 
 Vue.config.productionTip = false;
 
@@ -55,7 +55,6 @@ const createVuetify = function (appConfig) {
         'onprimary': '#ffffff',
         'secondary': '#af2622',
         'onsecondary': '#ffffff',
-        'onsurface': '#bf302d',
         'accent': '#ffffff',
         'error': '#ff6f00'
       },
@@ -64,7 +63,6 @@ const createVuetify = function (appConfig) {
         'onprimary': '#ffffff',
         'secondary': '#ea9b9b',
         'onsecondary': '#272727',
-        'onsurface': '#1e1e1e',
         'accent': '#ea9b9b',
         'error': '#ff6f00'
       }
@@ -114,6 +112,12 @@ const createVueI18n = function (appConfig) {
  * @returns The migrated application context.
  */
 const migrateAppConfig = function (appConfig) {
+  // Warning for deprecated baseColor
+  if (appConfig.baseColor) {
+    console.warn('The configuration path ".baseColor" is deprecated, ' +
+      'instead declare a path ".colorTheme"');
+  }
+
   // Migrate boolean values for module.win.
   if (appConfig.modules) {
     Object.keys(appConfig.modules).forEach(name => {

--- a/src/main.js
+++ b/src/main.js
@@ -56,7 +56,6 @@ const createVuetify = function (appConfig) {
         'onprimary': '#ffffff',
         'secondary': '#af2622',
         'onsecondary': '#ffffff',
-        'accent': '#ffffff',
         'error': '#ff6f00'
       },
       'dark': {
@@ -64,7 +63,6 @@ const createVuetify = function (appConfig) {
         'onprimary': '#ffffff',
         'secondary': '#ea9b9b',
         'onsecondary': '#272727',
-        'accent': '#ea9b9b',
         'error': '#ff6f00'
       }
     }
@@ -76,10 +74,12 @@ const createVuetify = function (appConfig) {
   if (cfgTheme && typeof cfgTheme === 'object') {
     theme.dark = !!cfgTheme.dark;
 
-    // If themes is configured
-    if (cfgTheme.themes && typeof cfgTheme.themes === 'object') {
-      theme.themes = ColorThemeUtil.mergeThemes(cfgTheme.themes, theme.themes);
+    if (!cfgTheme.themes || typeof cfgTheme.themes !== 'object') {
+      cfgTheme.themes = {};
     }
+
+    // Apply user theme or fallback to default
+    theme.themes = ColorThemeUtil.mergeThemes(cfgTheme.themes, theme.themes);
 
     // Set customProperties
     // creates css colors for each vuetify color class

--- a/src/main.js
+++ b/src/main.js
@@ -47,8 +47,40 @@ if (appCtx) {
  * @returns The active vuetify instance.
  */
 const createVuetify = function (appConfig) {
+  let theme = {
+    dark: false,
+    themes: {
+      'light': {
+        'primary': '#af2622',
+        'onprimary': '#ffffff',
+        'secondary': '#af2622',
+        'onsecondary': '#ffffff',
+        'onsurface': '#bf302d',
+        'accent': '#ffffff',
+        'error': '#ff6f00'
+      },
+      'dark': {
+        'primary': '#272727',
+        'onprimary': '#ffffff',
+        'secondary': '#ea9b9b',
+        'onsecondary': '#272727',
+        'onsurface': '#1e1e1e',
+        'accent': '#ea9b9b',
+        'error': '#ff6f00'
+      }
+    }
+  }
+
+  // Override if there is colorTheme
+  if (appConfig.hasOwnProperty('colorTheme') && typeof appConfig.colorTheme === 'object') {
+    theme = {
+      ...theme,
+      ...appConfig.colorTheme
+    }
+  }
+
   const preset = {
-    theme: appConfig.colorTheme,
+    theme: theme,
     icons: {
       iconfont: 'mdiSvg'
     },

--- a/src/main.js
+++ b/src/main.js
@@ -48,48 +48,8 @@ if (appCtx) {
  * @returns The active vuetify instance.
  */
 const createVuetify = function (appConfig) {
-  let theme = {
-    dark: false,
-    themes: {
-      'light': {
-        'primary': '#af2622',
-        'onprimary': '#ffffff',
-        'secondary': '#af2622',
-        'onsecondary': '#ffffff',
-        'error': '#ff6f00'
-      },
-      'dark': {
-        'primary': '#272727',
-        'onprimary': '#ffffff',
-        'secondary': '#ea9b9b',
-        'onsecondary': '#272727',
-        'error': '#ff6f00'
-      }
-    }
-  }
-
-  const cfgTheme = appConfig.colorTheme;
-
-  // Override if there is colorTheme
-  if (cfgTheme && typeof cfgTheme === 'object') {
-    theme.dark = !!cfgTheme.dark;
-
-    if (!cfgTheme.themes || typeof cfgTheme.themes !== 'object') {
-      cfgTheme.themes = {};
-    }
-
-    // Apply user theme or fallback to default
-    theme.themes = ColorThemeUtil.mergeThemes(cfgTheme.themes, theme.themes);
-
-    // Set customProperties
-    // creates css colors for each vuetify color class
-    theme.options = {
-      'customProperties': true
-    }
-  }
-
   const preset = {
-    theme: theme,
+    theme: ColorThemeUtil.buildTheme(appConfig.colorTheme),
     icons: {
       iconfont: 'mdiSvg'
     },

--- a/src/mixins/ColorTheme.js
+++ b/src/mixins/ColorTheme.js
@@ -1,0 +1,37 @@
+import Color from '../util/Color'
+
+/**
+ * Mixin for colorTheme utils
+ */
+export const ColorTheme = {
+  computed: {
+    /**
+     * Checks if the theme is in dark mode
+     * @returns true if dark mode
+     */
+    isDarkTheme: function () {
+      return this.$vuetify.theme.dark;
+    },
+
+    /**
+     * Checks the luminance level of the primary color.
+     * @returns true if primary is a dark color
+     */
+    isPrimaryDark: function () {
+      // Get current theme
+      const theme = this.$vuetify.theme.currentTheme;
+
+      let primary = theme.primary;
+
+      // "primary" can be either an hexa string or
+      // an object of hexa string. In the later,
+      // we check the luminance for the primary
+      // base.
+      if (typeof primary === 'object') {
+        primary = primary.base;
+      }
+
+      return Color.checkLuminance(primary);
+    }
+  }
+}

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -13,7 +13,11 @@ const ColorUtil = {
   },
 
   /**
-   * https://stackoverflow.com/questions/12043187/how-to-check-if-hex-color-is-too-black
+   * Luminance theory from:
+   *    https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
+   * Hexa -> RGB from:
+   *    https://stackoverflow.com/questions/12043187/how-to-check-if-hex-color-is-too-black
+   *
    * Checks if an hexadecimal color is dark/bright
    * @param {String} hexa color in hexadecimal format
    * @returns {Boolean} true if dark
@@ -23,15 +27,25 @@ const ColorUtil = {
 
     const rgb = parseInt(c, 16); // convert rrggbb to decimal
 
-    const r = (rgb >> 16) & 0xff; // extract red
+    let r = (rgb >> 16) & 0xff; // extract red
+    let g = (rgb >> 8) & 0xff; // extract green
+    let b = (rgb >> 0) & 0xff; // extract blue
 
-    const g = (rgb >> 8) & 0xff; // extract green
+    // normalize to [0, 1]
+    r = r / 255.0;
+    g = g / 255.0;
+    b = b / 255.0;
 
-    const b = (rgb >> 0) & 0xff; // extract blue
+    // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+    r = r <= 0.03928 ? r / 12.92 : Math.pow(((r + 0.055) / 1.055), 2.4)
+    g = g <= 0.03928 ? g / 12.92 : Math.pow(((g + 0.055) / 1.055), 2.4)
+    b = b <= 0.03928 ? b / 12.92 : Math.pow(((b + 0.055) / 1.055), 2.4)
 
-    const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b; // per ITU-R BT.709 (Range 0-255)
+    // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+    const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
 
-    return luma < 128;
+    // returns true if dark color
+    return luma <= 0.179;
   }
 }
 

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -10,6 +10,28 @@ const ColorUtil = {
    */
   isCssColor (color) {
     return !!color && !!color.match(/^(#|(rgb|hsl)a?\()/);
+  },
+
+  /**
+   * https://stackoverflow.com/questions/12043187/how-to-check-if-hex-color-is-too-black
+   * Checks if an hexadecimal color is dark/bright
+   * @param {String} hexa color in hexadecimal format
+   * @returns {Boolean} true if dark
+   */
+  checkLuminance: function (hexa) {
+    const c = hexa.substring(1); // strip #
+
+    const rgb = parseInt(c, 16); // convert rrggbb to decimal
+
+    const r = (rgb >> 16) & 0xff; // extract red
+
+    const g = (rgb >> 8) & 0xff; // extract green
+
+    const b = (rgb >> 0) & 0xff; // extract blue
+
+    const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b; // per ITU-R BT.709 (Range 0-255)
+
+    return luma < 128;
   }
 }
 

--- a/src/util/ColorTheme.js
+++ b/src/util/ColorTheme.js
@@ -3,10 +3,16 @@ import ColorUtil from './Color'
 // Macros for light/dark theme
 const LIGHT_WHITE = '#ffffff';
 const LIGHT_ERROR = '#FF5252';
+const LIGHT_INFO = '#2196F3';
+const LIGHT_SUCCESS = '#4CAF50';
+const LIGHT_WARNING = '#FFC107';
 const LIGHT_BLACK = '#000000';
 const DARK_WHITE = '#ffffff';
-const DARK_BLACK = '#272727';
 const DARK_ERROR = '#FF5252';
+const DARK_INFO = '#2196F3';
+const DARK_SUCCESS = '#4CAF50';
+const DARK_WARNING = '#FFC107';
+const DARK_BLACK = '#272727';
 
 /**
    * Gets the base color for the input color.
@@ -45,7 +51,7 @@ const ColorThemeUtil = {
    * @returns {Object} merged color theme
    */
   mergeThemes (userTheme, defaultTheme) {
-    const { light, dark } = userTheme;
+    let { light, dark } = userTheme;
 
     const merged = {
       light: {},
@@ -53,60 +59,64 @@ const ColorThemeUtil = {
     }
 
     // If light theme is configured with at least the primary color
-    if (light && light.primary) {
-      // set primary color
-      merged.light.primary = light.primary;
-
-      // set secondary to user secondary,
-      // otherwise fallback to primary
-      merged.light.secondary = light.secondary ? light.secondary : light.primary;
-
-      // set accent to user accent,
-      // otherwise fallback to the light theme white
-      merged.light.accent = light.accent ? light.accent : LIGHT_WHITE;
-
-      // set onprimary to user onprimary,
-      // otherwise fallback to a color that contrasts with the primary
-      merged.light.onprimary = light.onprimary ? light.onprimary : contrastColor(merged.light.primary, LIGHT_WHITE, LIGHT_BLACK);
-
-      // set onprimary to user onsecondary,
-      // otherwise fallback to a color that contrasts with the secondary
-      merged.light.onsecondary = light.onsecondary ? light.onsecondary : contrastColor(merged.light.secondary, LIGHT_WHITE, LIGHT_BLACK);
-
-      // set error to user error,
-      // otherwise fallback to light theme error
-      merged.light.error = light.error ? light.error : LIGHT_ERROR;
-    } else {
-      // fallback to default ligth theme
-      merged.light = defaultTheme.light;
+    if (!light || !light.primary) {
+      // fallback to default light theme
+      light = defaultTheme.light;
     }
+
+    // set primary color
+    merged.light.primary = light.primary;
+
+    // set secondary to user secondary,
+    // otherwise fallback to primary
+    merged.light.secondary = light.secondary ? light.secondary : light.primary;
+
+    // set accent to the light theme white
+    merged.light.accent = contrastColor(merged.light.primary, LIGHT_WHITE, LIGHT_BLACK);
+
+    // set onprimary to user onprimary,
+    // otherwise fallback to a color that contrasts with the primary
+    merged.light.onprimary = light.onprimary ? light.onprimary : contrastColor(merged.light.primary, LIGHT_WHITE, LIGHT_BLACK);
+
+    // set onprimary to user onsecondary,
+    // otherwise fallback to a color that contrasts with the secondary
+    merged.light.onsecondary = light.onsecondary ? light.onsecondary : contrastColor(merged.light.secondary, LIGHT_WHITE, LIGHT_BLACK);
+
+    // set semantic colors,
+    // otherwise fallback to light theme defaults
+    merged.light.info = light.info ? light.info : LIGHT_INFO;
+    merged.light.success = light.success ? light.success : LIGHT_SUCCESS;
+    merged.light.warning = light.warning ? light.warning : LIGHT_WARNING;
+    merged.light.error = light.error ? light.error : LIGHT_ERROR;
 
     // If light theme is configured with at least the secondary color
-    if (dark && dark.secondary) {
-      // set primary to dark theme primary
-      merged.dark.primary = DARK_BLACK;
-
-      // set secondary
-      merged.dark.secondary = dark.secondary;
-
-      // set accent to user accent,
-      // otherwise fallback to secondary
-      merged.dark.accent = dark.accent ? dark.accent : dark.secondary;
-
-      // set onprimary to dark theme white
-      merged.dark.onprimary = DARK_WHITE;
-
-      // set onsecondary to user onsecondary,
-      // otherwise fallback to a color that contrasts with secondary
-      merged.dark.onsecondary = dark.onsecondary ? dark.onsecondary : contrastColor(merged.dark.secondary, DARK_WHITE, DARK_BLACK);
-
-      // set error to user error,
-      // otherwise fallback to dark theme error
-      merged.dark.error = dark.error ? dark.error : DARK_ERROR;
-    } else {
+    if (!dark || !dark.secondary) {
       // fallback to default dark theme
-      merged.dark = defaultTheme.dark;
+      dark = defaultTheme.dark;
     }
+
+    // set primary to dark theme primary
+    merged.dark.primary = DARK_BLACK;
+
+    // set secondary
+    merged.dark.secondary = dark.secondary;
+
+    // set accent to secondary
+    merged.dark.accent = dark.secondary;
+
+    // set onprimary to dark theme white
+    merged.dark.onprimary = DARK_WHITE;
+
+    // set onsecondary to user onsecondary,
+    // otherwise fallback to a color that contrasts with secondary
+    merged.dark.onsecondary = dark.onsecondary ? dark.onsecondary : contrastColor(merged.dark.secondary, DARK_WHITE, DARK_BLACK);
+
+    // set semantic colors,
+    // otherwise fallback to dark theme defaults
+    merged.dark.info = dark.info ? dark.info : DARK_INFO;
+    merged.dark.success = dark.success ? dark.success : DARK_SUCCESS;
+    merged.dark.warning = dark.warning ? dark.warning : DARK_WARNING;
+    merged.dark.error = dark.error ? dark.error : DARK_ERROR;
 
     return merged;
   }

--- a/src/util/ColorTheme.js
+++ b/src/util/ColorTheme.js
@@ -1,5 +1,23 @@
 import ColorUtil from './Color'
 
+// Macro for default color themes configuration
+const DEFAULT_THEMES = Object.freeze({
+  'light': {
+    'primary': '#af2622',
+    'onprimary': '#ffffff',
+    'secondary': '#af2622',
+    'onsecondary': '#ffffff',
+    'error': '#ff6f00'
+  },
+  'dark': {
+    'primary': '#272727',
+    'onprimary': '#ffffff',
+    'secondary': '#ea9b9b',
+    'onsecondary': '#272727',
+    'error': '#ff6f00'
+  }
+});
+
 // Macros for light/dark theme
 const LIGHT_WHITE = '#ffffff';
 const LIGHT_ERROR = '#FF5252';
@@ -46,12 +64,12 @@ function contrastColor (color, light, dark) {
 const ColorThemeUtil = {
   /**
    * Merges user color theme with the default color theme
-   * @param {Object} userTheme user theme from app-config
+   * @param {Object} inputTheme input theme from app-config
    * @param {Object} defaultTheme default Wegue theme
    * @returns {Object} merged color theme
    */
-  mergeThemes (userTheme, defaultTheme) {
-    let { light, dark } = userTheme;
+  mergeThemes (inputTheme, defaultTheme) {
+    let { light, dark } = inputTheme;
 
     const merged = {
       light: {},
@@ -119,6 +137,40 @@ const ColorThemeUtil = {
     merged.dark.error = dark.error ? dark.error : DARK_ERROR;
 
     return merged;
+  },
+
+  /**
+   * Builds the theme object used by Vuetify
+   * @param {Object} inputConfig user configuration from app-config
+   * @returns {Object} theme object
+   */
+  buildTheme: function (inputConfig) {
+    // If there is no input config, create it
+    if (!inputConfig || typeof inputConfig !== 'object') {
+      inputConfig = { dark: false };
+    }
+
+    // If there is no input themes, create it
+    if (!inputConfig.themes || typeof inputConfig.themes !== 'object') {
+      inputConfig.themes = {};
+    }
+
+    // Object for the output config
+    const outputConfig = {};
+
+    // Apply start with dark theme
+    outputConfig.dark = !!inputConfig.dark;
+
+    // Apply user theme or fallback to default
+    outputConfig.themes = ColorThemeUtil.mergeThemes(inputConfig.themes, DEFAULT_THEMES);
+
+    // Set customProperties.
+    // This creates css colors for each vuetify color class
+    outputConfig.options = {
+      'customProperties': true
+    }
+
+    return outputConfig;
   }
 }
 

--- a/src/util/ColorTheme.js
+++ b/src/util/ColorTheme.js
@@ -1,0 +1,115 @@
+import ColorUtil from './Color'
+
+// Macros for light/dark theme
+const LIGHT_WHITE = '#ffffff';
+const LIGHT_ERROR = '#FF5252';
+const LIGHT_BLACK = '#000000';
+const DARK_WHITE = '#ffffff';
+const DARK_BLACK = '#272727';
+const DARK_ERROR = '#FF5252';
+
+/**
+   * Gets the base color for the input color.
+   * See the theme object interface on
+   * https://vuetifyjs.com/en/features/theme/#custom-theme-variants
+   * @param {String | Object} color hexadecimal/object color
+   * @returns {String} base color
+   */
+function getBaseColor (color) {
+  return typeof color === 'object' ? color.base : color;
+}
+
+/**
+ * Checks luminance of the input color and:
+ *   - chooses "light" if color is dark;
+ *   - chooses "dark" if color is light
+ * @param {String | Object} color hexadecimal/object color
+ * @param {String} light hexadecimal color
+ * @param {String} dark hexadecimal color
+ * @returns {String} contrast color
+ */
+function contrastColor (color, light, dark) {
+  const baseColor = getBaseColor(color);
+
+  return ColorUtil.checkLuminance(baseColor) ? light : dark
+}
+
+/**
+ * Util class for vuetify theming
+ */
+const ColorThemeUtil = {
+  /**
+   * Merges user color theme with the default color theme
+   * @param {Object} userTheme user theme from app-config
+   * @param {Object} defaultTheme default Wegue theme
+   * @returns {Object} merged color theme
+   */
+  mergeThemes (userTheme, defaultTheme) {
+    const { light, dark } = userTheme;
+
+    const merged = {
+      light: {},
+      dark: {}
+    }
+
+    // If light theme is configured with at least the primary color
+    if (light && light.primary) {
+      // set primary color
+      merged.light.primary = light.primary;
+
+      // set secondary to user secondary,
+      // otherwise fallback to primary
+      merged.light.secondary = light.secondary ? light.secondary : light.primary;
+
+      // set accent to user accent,
+      // otherwise fallback to the light theme white
+      merged.light.accent = light.accent ? light.accent : LIGHT_WHITE;
+
+      // set onprimary to user onprimary,
+      // otherwise fallback to a color that contrasts with the primary
+      merged.light.onprimary = light.onprimary ? light.onprimary : contrastColor(merged.light.primary, LIGHT_WHITE, LIGHT_BLACK);
+
+      // set onprimary to user onsecondary,
+      // otherwise fallback to a color that contrasts with the secondary
+      merged.light.onsecondary = light.onsecondary ? light.onsecondary : contrastColor(merged.light.secondary, LIGHT_WHITE, LIGHT_BLACK);
+
+      // set error to user error,
+      // otherwise fallback to light theme error
+      merged.light.error = light.error ? light.error : LIGHT_ERROR;
+    } else {
+      // fallback to default ligth theme
+      merged.light = defaultTheme.light;
+    }
+
+    // If light theme is configured with at least the secondary color
+    if (dark && dark.secondary) {
+      // set primary to dark theme primary
+      merged.dark.primary = DARK_BLACK;
+
+      // set secondary
+      merged.dark.secondary = dark.secondary;
+
+      // set accent to user accent,
+      // otherwise fallback to secondary
+      merged.dark.accent = dark.accent ? dark.accent : dark.secondary;
+
+      // set onprimary to dark theme white
+      merged.dark.onprimary = DARK_WHITE;
+
+      // set onsecondary to user onsecondary,
+      // otherwise fallback to a color that contrasts with secondary
+      merged.dark.onsecondary = dark.onsecondary ? dark.onsecondary : contrastColor(merged.dark.secondary, DARK_WHITE, DARK_BLACK);
+
+      // set error to user error,
+      // otherwise fallback to dark theme error
+      merged.dark.error = dark.error ? dark.error : DARK_ERROR;
+    } else {
+      // fallback to default dark theme
+      merged.dark = defaultTheme.dark;
+    }
+
+    return merged;
+  }
+}
+
+export default ColorThemeUtil;

--- a/src/util/ColorTheme.js
+++ b/src/util/ColorTheme.js
@@ -7,6 +7,7 @@ const DEFAULT_THEMES = Object.freeze({
     'onprimary': '#ffffff',
     'secondary': '#af2622',
     'onsecondary': '#ffffff',
+    'anchor': '#af2622',
     'error': '#ff6f00'
   },
   'dark': {
@@ -14,6 +15,7 @@ const DEFAULT_THEMES = Object.freeze({
     'onprimary': '#ffffff',
     'secondary': '#ea9b9b',
     'onsecondary': '#272727',
+    'anchor': '#ea9b9b',
     'error': '#ff6f00'
   }
 });
@@ -92,6 +94,9 @@ const ColorThemeUtil = {
     // set accent to the light theme white
     merged.light.accent = contrastColor(merged.light.primary, LIGHT_WHITE, LIGHT_BLACK);
 
+    // set anchor to the light theme secondary
+    merged.light.anchor = merged.light.secondary;
+
     // set onprimary to user onprimary,
     // otherwise fallback to a color that contrasts with the primary
     merged.light.onprimary = light.onprimary ? light.onprimary : contrastColor(merged.light.primary, LIGHT_WHITE, LIGHT_BLACK);
@@ -118,6 +123,9 @@ const ColorThemeUtil = {
 
     // set secondary
     merged.dark.secondary = dark.secondary;
+
+    // set anchor to the dark theme secondary
+    merged.dark.anchor = merged.dark.secondary;
 
     // set accent to secondary
     merged.dark.accent = dark.secondary;

--- a/src/util/ColorTheme.js
+++ b/src/util/ColorTheme.js
@@ -57,7 +57,7 @@ function getBaseColor (color) {
 function contrastColor (color, light, dark) {
   const baseColor = getBaseColor(color);
 
-  return ColorUtil.checkLuminance(baseColor) ? light : dark
+  return ColorUtil.checkLuminance(baseColor) ? light : dark;
 }
 
 /**

--- a/test/unit/specs/WguAppTemplate.spec.js
+++ b/test/unit/specs/WguAppTemplate.spec.js
@@ -14,7 +14,6 @@ describe('WguAppTpl.vue', () => {
     beforeEach(() => {
       Vue.prototype.$appConfig = {
         showCopyrightYear: true,
-        baseColor: 'red',
         modules: {}
       };
       comp = shallowMount(WguAppTpl);
@@ -26,7 +25,6 @@ describe('WguAppTpl.vue', () => {
       expect(vm.floatingWins).to.be.an('array');
       expect(vm.sidebarWins).to.be.an('array');
       expect(vm.showCopyrightYear).to.equal(true);
-      expect(vm.baseColor).to.equal('red');
     });
   });
 

--- a/test/unit/specs/components/AppFooter.spec.js
+++ b/test/unit/specs/components/AppFooter.spec.js
@@ -23,7 +23,6 @@ describe('AppFooter.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal('red darken-3');
       expect(comp.vm.showCopyrightYear).to.equal(true);
     });
 

--- a/test/unit/specs/components/AppHeader.spec.js
+++ b/test/unit/specs/components/AppHeader.spec.js
@@ -8,20 +8,6 @@ describe('AppHeader.vue', () => {
     expect(typeof AppHeader).to.not.equal('undefined');
   });
 
-  describe('props', () => {
-    let comp;
-    let vm;
-    beforeEach(() => {
-      Vue.prototype.$appConfig = { modules: {} };
-      comp = shallowMount(AppHeader);
-      vm = comp.vm;
-    });
-
-    it('has correct default props', () => {
-      expect(vm.color).to.equal('red darken-3');
-    });
-  });
-
   describe('data', () => {
     let comp;
     let vm;
@@ -57,8 +43,7 @@ describe('AppHeader.vue', () => {
       // mock a module conf
       Vue.prototype.$appConfig = { modules: {
         'wgu-zoomtomaxextent': {
-          target: 'menu',
-          darkLayout: true
+          target: 'menu'
         } } };
       const moduleData = vm.getModuleButtons('menu');
       expect(moduleData).to.be.an('array');
@@ -77,8 +62,7 @@ describe('AppHeader.vue', () => {
       // mock a module conf
       Vue.prototype.$appConfig = { modules: {
         'wgu-zoomtomaxextent': {
-          target: 'toolbar',
-          darkLayout: true
+          target: 'toolbar'
         } } };
       const moduleData = vm.getModuleButtons('toolbar');
       expect(moduleData).to.be.an('array');

--- a/test/unit/specs/components/bglayerswitcher/BgLayerList.spec.js
+++ b/test/unit/specs/components/bglayerswitcher/BgLayerList.spec.js
@@ -5,10 +5,6 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 
 const moduleProps = {
-  'color': 'white',
-  'dark': true,
-  'selColor': 'red darken-3',
-  'selDark': true,
   'imageWidth': 152,
   'imageHeight': 114,
   'previewIcon': 'map'
@@ -34,10 +30,6 @@ describe('bglayerswitcher/BgLayerList.vue', () => {
     });
 
     it('has correct props', () => {
-      expect(vm.color).to.equal('white');
-      expect(vm.dark).to.equal(true);
-      expect(vm.selColor).to.equal('red darken-3');
-      expect(vm.selDark).to.equal(true);
       expect(vm.imageWidth).to.equal(152);
       expect(vm.imageHeight).to.equal(114);
       expect(vm.previewIcon).to.equal('map');

--- a/test/unit/specs/components/bglayerswitcher/BgLayerSwitcher.spec.js
+++ b/test/unit/specs/components/bglayerswitcher/BgLayerSwitcher.spec.js
@@ -1,10 +1,13 @@
 import { mount, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
 import BgLayerSwitcher from '@/components/bglayerswitcher/BgLayerSwitcher';
 import OlMap from 'ol/Map';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 
 describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
+  const vuetify = new Vuetify();
+
   it('is defined', () => {
     expect(BgLayerSwitcher).to.not.be.an('undefined');
   });
@@ -13,14 +16,14 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
     let comp;
     let vm;
     beforeEach(() => {
-      comp = shallowMount(BgLayerSwitcher);
+      comp = shallowMount(BgLayerSwitcher, {
+        vuetify
+      });
       vm = comp.vm
     });
 
     it('has correct default props', () => {
-      expect(vm.color).to.equal('red darken-3');
       expect(vm.icon).to.equal('map');
-      expect(vm.dark).to.equal(true);
       expect(vm.imageWidth).to.equal(152);
       expect(vm.imageHeight).to.equal(114);
     });
@@ -34,7 +37,9 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
     let comp;
     let vm;
     beforeEach(() => {
-      comp = shallowMount(BgLayerSwitcher);
+      comp = shallowMount(BgLayerSwitcher, {
+        vuetify
+      });
       vm = comp.vm;
     });
 
@@ -53,7 +58,9 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
     let comp;
     let vm;
     beforeEach(() => {
-      comp = shallowMount(BgLayerSwitcher);
+      comp = shallowMount(BgLayerSwitcher, {
+        vuetify
+      });
       vm = comp.vm;
     });
 
@@ -100,9 +107,7 @@ describe('bglayerswitcher/BgLayerSwitcher.vue', () => {
 
     beforeEach(() => {
       comp = mount(BgLayerSwitcher, {
-        created () {
-          this.$vuetify.theme = { dark: false };
-        },
+        vuetify,
         computed: {
           show () {
             return true;

--- a/test/unit/specs/components/geocoder/Geocoder.spec.js
+++ b/test/unit/specs/components/geocoder/Geocoder.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify'
 import Geocoder from '@/components/geocoder/Geocoder';
 import { OpenStreetMap } from '../../../../../src/components/geocoder/providers/osm';
 import { Photon } from '../../../../../src/components/geocoder/providers/photon';
@@ -8,6 +9,8 @@ import { fromLonLat } from 'ol/proj';
 // import * as sinon from 'sinon';
 
 describe('geocoder/Geocoder.vue', () => {
+  const vuetify = new Vuetify();
+
   // Inspect the raw component options
   it('is defined', () => {
     expect(typeof Geocoder).to.not.equal('undefined');
@@ -20,14 +23,15 @@ describe('geocoder/Geocoder.vue', () => {
   describe('props', () => {
     let comp;
     beforeEach(() => {
-      comp = shallowMount(Geocoder);
+      comp = shallowMount(Geocoder, {
+        vuetify
+      });
     });
 
     it('has correct default props', () => {
       expect(comp.vm.icon).to.equal('search');
       expect(comp.vm.rounded).to.equal(true);
       expect(comp.vm.autofocus).to.equal(true);
-      expect(comp.vm.dark).to.equal(false);
       expect(comp.vm.persistentHint).to.equal(true);
     });
   });
@@ -37,7 +41,9 @@ describe('geocoder/Geocoder.vue', () => {
     let vm;
 
     beforeEach(() => {
-      comp = shallowMount(Geocoder);
+      comp = shallowMount(Geocoder, {
+        vuetify
+      });
       vm = comp.vm;
     });
 
@@ -57,13 +63,13 @@ describe('geocoder/Geocoder.vue', () => {
     beforeEach(() => {
       const moduleProps = {
         'target': 'toolbar',
-        'darkLayout': true,
         'minChars': 5,
         'queryDelay': 200,
         'debug': false,
         'provider': 'photon'
       };
       comp = shallowMount(Geocoder, {
+        vuetify,
         propsData: moduleProps
       });
       vm = comp.vm;
@@ -85,13 +91,13 @@ describe('geocoder/Geocoder.vue', () => {
     beforeEach(() => {
       const moduleProps = {
         'target': 'toolbar',
-        'darkLayout': true,
         'minChars': 6,
         'queryDelay': 200,
         'debug': false,
         'provider': 'opencage'
       };
       comp = shallowMount(Geocoder, {
+        vuetify,
         propsData: moduleProps
       });
       vm = comp.vm;
@@ -122,6 +128,7 @@ describe('geocoder/Geocoder.vue', () => {
         'provider': 'osm'
       };
       comp = shallowMount(Geocoder, {
+        vuetify,
         propsData: moduleProps
       });
       vm = comp.vm;
@@ -208,7 +215,9 @@ describe('geocoder/Geocoder.vue', () => {
     let vm;
 
     beforeEach(() => {
-      comp = shallowMount(Geocoder);
+      comp = shallowMount(Geocoder, {
+        vuetify
+      });
       vm = comp.vm;
     });
 

--- a/test/unit/specs/components/infoclick/CoordsTable.spec.js
+++ b/test/unit/specs/components/infoclick/CoordsTable.spec.js
@@ -1,7 +1,10 @@
 import { shallowMount } from '@vue/test-utils';
 import CoordsTable from '@/components/infoclick/CoordsTable';
+import Vuetify from 'vuetify';
 
 describe('infoclick/CoordsTable.vue', () => {
+  const vuetify = new Vuetify();
+
   // Inspect the raw component options
   it('is defined', () => {
     expect(typeof CoordsTable).to.not.equal('undefined');
@@ -10,11 +13,12 @@ describe('infoclick/CoordsTable.vue', () => {
   describe('props', () => {
     let comp;
     beforeEach(() => {
-      comp = shallowMount(CoordsTable);
+      comp = shallowMount(CoordsTable, {
+        vuetify
+      });
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal('red darken-3');
       expect(comp.vm.coordsData).to.equal(undefined);
       expect(comp.vm.showMapPos).to.equal(true);
       expect(comp.vm.showWgsPos).to.equal(true);
@@ -25,7 +29,9 @@ describe('infoclick/CoordsTable.vue', () => {
   describe('data', () => {
     let comp;
     beforeEach(() => {
-      comp = shallowMount(CoordsTable);
+      comp = shallowMount(CoordsTable, {
+        vuetify
+      });
     });
 
     it('has correct default data', () => {
@@ -33,24 +39,12 @@ describe('infoclick/CoordsTable.vue', () => {
     });
   });
 
-  describe('computed properties', () => {
-    let comp;
-    beforeEach(() => {
-      comp = shallowMount(CoordsTable);
-    });
-
-    it('tableStyles returning correct color for given color', () => {
-      expect(comp.vm.tableStyles.border).to.equal('2px solid #c62828');
-      const color = 'rgb(0,0,0)';
-      comp.setProps({ color: color });
-      expect(comp.vm.tableStyles.border).to.equal('2px solid ' + color);
-    });
-  });
-
   describe('watchers', () => {
     let comp;
     beforeEach(() => {
-      comp = shallowMount(CoordsTable);
+      comp = shallowMount(CoordsTable, {
+        vuetify
+      });
     });
 
     it('watches coordsData', done => {

--- a/test/unit/specs/components/infoclick/InfoClickWin.spec.js
+++ b/test/unit/specs/components/infoclick/InfoClickWin.spec.js
@@ -23,7 +23,6 @@ describe('infoclick/InfoClickWin.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal('red darken-3');
       expect(comp.vm.icon).to.equal('info');
       expect(comp.vm.showMedia).to.equal(false);
       expect(comp.vm.mediaInfoLinkUrlProp).to.equal(undefined);

--- a/test/unit/specs/components/infoclick/PropertyTable.spec.js
+++ b/test/unit/specs/components/infoclick/PropertyTable.spec.js
@@ -14,22 +14,7 @@ describe('infoclick/PropertyTable.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal('red darken-3');
       expect(comp.vm.properties).to.equal(undefined);
-    });
-  });
-
-  describe('computed properties', () => {
-    let comp;
-    beforeEach(() => {
-      comp = shallowMount(PropertyTable);
-    });
-
-    it('tableStyles returning correct color for given color', () => {
-      expect(comp.vm.tableStyles.border).to.equal('2px solid #c62828');
-      const color = 'rgb(0,0,0)';
-      comp.setProps({ color: color });
-      expect(comp.vm.tableStyles.border).to.equal('2px solid ' + color);
     });
   });
 });

--- a/test/unit/specs/components/localeswitcher/LocaleSwitcher.spec.js
+++ b/test/unit/specs/components/localeswitcher/LocaleSwitcher.spec.js
@@ -27,7 +27,6 @@ describe('localeswitcher/LocaleSwitcher.vue', () => {
 
     it('has correct default props', () => {
       expect(vm.icon).to.equal('language');
-      expect(vm.dark).to.equal(false);
     });
 
     afterEach(() => {

--- a/test/unit/specs/components/modulecore/ModuleCard.spec.js
+++ b/test/unit/specs/components/modulecore/ModuleCard.spec.js
@@ -26,7 +26,6 @@ describe('modulecore/ModuleCard.vue', () => {
 
     it('has correct default props', () => {
       expect(comp.vm.minimizable).to.equal(false);
-      expect(comp.vm.color).to.equal('red darken-3');
       expect(comp.vm.backgroundImage).to.be.undefined;
       expect(comp.vm.draggable).to.equal(true);
       expect(comp.vm.visible).to.equal(false);

--- a/test/unit/specs/components/modulecore/ToggleButton.spec.js
+++ b/test/unit/specs/components/modulecore/ToggleButton.spec.js
@@ -25,7 +25,6 @@ describe('modulecore/ToggleButton.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal(null);
       expect(comp.vm.visible).to.equal(false);
     });
 

--- a/test/unit/specs/components/modulecore/ToggleButton.spec.js
+++ b/test/unit/specs/components/modulecore/ToggleButton.spec.js
@@ -25,7 +25,7 @@ describe('modulecore/ToggleButton.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.dark).to.equal(false);
+      expect(comp.vm.color).to.equal(null);
       expect(comp.vm.visible).to.equal(false);
     });
 

--- a/test/unit/specs/components/ol/Map.spec.js
+++ b/test/unit/specs/components/ol/Map.spec.js
@@ -42,7 +42,6 @@ describe('ol/Map.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(vm.color).to.equal('red darken-3');
       expect(vm.collapsibleAttribution).to.equal(false);
       expect(vm.rotateableMap).to.equal(false);
     });
@@ -191,12 +190,12 @@ describe('ol/Map.vue', () => {
       mockRotDiv.append(mockSubRotDiv);
       document.body.append(mockRotDiv);
 
-      comp.setProps({ color: 'rgb(0, 0, 0)' });
-      vm.setOlButtonColor();
+      // comp.setProps({ color: 'rgb(0, 0, 0)' });
+      // vm.setOlButtonColor();
 
-      expect(mockSubZoomInEl.style.backgroundColor).to.equal(vm.color);
-      expect(mockSubZoomOutEl.style.backgroundColor).to.equal(vm.color);
-      expect(mockSubRotDiv.style.backgroundColor).to.equal(vm.color);
+      // expect(mockSubZoomInEl.style.backgroundColor).to.equal(vm.color);
+      // expect(mockSubZoomOutEl.style.backgroundColor).to.equal(vm.color);
+      // expect(mockSubRotDiv.style.backgroundColor).to.equal(vm.color);
 
       // cleanup (otherwise follow up tests fail)
       mockZoomDiv.parentNode.removeChild(mockZoomDiv);
@@ -223,10 +222,9 @@ describe('ol/Map.vue', () => {
       mockRotDiv.append(mockSubRotEl);
       document.body.append(mockRotDiv);
 
-      // set a vuetify color definition like 'red darken-3'
-      const cssCls1 = 'red';
-      const cssCls2 = 'darken-3';
-      vm.color = cssCls1 + ' ' + cssCls2;
+      // set a vuetify color definition like 'secondary onsecondary--text'
+      const cssCls1 = 'secondary';
+      const cssCls2 = 'onsecondary--text';
       vm.setOlButtonColor();
 
       expect(mockSubZoomInEl.classList.contains(cssCls1)).to.equal(true);

--- a/test/unit/specs/components/ol/Map.spec.js
+++ b/test/unit/specs/components/ol/Map.spec.js
@@ -173,38 +173,6 @@ describe('ol/Map.vue', () => {
       expect(typeof selectIa).to.not.equal('undefined');
     });
 
-    it('setOlButtonColor applies CSS color to OL buttons', () => {
-      // mock a OL zoom button
-      const mockZoomDiv = document.createElement('div');
-      const mockSubZoomInEl = document.createElement('button');
-      const mockSubZoomOutEl = document.createElement('button');
-      mockZoomDiv.classList.add('ol-zoom');
-      mockSubZoomInEl.classList.add('ol-zoom-in');
-      mockSubZoomOutEl.classList.add('ol-zoom-out');
-      mockZoomDiv.append(mockSubZoomInEl);
-      mockZoomDiv.append(mockSubZoomOutEl);
-      document.body.append(mockZoomDiv);
-
-      // mock a OL rotate button
-      const mockRotDiv = document.createElement('div');
-      const mockSubRotDiv = document.createElement('div');
-      mockRotDiv.classList.add('ol-rotate');
-      mockSubRotDiv.classList.add('ol-rotate-reset');
-      mockRotDiv.append(mockSubRotDiv);
-      document.body.append(mockRotDiv);
-
-      // comp.setProps({ color: 'rgb(0, 0, 0)' });
-      // vm.setOlButtonColor();
-
-      // expect(mockSubZoomInEl.style.backgroundColor).to.equal(vm.color);
-      // expect(mockSubZoomOutEl.style.backgroundColor).to.equal(vm.color);
-      // expect(mockSubRotDiv.style.backgroundColor).to.equal(vm.color);
-
-      // cleanup (otherwise follow up tests fail)
-      mockZoomDiv.parentNode.removeChild(mockZoomDiv);
-      mockRotDiv.parentNode.removeChild(mockRotDiv);
-    });
-
     it('setOlButtonColor applies Vuetify color to OL buttons', () => {
       // mock a OL zoom button
       const mockZoomDiv = document.createElement('div');

--- a/test/unit/specs/components/ol/Map.spec.js
+++ b/test/unit/specs/components/ol/Map.spec.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import Vuetify from 'vuetify'
 import { mount } from '@vue/test-utils';
 import Map from '@/components/ol/Map';
 import OlMap from 'ol/Map';
@@ -19,6 +20,8 @@ const tileGridDefs = {
 };
 
 describe('ol/Map.vue', () => {
+  const vuetify = new Vuetify()
+
   // Inspect the raw component options
   it('is defined', () => {
     expect(typeof Map).to.not.equal('undefined');
@@ -37,7 +40,7 @@ describe('ol/Map.vue', () => {
     let vm;
     beforeEach(() => {
       Vue.prototype.$appConfig = { modules: {} };
-      comp = mount(Map);
+      comp = mount(Map, { vuetify });
       vm = comp.vm;
     });
 
@@ -55,7 +58,7 @@ describe('ol/Map.vue', () => {
     let comp;
     let vm;
     beforeEach(() => {
-      comp = mount(Map);
+      comp = mount(Map, { vuetify });
       vm = comp.vm;
     });
 
@@ -79,7 +82,7 @@ describe('ol/Map.vue', () => {
     let vm;
     beforeEach(() => {
       Vue.prototype.$appConfig = { tileGridDefs: tileGridDefs };
-      comp = mount(Map);
+      comp = mount(Map, { vuetify });
       vm = comp.vm;
     });
 
@@ -109,7 +112,7 @@ describe('ol/Map.vue', () => {
           ['EPSG:28992', '+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.999908 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.350732676542563,-1.8703473836068,4.0812 +no_defs']
         ]
       };
-      comp = mount(Map);
+      comp = mount(Map, { vuetify });
       vm = comp.vm;
     });
 
@@ -131,7 +134,7 @@ describe('ol/Map.vue', () => {
     let comp;
     let vm;
     beforeEach(() => {
-      comp = mount(Map);
+      comp = mount(Map, { vuetify });
       vm = comp.vm;
     });
 
@@ -331,7 +334,7 @@ describe('ol/Map.vue', () => {
           'visible': true
         }]
       };
-      comp = mount(Map);
+      comp = mount(Map, { vuetify });
       vm = comp.vm;
     });
 

--- a/test/unit/specs/components/progress/MapLoadingStatus.spec.js
+++ b/test/unit/specs/components/progress/MapLoadingStatus.spec.js
@@ -1,22 +1,9 @@
-import Vue from 'vue'
 import MapLoadingStatus from '@/components/progress/MapLoadingStatus'
 
 describe('progress/MapLoadingStatus.vue', () => {
   // Inspect the raw component options
   it('is defined', () => {
     expect(typeof MapLoadingStatus).to.not.equal('undefined');
-  });
-
-  it('has the correct properties', () => {
-    // Extend the component to get the constructor, which we can then
-    // initialize directly.
-    const Constructor = Vue.extend(MapLoadingStatus);
-    const comp = new Constructor({
-      // Props are passed in "propsData"
-      propsData: {}
-    }).$mount();
-
-    expect(comp.color).to.equal('red darken-3');
   });
 
   // Evaluate the results of functions in

--- a/test/unit/specs/components/themeswitcher/ThemeSwitcher.spec.js
+++ b/test/unit/specs/components/themeswitcher/ThemeSwitcher.spec.js
@@ -1,0 +1,82 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import ThemeSwitcher from '@/components/themeswitcher/ThemeSwitcher'
+import Vuetify from 'vuetify'
+
+describe('themeswitcher/ThemeSwitcher.vue', () => {
+  const localVue = createLocalVue();
+  let vuetify;
+
+  beforeEach(() => {
+    vuetify = new Vuetify()
+  });
+
+  // Inspect the raw component options
+  it('is defined', () => {
+    expect(typeof ThemeSwitcher).to.not.equal('undefined');
+  });
+
+  describe('unconfigured', () => {
+    let comp;
+
+    beforeEach(() => {
+      comp = mount(ThemeSwitcher, {
+        localVue,
+        vuetify
+      });
+    });
+
+    it('has correct default props', () => {
+      expect(comp.vm.color).to.equal(null);
+    });
+  });
+
+  describe('configured', () => {
+    let comp;
+
+    beforeEach(() => {
+      comp = mount(ThemeSwitcher, {
+        localVue,
+        vuetify,
+        propsData: {
+          color: '#af2622'
+        }
+      });
+    });
+
+    it('has correct default props', () => {
+      expect(comp.vm.color).to.equal('#af2622');
+    });
+  });
+
+  describe('theme switching', () => {
+    let comp, button;
+
+    before(() => {
+      comp = mount(ThemeSwitcher, {
+        localVue,
+        vuetify,
+        propsData: {
+          color: '#af2622'
+        }
+      });
+
+      button = comp.find('.v-btn');
+    });
+
+    it('start with light theme', () => {
+      expect(comp.vm.$vuetify.theme.dark).to.equal(false);
+    });
+
+    it('switch to dark theme', () => {
+      button.trigger('click');
+
+      expect(comp.vm.$vuetify.theme.dark).to.equal(true);
+    });
+
+    it('switch back to light theme', () => {
+      button.trigger('click');
+
+      expect(comp.vm.$vuetify.theme.dark).to.equal(false);
+    });
+  });
+});

--- a/test/unit/specs/components/themeswitcher/ThemeSwitcher.spec.js
+++ b/test/unit/specs/components/themeswitcher/ThemeSwitcher.spec.js
@@ -6,6 +6,11 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
   const localVue = createLocalVue();
   let vuetify;
 
+  const defaultProps = {
+    moduleName: 'wgu-toolbar',
+    icon: 'dark_mode'
+  }
+
   beforeEach(() => {
     vuetify = new Vuetify()
   });
@@ -21,7 +26,10 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
     beforeEach(() => {
       comp = mount(ThemeSwitcher, {
         localVue,
-        vuetify
+        vuetify,
+        propsData: {
+          ...defaultProps
+        }
       });
     });
 
@@ -38,12 +46,15 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
         localVue,
         vuetify,
         propsData: {
+          ...defaultProps,
           color: '#af2622'
         }
       });
     });
 
     it('has correct default props', () => {
+      expect(comp.vm.moduleName).to.equal('wgu-toolbar');
+      expect(comp.vm.icon).to.equal('dark_mode');
       expect(comp.vm.color).to.equal('#af2622');
     });
   });
@@ -56,6 +67,7 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
         localVue,
         vuetify,
         propsData: {
+          ...defaultProps,
           color: '#af2622'
         }
       });
@@ -67,14 +79,18 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
       expect(comp.vm.$vuetify.theme.dark).to.equal(false);
     });
 
-    it('switch to dark theme', () => {
+    it('switch to dark theme', async () => {
       button.trigger('click');
+
+      await comp.vm.$nextTick();
 
       expect(comp.vm.$vuetify.theme.dark).to.equal(true);
     });
 
-    it('switch back to light theme', () => {
+    it('switch back to light theme', async () => {
       button.trigger('click');
+
+      await comp.vm.$nextTick();
 
       expect(comp.vm.$vuetify.theme.dark).to.equal(false);
     });

--- a/test/unit/specs/components/themeswitcher/ThemeSwitcher.spec.js
+++ b/test/unit/specs/components/themeswitcher/ThemeSwitcher.spec.js
@@ -20,7 +20,7 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
     expect(typeof ThemeSwitcher).to.not.equal('undefined');
   });
 
-  describe('unconfigured', () => {
+  describe('configured', () => {
     let comp;
 
     beforeEach(() => {
@@ -34,28 +34,8 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
     });
 
     it('has correct default props', () => {
-      expect(comp.vm.color).to.equal(null);
-    });
-  });
-
-  describe('configured', () => {
-    let comp;
-
-    beforeEach(() => {
-      comp = mount(ThemeSwitcher, {
-        localVue,
-        vuetify,
-        propsData: {
-          ...defaultProps,
-          color: '#af2622'
-        }
-      });
-    });
-
-    it('has correct default props', () => {
       expect(comp.vm.moduleName).to.equal('wgu-toolbar');
       expect(comp.vm.icon).to.equal('dark_mode');
-      expect(comp.vm.color).to.equal('#af2622');
     });
   });
 
@@ -67,8 +47,7 @@ describe('themeswitcher/ThemeSwitcher.vue', () => {
         localVue,
         vuetify,
         propsData: {
-          ...defaultProps,
-          color: '#af2622'
+          ...defaultProps
         }
       });
 


### PR DESCRIPTION
This PR allows overriding the default Vuetify theme configuration.

#### Tasks:
* [x] add app context config to override the default theme;
   * property `baseColor` will be replaced by `colorTheme`; 
* [x] create toolbar tool to switch between light/dark modes;
* [x] write set of default colors (app-config);
  * fallback to default if no colors are provided;
* [x] remove deprecated color configurations (related to `baseColor`);
* [x]  add log message to warn on the deprecated `baseColor`;
* [x] update unit tests;
  * baseColor;
  * colorTheme;
  * darkLayout; 
* [x] update docs;
  * colorTheme property;
  * tips on how to pick theme colors;
* [x] update locales;

#### Extras:
* expose color classes as CSS variables ([docs](https://vuetifyjs.com/en/features/theme/#custom-properties));
* ~~allow~~ Vuetify theme presets (material studies).
  - requires webpack version >= 4

#### To improve in the future
* solo fields ([discussion here](https://github.com/meggsimum/wegue/pull/262#issuecomment-992700598));
* hover over cards ([discussion here](https://github.com/meggsimum/wegue/pull/262#issuecomment-981593703));

#### Material design guidelines
* [Color system](https://material.io/design/color/the-color-system.html);
* [Dark theme](https://material.io/design/color/dark-theme.html);
* [Components](https://material.io/archive/guidelines/material-design/introduction.html#);

Closes #202