### PR TITLE
Permalink layer exclusion

### DIFF
--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -17,7 +17,7 @@ The following properties can be applied to all map layer types
 | opacity            | Numeric value ranging from 0 to 1 describing the opaqueness of the layer. Defaults to `1.0`. | `"opacity": 0.5` |
 | zIndex             | Numeric value specifying the stack order of layers. Layers will be ordered by z-index and then by order of declaration. Defaults to `-1` for background layers and `0` for all other layers.  | `"zIndex": 2` |
 | displayInLayerList | Boolean value, whether the layer should appear in the LayerList. Ignored if the layer is a background layer - see option `isBaseLayer`  | `"displayInLayerList": true` |
-| supportsPermalink  | Boolean value, whether the layers state should be considered   in permanent links - see also [permalink](wegue-configuration?id=permalink). Defaults to `true`.  | `"supportsPermalink": true` |
+| supportsPermalink  | Boolean value, whether the layers state should be considered in permanent links - see also [permalink](wegue-configuration?id=permalink). Defaults to `true`.  | `"supportsPermalink": true` |
 | attributions       | Text or HTML string to be displayed as source attribution in the map. This setting will override the layer attributions declared in the language packs.  | `"attributions": "<a href='https://www.pdok.nl' target='_blank'>PDOK</a> by Dutch Kadaster",` |
 | previewImage       | URL to a preview image for layers to be displayed in the background layer selection control. This option has no effect if the layer is not a background layer - see option `isBaseLayer`  | `"previewImage": "static/icon/my-layer-preview.png"`  |
 

--- a/docs/map-layer-configuration.md
+++ b/docs/map-layer-configuration.md
@@ -17,6 +17,7 @@ The following properties can be applied to all map layer types
 | opacity            | Numeric value ranging from 0 to 1 describing the opaqueness of the layer. Defaults to `1.0`. | `"opacity": 0.5` |
 | zIndex             | Numeric value specifying the stack order of layers. Layers will be ordered by z-index and then by order of declaration. Defaults to `-1` for background layers and `0` for all other layers.  | `"zIndex": 2` |
 | displayInLayerList | Boolean value, whether the layer should appear in the LayerList. Ignored if the layer is a background layer - see option `isBaseLayer`  | `"displayInLayerList": true` |
+| supportsPermalink  | Boolean value, whether the layers state should be considered   in permanent links - see also [permalink](wegue-configuration?id=permalink). Defaults to `true`.  | `"supportsPermalink": true` |
 | attributions       | Text or HTML string to be displayed as source attribution in the map. This setting will override the layer attributions declared in the language packs.  | `"attributions": "<a href='https://www.pdok.nl' target='_blank'>PDOK</a> by Dutch Kadaster",` |
 | previewImage       | URL to a preview image for layers to be displayed in the background layer selection control. This option has no effect if the layer is not a background layer - see option `isBaseLayer`  | `"previewImage": "static/icon/my-layer-preview.png"`  |
 

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -21,7 +21,11 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | mapGeodataDragDop  | Configuration object for geodata file drag/drop functionality on the map. Only by setting the config this function will be enabled. | see [mapGeodataDragDop](wegue-configuration?id=mapGeodataDragDop) |
 | **modules**        | Array of module configuration objects | See [modules](module-configuration) |
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
+<<<<<<< HEAD
 | overviewMap        | Configuration object for the overview map. | See [overviewMap](wegue-configuration?id=overviewMap)
+=======
+| permalink          | Configuration object for permanent links. | See [permalink](wegue-configuration?id=permalink)
+>>>>>>> Added missing section for permalink configuration to the documentation.
 | projectionDefs     | Array of CRS / projection definition objects compatible to proj4js | See [projectionDefs](wegue-configuration?id=projectiondefs) |
 | tileGridDefs       | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
 | viewAnimation      | Configuration object for view animations | See [viewAnimation](wegue-configuration?id=viewAnimation) |
@@ -304,6 +308,7 @@ Below is an example for a sidebar configuration object:
   }
 ```
 
+<<<<<<< HEAD
 ### overviewMap
 Wegue integrates an overview map control, if the optional `overviewMap` property is declared. 
 
@@ -329,6 +334,36 @@ Below is an example for an overview map configuration object:
   }
 ```
 
+=======
+### permalink
+
+Wegue supports permanent links, which are URLs intenteded to remain unchanged and to be shared on the web. Wegue allows customization of its permalink URL encoding behaviour by the `permalink` property.
+
+The following configurations can be set:
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| location          | Whether to encode permalink attributes as part of the hash ('#' separator) or query string portion ('?' separator) of the URL. Defaults to query string portion.  | `"location": "hash"`
+| layers            | Include the visible state of layers. Defaults to `false` | `"layers": true`
+| extent            | Include the currently visible extent of layers. Defaults to `false` | `"extent": false`
+| projection        | Projection used to encode layer coordinates. Defaults to the global `mapProjection` | `"projection": "EPSG:4326"`
+| paramPrefix       | Additional prefix when encoding parameters. Per default no prefix is used. | `"paramPrefix": ""`
+| history           | Specifies whether to append UI interactions resulting in a permalink change to the browser history. Defaults to `false`. | `"history": true`
+| precision         | Decimal precision when encoding numeric parameters, e.g. layer coordinates. Defaults to `4`. | `"precision": 4`
+
+Below is an example for an permalink configuration object:
+
+```
+  "permalink": {
+    "location": "hash",
+    "layers": true,
+    "extent": false,
+    "projection": "EPSG:4326",
+    "paramPrefix": "",
+    "history": true
+  }
+```
+>>>>>>> Added missing section for permalink configuration to the documentation.
 ## Example configuration
 
 Example configurations can be found in the `app-starter/static` directory. Below an example as used in the Demo:

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -21,11 +21,8 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | mapGeodataDragDop  | Configuration object for geodata file drag/drop functionality on the map. Only by setting the config this function will be enabled. | see [mapGeodataDragDop](wegue-configuration?id=mapGeodataDragDop) |
 | **modules**        | Array of module configuration objects | See [modules](module-configuration) |
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
-<<<<<<< HEAD
 | overviewMap        | Configuration object for the overview map. | See [overviewMap](wegue-configuration?id=overviewMap)
-=======
 | permalink          | Configuration object for permanent links. | See [permalink](wegue-configuration?id=permalink)
->>>>>>> Added missing section for permalink configuration to the documentation.
 | projectionDefs     | Array of CRS / projection definition objects compatible to proj4js | See [projectionDefs](wegue-configuration?id=projectiondefs) |
 | tileGridDefs       | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
 | viewAnimation      | Configuration object for view animations | See [viewAnimation](wegue-configuration?id=viewAnimation) |
@@ -308,7 +305,6 @@ Below is an example for a sidebar configuration object:
   }
 ```
 
-<<<<<<< HEAD
 ### overviewMap
 Wegue integrates an overview map control, if the optional `overviewMap` property is declared. 
 
@@ -334,7 +330,6 @@ Below is an example for an overview map configuration object:
   }
 ```
 
-=======
 ### permalink
 
 Wegue supports permanent links, which are URLs intenteded to remain unchanged and to be shared on the web. Wegue allows customization of its permalink URL encoding behaviour by the `permalink` property.
@@ -363,7 +358,6 @@ Below is an example for an permalink configuration object:
     "history": true
   }
 ```
->>>>>>> Added missing section for permalink configuration to the documentation.
 ## Example configuration
 
 Example configurations can be found in the `app-starter/static` directory. Below an example as used in the Demo:

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -194,6 +194,9 @@ export default {
         // if not defined explicitly.
         lConf.zIndex = lConf.zIndex ?? (lConf.isBaseLayer ? -1 : 0);
 
+        // Default usage of permalink to true, if not explicitly defined.
+        lConf.supportsPermalink = lConf.supportsPermalink ?? true;
+
         let layer = LayerFactory.getInstance(lConf, me.map);
         layers.push(layer);
 

--- a/src/components/ol/PermalinkController.js
+++ b/src/components/ol/PermalinkController.js
@@ -13,7 +13,6 @@ export default class PermalinkController {
   projection = null;
   conf = null;
   urlParams = null;
-  ignoreLayers = ['wgu-measure-layer', 'wgu-geolocator-layer'];
 
   constructor (map, permalinkConf) {
     this.map = map;
@@ -266,7 +265,7 @@ export default class PermalinkController {
    */
   getLayerIds () {
     return this.map.getLayers().getArray().filter(
-      layer => !!layer.get('lid') && layer.getVisible() && !this.ignoreLayers.includes(layer.get('lid'))
+      layer => !!layer.get('lid') && layer.getVisible() && layer.get('supportsPermalink')
     ).map(layer => layer.get('lid'));
   }
 

--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -87,6 +87,7 @@ export const LayerFactory = {
       isBaseLayer: lConf.isBaseLayer,
       previewImage: lConf.previewImage,
       displayInLayerList: lConf.displayInLayerList,
+      supportsPermalink: lConf.supportsPermalink,
       extent: lConf.extent,
       visible: lConf.visible,
       opacity: lConf.opacity,

--- a/test/unit/specs/components/ol/PermalinkController.spec.js
+++ b/test/unit/specs/components/ol/PermalinkController.spec.js
@@ -26,6 +26,15 @@ const permalinkDef = {
     'isBaseLayer': false,
     'visible': false,
     'displayInLayerList': true
+  },
+  {
+    'type': 'OSM',
+    'lid': 'permalink-excluded-layer',
+    'isBaseLayer': false,
+    'visible': true,
+    'selectable': false,
+    'displayInLayerList': false,
+    'supportsPermalink': false
   }],
   permalink: {
     'location': 'hash',
@@ -88,17 +97,17 @@ describe('ol/Map.vue', () => {
 
     it('Setup permalinkController', () => {
       expect(vm.permalinkController.shouldUpdate).equals(true);
-      expect(vm.map.getLayers().getLength()).to.equal(2);
+      expect(vm.map.getLayers().getLength()).to.equal(3);
       vm.permalinkController.unsubscribeLayers();
       expect(vm.permalinkController.layerListeners.length).to.equal(0);
       vm.permalinkController.subscribeLayers();
-      expect(vm.permalinkController.layerListeners.length).to.equal(2);
+      expect(vm.permalinkController.layerListeners.length).to.equal(3);
     });
 
     it('Layer Listeners are (re)created when the layer stack changes', () => {
       vm.map.addLayer(new VectorLayer());
-      expect(vm.permalinkController.layerListeners.length).to.equal(3);
-      expect(vm.map.getLayers().getLength()).to.equal(3);
+      expect(vm.permalinkController.layerListeners.length).to.equal(4);
+      expect(vm.map.getLayers().getLength()).to.equal(4);
       vm.permalinkController.unsubscribeLayers();
       expect(vm.permalinkController.layerListeners.length).to.equal(0);
     });
@@ -168,7 +177,7 @@ describe('ol/Map.vue', () => {
       expect(mapView.getZoom()).to.equal(4);
       expect(Math.round(mapView.getCenter()[0])).to.equal(445278);
       expect(Math.round(mapView.getCenter()[1])).to.equal(6800125);
-      expect(Math.round(map.getLayers().getLength())).to.equal(2);
+      expect(Math.round(map.getLayers().getLength())).to.equal(3);
     });
     // Below gives problems in Karma as the document is reloaded by setting document.location.search!
     // it('Setup and apply permalinkController - apply from document.location.search', () => {


### PR DESCRIPTION
This branch implements dynmical exclusion of layers from permalinks by means of a newly introduced layer attribute `supportsPermalink`. The corresponding issue is described in #244 (resolves #244).

I also added a documentation section for the `permalink` configuration, which did not exist yet.