### PR TITLE
Overview map

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -70,7 +70,7 @@
   import AppSidebar from './components/AppSidebar'
   import AppLogo from '../src/components/AppLogo'
   import BgLayerSwitcher from '../src/components/bglayerswitcher/BgLayerSwitcher.vue'
-  import OverviewMap from './src/components/overviewmap/OverviewMap.vue'
+  import OverviewMap from '../src/components/overviewmap/OverviewMap.vue'
   import MeasureWin from '../src/components/measuretool/MeasureWin'
   import LayerListWin from '../src/components/layerlist/LayerListWin'
   import HelpWin from '../src/components/helpwin/HelpWin'

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -35,7 +35,7 @@
         <portal-target name="map-overlay" />
         <wgu-app-logo />
         <wgu-bglayerswitcher />
-        <wgu-overviewmap v-if="overviewMapConfig" :color="baseColor" v-bind="overviewMapConfig"/>
+        <wgu-overviewmap v-if="overviewMapConfig" v-bind="overviewMapConfig"/>
       </v-container>
     </v-content>
 

--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -35,6 +35,7 @@
         <portal-target name="map-overlay" />
         <wgu-app-logo />
         <wgu-bglayerswitcher />
+        <wgu-overviewmap v-if="overviewMapConfig" :color="baseColor" v-bind="overviewMapConfig"/>
       </v-container>
     </v-content>
 
@@ -69,6 +70,7 @@
   import AppSidebar from './components/AppSidebar'
   import AppLogo from '../src/components/AppLogo'
   import BgLayerSwitcher from '../src/components/bglayerswitcher/BgLayerSwitcher.vue'
+  import OverviewMap from './src/components/overviewmap/OverviewMap.vue'
   import MeasureWin from '../src/components/measuretool/MeasureWin'
   import LayerListWin from '../src/components/layerlist/LayerListWin'
   import HelpWin from '../src/components/helpwin/HelpWin'
@@ -86,6 +88,7 @@
       'wgu-app-sidebar': AppSidebar,
       'wgu-app-logo': AppLogo,
       'wgu-bglayerswitcher': BgLayerSwitcher,
+      'wgu-overviewmap': OverviewMap,
       'wgu-measuretool-win': MeasureWin,
       'wgu-layerlist-win': LayerListWin,
       'wgu-helpwin-win': HelpWin,
@@ -98,6 +101,7 @@
       return {
         isEmbedded: false,
         sidebarConfig: this.getSidebarConfig(),
+        overviewMapConfig: this.getOverviewMapConfig(),
         floatingWins: this.getModuleWinData('floating'),
         sidebarWins: this.getModuleWinData('sidebar'),
         showCopyrightYear: Vue.prototype.$appConfig.showCopyrightYear
@@ -130,6 +134,14 @@
       getSidebarConfig () {
         const appConfig = Vue.prototype.$appConfig || {};
         return appConfig['sidebar'];
+      },
+      /**
+       * Returns the configuration object for the overview map from app-config.
+       * @return {Object} Overview map configuration object.
+       */
+      getOverviewMapConfig () {
+        const appConfig = Vue.prototype.$appConfig || {};
+        return appConfig['overviewMap'];
       },
       /**
        * Determines the module window configuration objects from app-config:

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -42,6 +42,11 @@
     ]
   ],
 
+  "overviewMap" : {
+    "collapsible": true,
+    "collapsed": false
+  },
+
   "viewAnimation": {
     "type": "fly",
     "options": {

--- a/app-starter/static/app-conf-projected.json
+++ b/app-starter/static/app-conf-projected.json
@@ -43,8 +43,7 @@
   ],
 
   "overviewMap" : {
-    "collapsible": true,
-    "collapsed": false
+    "visible": false
   },
 
   "viewAnimation": {

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -28,8 +28,7 @@
   },
 
   "overviewMap" : {
-    "collapsible": true,
-    "collapsed": false
+    "visible": false
   },
 
   "viewAnimation": {

--- a/app-starter/static/app-conf-sidebar.json
+++ b/app-starter/static/app-conf-sidebar.json
@@ -27,6 +27,11 @@
     "displayInLayerList": true
   },
 
+  "overviewMap" : {
+    "collapsible": true,
+    "collapsed": false
+  },
+
   "viewAnimation": {
     "type": "fly",
     "options": {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -28,8 +28,7 @@
   },
 
   "overviewMap" : {
-    "collapsible": true,
-    "collapsed": false
+    "visible": false
   },
 
   "viewAnimation": {

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -27,6 +27,11 @@
     "displayInLayerList": true
   },
 
+  "overviewMap" : {
+    "collapsible": true,
+    "collapsed": false
+  },
+
   "viewAnimation": {
     "type": "fly",
     "options": {

--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -21,6 +21,7 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | mapGeodataDragDop  | Configuration object for geodata file drag/drop functionality on the map. Only by setting the config this function will be enabled. | see [mapGeodataDragDop](wegue-configuration?id=mapGeodataDragDop) |
 | **modules**        | Array of module configuration objects | See [modules](module-configuration) |
 | **mapLayers**      | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
+| overviewMap        | Configuration object for the overview map. | See [overviewMap](wegue-configuration?id=overviewMap)
 | projectionDefs     | Array of CRS / projection definition objects compatible to proj4js | See [projectionDefs](wegue-configuration?id=projectiondefs) |
 | tileGridDefs       | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
 | viewAnimation      | Configuration object for view animations | See [viewAnimation](wegue-configuration?id=viewAnimation) |
@@ -303,6 +304,31 @@ Below is an example for a sidebar configuration object:
   }
 ```
 
+### overviewMap
+Wegue integrates an overview map control, if the optional `overviewMap` property is declared. 
+
+The `overviewMap` object supports the following properties:
+
+| Property           | Meaning   | Example |
+|--------------------|:---------:|---------|
+| icon               | Provide a customized map icon. Defaults to `zoom_out_map`.  | `"icon": "zoom_out_map"` |
+| visible            | Specifies whether the overviewMap appears in open or closed state on application start. Defaults to true. | `"visible": true` |
+| rotateWithView     | Whether the control view should rotate with the main map view. Defaults to true. | `"rotateWithView": true` |
+| width              | Width of the overview map panel in viewport coordinates. Defaults to 164px.  | `"width": 164` |
+| height             | Height of the overview map panel in viewport coordinates. Defaults to 178px.  | `"height": 178` |
+
+Below is an example for an overview map configuration object:
+
+
+```
+  "overviewMap": {
+    "visible": true,
+    "rotateWithView": true,
+    "width": 164,
+    "height": 178
+  }
+```
+
 ## Example configuration
 
 Example configurations can be found in the `app-starter/static` directory. Below an example as used in the Demo:
@@ -311,7 +337,7 @@ Example configurations can be found in the `app-starter/static` directory. Below
 {
 
   "colorTheme": {
-    "dark": false,
+    "dark": false
   },
 
   "logo": "https://dummyimage.com/100x100/aaa/fff&text=Wegue",
@@ -335,6 +361,10 @@ Example configurations can be found in the `app-starter/static` directory. Below
     "zoomToData": true,
     "replaceData": true,
     "displayInLayerList": true
+  },
+
+  "overviewMap" : {
+    "visible": false
   },
 
   "viewAnimation": {
@@ -559,6 +589,10 @@ Example configurations can be found in the `app-starter/static` directory. Below
     },
     "wgu-geolocator": {
       "target": "toolbar"
+    },
+    "wgu-themeswitcher": {
+      "target": "toolbar",
+      "icon": "dark_mode"
     },
     "wgu-attributetable": {
       "target": "menu",

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -39,6 +39,22 @@ html {
   background-color: rgba(255,255,255,0.6) !important;
 }
 
+.wgu-overviewmap,
+.wgu-overviewmap.ol-uncollapsible {
+  top: auto;
+  left: auto;
+  bottom: 8em;
+  right: 0.5em;
+}
+
+.wgu-overviewmap:not(.ol-collapsed) button{ 
+  top: auto; 
+  left: auto;
+  bottom: 2px;
+  right: 2px;
+}
+
+
 /*
   TODO Review ccs colorization.
   Used to force the onprimary color for solo fields (light theme only).

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -72,7 +72,11 @@ html {
   border: none;
   width: 100%;
   height: 100%;
-} 
+}
+
+.ol-overviewmap-box {
+  border: 2px dotted var(--v-secondary-base);
+}
 
 /*
   TODO Review ccs colorization.

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -59,13 +59,14 @@ html {
 
 .wgu-overviewmap-ctrl,
 .wgu-overviewmap-ctrl.ol-uncollapsible {
-  line-height: normal;
+  width: 100%;
+  height: 100%;
 }
 
 .wgu-overviewmap-ctrl .ol-overviewmap-map {
   border: none;
-  width: 152px;
-  height: 166px;
+  width: 100%;
+  height: 100%;
 } 
 
 /*

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -41,6 +41,7 @@ html {
 
 .wgu-overviewmap,
 .wgu-overviewmap.ol-uncollapsible {
+  line-height: normal;
   top: auto;
   left: auto;
   bottom: 8em;
@@ -54,6 +55,22 @@ html {
   right: 2px;
 }
 
+.wgu-overviewmap .ol-overviewmap-map {
+  border: none;
+  width: 152px;
+  height: 166px;
+} 
+
+/* Vuetify card like style for the OL overview map. 
+   Remarks: v-card class cannot be applied to the control, because this will affect the style 
+   of the open/close button.
+*/
+.wgu-overviewmap:not(.ol-collapsed) {
+  border-radius: 4px;
+  padding: 4px;
+  background-color: white;
+  box-shadow: 0 3px 1px -2px rgba(0,0,0,.2),0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12);
+}
 
 /*
   TODO Review ccs colorization.

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -74,7 +74,7 @@ html {
   height: 100%;
 }
 
-.ol-overviewmap-box {
+.wgu-overviewmap-ctrl .ol-overviewmap-box {
   border: 2px dotted var(--v-secondary-base);
 }
 

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -25,32 +25,37 @@ html {
   bottom: 45px;
 }
 
-.wgu-bglayerswitcher {
+/*
+  Common style for action buttons placed over the map.
+  This is to match the look and feel of the OL buttons to give
+  them a border for better map constrast.
+*/
+.wgu-map-button {
   position: absolute; 
   z-index: 2; 
+  padding: 3px;
+  border-radius: 50%;
+  background-color: rgba(255,255,255,0.4) !important;  
+}
+
+.wgu-map-button:hover {
+  background-color: rgba(255,255,255,0.6) !important;
+}
+
+/* 
+ Background layer switcher positioning and styles.
+*/
+.wgu-bglayerswitcher {
   left: 15px;
   top: 70px;
-  padding: 3px;
-  border-radius: 50%;
-  background-color: rgba(255,255,255,0.4) !important;
 }
 
-.wgu-bglayerswitcher:hover {
-  background-color: rgba(255,255,255,0.6) !important;
-}
-
+/* 
+ Overview map positioning and styles.
+*/
 .wgu-overviewmap {
-  position: absolute; 
-  z-index: 2;
   left: 15px;
   top: calc(50% - 23px);
-  padding: 3px;
-  border-radius: 50%;
-  background-color: rgba(255,255,255,0.4) !important;
-}
-
-.wgu-overviewmap:hover {
-  background-color: rgba(255,255,255,0.6) !important;
 }
 
 .wgu-overviewmap-ctrl {

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -28,7 +28,7 @@ html {
 /*
   Common style for action buttons placed over the map.
   This is to match the look and feel of the OL buttons to give
-  them a border for better map constrast.
+  them a border for better map contrast.
 */
 .wgu-map-button {
   position: absolute; 

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -51,8 +51,8 @@ html {
 .wgu-overviewmap:not(.ol-collapsed) button{ 
   top: auto; 
   left: auto;
-  bottom: 2px;
-  right: 2px;
+  bottom: 7px;
+  right: 7px;
 }
 
 .wgu-overviewmap .ol-overviewmap-map {
@@ -63,13 +63,14 @@ html {
 
 /* Vuetify card like style for the OL overview map. 
    Remarks: v-card class cannot be applied to the control, because this will affect the style 
-   of the open/close button.
+   of the control in collapsed state.
 */
 .wgu-overviewmap:not(.ol-collapsed) {
   border-radius: 4px;
   padding: 4px;
   background-color: white;
   box-shadow: 0 3px 1px -2px rgba(0,0,0,.2),0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12);
+  transform: translate(5px, 5px);
 }
 
 /*

--- a/src/assets/css/wegue.css
+++ b/src/assets/css/wegue.css
@@ -39,39 +39,34 @@ html {
   background-color: rgba(255,255,255,0.6) !important;
 }
 
-.wgu-overviewmap,
-.wgu-overviewmap.ol-uncollapsible {
+.wgu-overviewmap {
+  position: absolute; 
+  z-index: 2;
+  left: 15px;
+  top: calc(50% - 23px);
+  padding: 3px;
+  border-radius: 50%;
+  background-color: rgba(255,255,255,0.4) !important;
+}
+
+.wgu-overviewmap:hover {
+  background-color: rgba(255,255,255,0.6) !important;
+}
+
+.wgu-overviewmap-ctrl {
+  position: relative;
+}
+
+.wgu-overviewmap-ctrl,
+.wgu-overviewmap-ctrl.ol-uncollapsible {
   line-height: normal;
-  top: auto;
-  left: auto;
-  bottom: 8em;
-  right: 0.5em;
 }
 
-.wgu-overviewmap:not(.ol-collapsed) button{ 
-  top: auto; 
-  left: auto;
-  bottom: 7px;
-  right: 7px;
-}
-
-.wgu-overviewmap .ol-overviewmap-map {
+.wgu-overviewmap-ctrl .ol-overviewmap-map {
   border: none;
   width: 152px;
   height: 166px;
 } 
-
-/* Vuetify card like style for the OL overview map. 
-   Remarks: v-card class cannot be applied to the control, because this will affect the style 
-   of the control in collapsed state.
-*/
-.wgu-overviewmap:not(.ol-collapsed) {
-  border-radius: 4px;
-  padding: 4px;
-  background-color: white;
-  box-shadow: 0 3px 1px -2px rgba(0,0,0,.2),0 2px 2px 0 rgba(0,0,0,.14),0 1px 5px 0 rgba(0,0,0,.12);
-  transform: translate(5px, 5px);
-}
 
 /*
   TODO Review ccs colorization.

--- a/src/components/bglayerswitcher/BgLayerSwitcher.vue
+++ b/src/components/bglayerswitcher/BgLayerSwitcher.vue
@@ -7,7 +7,7 @@
       attach="#wgu-bglayerswitcher-wrapper"
       >
       <template v-slot:activator="{on}">
-        <v-sheet class="wgu-bglayerswitcher">
+        <v-sheet class="wgu-map-button wgu-bglayerswitcher">
           <v-btn v-on="on"
             color="secondary"
             fab

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -64,12 +64,18 @@ export default {
     // Make the OL map accessible for Mapable mixin even 'ol-map-mounted' has
     // already been fired. Don not use directly in cmps, use Mapable instead.
     Vue.prototype.$map = me.map;
+
+    me.map.setTarget(document.getElementById('ol-map-container'));
+
     // Send the event 'ol-map-mounted' with the OL map as payload
     WguEventBus.$emit('ol-map-mounted', me.map);
 
-    // resize the map, so it fits to parent
+    // TODO
+    //  Re-evaluate whether and if yes which of the following operations have to be deferred.
+    //  If so, a better implementation could be to rely on this.$nextTick(), which currently causes trouble
+    //  for the units tests (deferred operations are invoked after the component has already been destroyed).
     me.timerHandle = setTimeout(() => {
-      me.map.setTarget(document.getElementById('ol-map-container'));
+      // resize the map, so it fits to parent
       me.map.updateSize();
 
       // adjust the bg color of the OL buttons (like zoom, rotate north, ...)

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -86,6 +86,10 @@ export default {
     }, 200);
   },
   destroyed () {
+    // Send the event 'ol-map-unmounted' with the OL map as payload
+    WguEventBus.$emit('ol-map-unmounted', this.map);
+
+    // Destroy controllers, remove map references
     if (this.timerHandle) {
       clearTimeout(this.timerHandle);
     }
@@ -93,8 +97,13 @@ export default {
       this.permalinkController.tearDown();
       this.permalinkController = undefined;
     }
-    // Send the event 'ol-map-unmounted' with the OL map as payload
-    WguEventBus.$emit('ol-map-unmounted', this.map);
+    if (this.map) {
+      this.map.getLayers().clear();
+      this.map.getInteractions().clear();
+      this.map.getControls().clear();
+      this.map.getOverlays().clear();
+    }
+    this.map = undefined;
   },
   created () {
     // make map rotateable according to property

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -1,77 +1,52 @@
-<!-- 
-  This component wraps up an OpenLayers overview map and is attached directly to the 
-  ol-map-container, currently without any vue speficic template code.
--->
-
+<template>
+  <div id="wgu-overviewmap-wrapper">
+    <v-menu offset-x nudge-right="15"
+      transition="scale-transition"
+      :close-on-content-click="false"
+      :close-on-click="false"
+      v-model="open"
+      attach="#wgu-overviewmap-wrapper"
+      >
+      <template v-slot:activator="{on}">
+        <v-sheet class="wgu-overviewmap">
+          <v-btn v-on="on"
+            :color="color" 
+            :dark="dark"
+            fab
+            :title="$t('wgu-overviewmap.title')"
+            >
+            <v-icon medium>{{icon}}</v-icon>
+          </v-btn>
+        </v-sheet>
+      </template>
+      <!-- Remarks: The overviewmap-panel is wrapped by an v-if block to avoid unneccesary image 
+          requests when the panel is not visible -->
+      <wgu-overviewmap-panel v-if="open"
+        color="white"
+        :dark="false"
+        :rotateWithView="rotateWithView"
+      />
+    </v-menu>
+  </div>
+</template>
 <script>
-import { Mapable } from '../../mixins/Mapable';
-import OverviewMapController from './OverviewMapController';
+import OverviewMapPanel from './OverviewMapPanel';
 
 export default {
   name: 'wgu-overviewmap',
-  mixins: [Mapable],
+  components: {
+    'wgu-overviewmap-panel': OverviewMapPanel
+  },
   props: {
     color: { type: String, required: false, default: 'red darken-3' },
-    collapsible: { type: Boolean, required: false, default: true },
+    icon: { type: String, required: false, default: 'zoom_out_map' },
+    dark: { type: Boolean, required: false, default: true },
     collapsed: { type: Boolean, required: false, default: true },
-    label: { type: String, required: false, default: '\u00AB' },
-    collapseLabel: { type: String, required: false, default: '\u00BB' },
     rotateWithView: { type: Boolean, required: false, default: true }
   },
   data () {
     return {
-      layers: []
-    }
-  },
-  render () {
-  },
-  destroyed () {
-    this.destroy();
-  },
-  methods: {
-    /**
-     * This function is executed, after the map is bound (see mixins/Mapable).
-     * Bind to the layers from the OpenLayers map.
-     */
-    onMapBound () {
-      this.layers = this.map.getLayers().getArray();
-      this.overviewMap = new OverviewMapController(this.map, this.$props);
-    },
-    /**
-     * This function is executed, before the map is unbound (see mixins/Mapable)
-     */
-    onMapUnbound () {
-      this.destroy();
-    },
-    /**
-     * Tears down the overview map controller.
-     */
-    destroy () {
-      if (this.overviewMap) {
-        this.overviewMap.destroy();
-        this.overviewMap = undefined;
-      }
-    }
-  },
-  computed: {
-    /**
-     * Reactive property to return the currently visible OpenLayers background layer.
-     * To disambiguate multiple selected background layers - which may occur programmatically -
-     * this returns the first in the list of background layers.
-     */
-    selectedBgLayer () {
-      return this.layers
-        .filter(layer => layer.get('isBaseLayer'))
-        .reverse()
-        .find(layer => layer.getVisible());
-    }
-  },
-  watch: {
-    /**
-     * Watch for background layer selection change.
-     */
-    selectedBgLayer () {
-      this.overviewMap.setLayer(this.selectedBgLayer);
+      open: !this.collapsed
     }
   }
 };

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -25,6 +25,9 @@ export default {
   },
   render () {
   },
+  destroyed () {
+    this.destroy();
+  },
   methods: {
     /**
      * This function is executed, after the map is bound (see mixins/Mapable).
@@ -33,6 +36,21 @@ export default {
     onMapBound () {
       this.layers = this.map.getLayers().getArray();
       this.overviewMap = new OverviewMapController(this.map, this.$props);
+    },
+    /**
+     * This function is executed, before the map is unbound (see mixins/Mapable)
+     */
+    onMapUnbound () {
+      this.destroy();
+    },
+    /**
+     * Tears down the overview map controller.
+     */
+    destroy () {
+      if (this.overviewMap) {
+        this.overviewMap.destroy();
+        this.overviewMap = undefined;
+      }
     }
   },
   computed: {

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -42,12 +42,12 @@ export default {
     color: { type: String, required: false, default: 'red darken-3' },
     icon: { type: String, required: false, default: 'zoom_out_map' },
     dark: { type: Boolean, required: false, default: true },
-    collapsed: { type: Boolean, required: false, default: true },
+    visible: { type: Boolean, required: false, default: true },
     rotateWithView: { type: Boolean, required: false, default: true }
   },
   data () {
     return {
-      open: !this.collapsed
+      open: this.visible
     }
   }
 };

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -1,0 +1,52 @@
+<template>
+  <div id="wgu-overviewmap-wrapper" />
+</template>
+
+<script>
+import { Mapable } from '../../mixins/Mapable';
+import OverviewMapController from './OverviewMapController';
+
+export default {
+  name: 'wgu-overviewmap',
+  mixins: [Mapable],
+  props: {
+  },
+  data () {
+    return {
+      layers: []
+    }
+  },
+  methods: {
+    /**
+     * This function is executed, after the map is bound (see mixins/Mapable).
+     * Bind to the layers from the OpenLayers map.
+     */
+    onMapBound () {
+      this.layers = this.map.getLayers().getArray();
+      this.overviewMap = new OverviewMapController(this.map)
+    }
+  },
+  computed: {
+    /**
+     * Reactive property to return the currently visible OpenLayers background layer.
+     * To disambiguate multiple selected background layers - which may occur programmatically -
+     * this returns the first in the list of background layers.
+     * TODO replace by background-layer-change event
+     */
+    selectedBgLayer () {
+      return this.layers
+        .filter(layer => layer.get('isBaseLayer'))
+        .reverse()
+        .find(layer => layer.getVisible());
+    }
+  },
+  watch: {
+    /**
+     * Watch for background layer selection change.
+     */
+    selectedBgLayer () {
+      this.overviewMap.setLayer(this.selectedBgLayer);
+    }
+  }
+};
+</script>

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -26,6 +26,8 @@
         color="white"
         :dark="false"
         :rotateWithView="rotateWithView"
+        :width="width"
+        :height="height"
       />
     </v-menu>
   </div>
@@ -43,7 +45,9 @@ export default {
     icon: { type: String, required: false, default: 'zoom_out_map' },
     dark: { type: Boolean, required: false, default: true },
     visible: { type: Boolean, required: false, default: true },
-    rotateWithView: { type: Boolean, required: false, default: true }
+    rotateWithView: { type: Boolean, required: false, default: true },
+    width: { type: Number, required: false, default: 164 },
+    height: { type: Number, required: false, default: 178 }
   },
   data () {
     return {

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -4,6 +4,7 @@
       transition="scale-transition"
       :close-on-content-click="false"
       :close-on-click="false"
+      z-index=2
       v-model="open"
       attach="#wgu-overviewmap-wrapper"
       >

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -1,6 +1,7 @@
-<template>
-  <div id="wgu-overviewmap-wrapper" />
-</template>
+<!-- 
+  This component wraps up an OpenLayers overview map and is attached directly to the 
+  ol-map-container, currently without any vue speficic template code.
+-->
 
 <script>
 import { Mapable } from '../../mixins/Mapable';
@@ -15,6 +16,8 @@ export default {
     return {
       layers: []
     }
+  },
+  render () {
   },
   methods: {
     /**

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -9,7 +9,7 @@
       attach="#wgu-overviewmap-wrapper"
       >
       <template v-slot:activator="{on}">
-        <v-sheet class="wgu-overviewmap">
+        <v-sheet class="wgu-map-button wgu-overviewmap">
           <v-btn v-on="on"
             color="secondary" 
             fab

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -11,20 +11,17 @@
       <template v-slot:activator="{on}">
         <v-sheet class="wgu-overviewmap">
           <v-btn v-on="on"
-            :color="color" 
-            :dark="dark"
+            color="secondary" 
             fab
             :title="$t('wgu-overviewmap.title')"
             >
-            <v-icon medium>{{icon}}</v-icon>
+            <v-icon color="onsecondary" medium>{{icon}}</v-icon>
           </v-btn>
         </v-sheet>
       </template>
       <!-- Remarks: The overviewmap-panel is wrapped by an v-if block to avoid unneccesary image 
           requests when the panel is not visible -->
       <wgu-overviewmap-panel v-if="open"
-        color="white"
-        :dark="false"
         :rotateWithView="rotateWithView"
         :width="width"
         :height="height"
@@ -41,9 +38,7 @@ export default {
     'wgu-overviewmap-panel': OverviewMapPanel
   },
   props: {
-    color: { type: String, required: false, default: 'red darken-3' },
     icon: { type: String, required: false, default: 'zoom_out_map' },
-    dark: { type: Boolean, required: false, default: true },
     visible: { type: Boolean, required: false, default: true },
     rotateWithView: { type: Boolean, required: false, default: true },
     width: { type: Number, required: false, default: 164 },

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -11,6 +11,7 @@ export default {
   name: 'wgu-overviewmap',
   mixins: [Mapable],
   props: {
+    color: { type: String, required: false, default: 'red darken-3' }
   },
   data () {
     return {
@@ -26,7 +27,7 @@ export default {
      */
     onMapBound () {
       this.layers = this.map.getLayers().getArray();
-      this.overviewMap = new OverviewMapController(this.map)
+      this.overviewMap = new OverviewMapController(this.map, this.$props);
     }
   },
   computed: {
@@ -34,7 +35,6 @@ export default {
      * Reactive property to return the currently visible OpenLayers background layer.
      * To disambiguate multiple selected background layers - which may occur programmatically -
      * this returns the first in the list of background layers.
-     * TODO replace by background-layer-change event
      */
     selectedBgLayer () {
       return this.layers

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -11,7 +11,12 @@ export default {
   name: 'wgu-overviewmap',
   mixins: [Mapable],
   props: {
-    color: { type: String, required: false, default: 'red darken-3' }
+    color: { type: String, required: false, default: 'red darken-3' },
+    collapsible: { type: Boolean, required: false, default: true },
+    collapsed: { type: Boolean, required: false, default: true },
+    label: { type: Boolean, required: false, default: '\u00AB' },
+    collapseLabel: { type: String, required: false, default: '\u00BB' },
+    rotateWithView: { type: Boolean, required: false, default: true }
   },
   data () {
     return {

--- a/src/components/overviewmap/OverviewMap.vue
+++ b/src/components/overviewmap/OverviewMap.vue
@@ -14,7 +14,7 @@ export default {
     color: { type: String, required: false, default: 'red darken-3' },
     collapsible: { type: Boolean, required: false, default: true },
     collapsed: { type: Boolean, required: false, default: true },
-    label: { type: Boolean, required: false, default: '\u00AB' },
+    label: { type: String, required: false, default: '\u00AB' },
     collapseLabel: { type: String, required: false, default: '\u00BB' },
     rotateWithView: { type: Boolean, required: false, default: true }
   },

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -9,6 +9,7 @@ export default class OverviewMapController {
   overviewMapControl = null;
   map = null;
   layer = null;
+  timerHandle = null
 
   /**
    * Construction
@@ -34,7 +35,7 @@ export default class OverviewMapController {
     // the overview map control. Presumably because no sizes have been computed yet on the
     // target DOM element. Another deferred render operation within requestAnimationFrame is
     // necessary to correctly position the selection box.
-    setTimeout(() => {
+    this.timerHandle = setTimeout(() => {
       this.map.addControl(this.overviewMapControl);
       this.setOlStyle();
       requestAnimationFrame(() => {
@@ -47,6 +48,9 @@ export default class OverviewMapController {
    * Unregister the OpenLayers overview map.
    */
   destroy () {
+    if (this.timerHandle) {
+      clearTimeout(this.timerHandle);
+    }
     if (this.layer) {
       const overviewMap = this.overviewMapControl.getOverviewMap();
       overviewMap.getLayers().clear();
@@ -54,6 +58,7 @@ export default class OverviewMapController {
     if (this.map) {
       this.map.removeControl(this.overviewMapControl);
     }
+    this.timerHandle = null;
     this.layer = null;
     this.map = null;
     this.overviewMapControl = null;

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -36,7 +36,7 @@ export default class OverviewMapController {
     // necessary to correctly position the selection box.
     setTimeout(() => {
       this.map.addControl(this.overviewMapControl);
-      this.setOlStyle(this.conf.color);
+      this.setOlStyle();
       requestAnimationFrame(() => {
         this.overviewMapControl.render();
       });
@@ -61,9 +61,8 @@ export default class OverviewMapController {
 
   /**
    * Applies a vuetify card like style to the inner overview map.
-   * @param {String} color The color to set.
    */
-  setOlStyle (color) {
+  setOlStyle () {
     document.querySelector('.ol-overviewmap-map').classList.add('v-card', 'ma-0');
   }
 

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -32,10 +32,14 @@ export default class OverviewMapController {
     // TODO:
     // Workaround because without defering the following operation, OL will fail to render
     // the overview map control. Presumably because no sizes have been computed yet on the
-    // target DOM element. Currently the selection box is also displaced initially.
+    // target DOM element. Another deferred render operation within requestAnimationFrame is
+    // necessary to correctly position the selection box.
     setTimeout(() => {
       this.map.addControl(this.overviewMapControl);
       this.setOlStyle(this.conf.color);
+      requestAnimationFrame(() => {
+        this.overviewMapControl.render();
+      });
     }, 100);
   };
 

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -27,6 +27,8 @@ export default class OverviewMapController {
       rotateWithView: this.conf.rotateWithView
     });
 
+    this.setLayer(null);
+
     // TODO:
     // Workaround because without defering the following operation, OL will fail to render
     // the overview map control. Presumably because no sizes have been computed yet on the

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -38,7 +38,7 @@ export default class OverviewMapController {
    * @param {String} color The color to set.
    */
   setOlStyle (color) {
-    document.querySelector('.ol-overviewmap-map').classList.add('v-card');
+    document.querySelector('.ol-overviewmap-map').classList.add('v-card', 'ma-1');
 
     if (color) {
       if (ColorUtil.isCssColor(color)) {

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -21,12 +21,14 @@ export default class OverviewMapController {
 
     this.overviewMapControl = new OverviewMap({
       className: 'ol-overviewmap wgu-overviewmap',
-      collapsed: false,
-      collapsible: true
+      collapsed: this.conf.collapsed,
+      collapsible: this.conf.collapsible,
+      label: this.conf.label,
+      collapseLabel: this.conf.collapseLabel,
+      rotateWithView: this.conf.rotateWithView
     });
 
     this.map.addControl(this.overviewMapControl);
-    this.overviewMapControl.setRotateWithView(true);
     this.setOlStyle(this.conf.color);
   };
 

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -1,0 +1,53 @@
+import { OverviewMap } from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+
+/**
+ * Implementation of an OpenLayers based overview map.
+ */
+export default class OverviewMapController {
+  overviewMapControl = null;
+  map = null;
+
+  /**
+   * Construction
+   * @param {ol.Map} map OpenLayers map.
+   * @param {Object} overviewMapConf The overview map configuration object.
+   */
+  constructor (map, overviewMapConf) {
+    this.map = map;
+    this.conf = overviewMapConf || {};
+
+    this.overviewMapControl = new OverviewMap({
+      className: 'ol-overviewmap wgu-overviewmap',
+      collapsed: false
+    });
+
+    this.map.addControl(this.overviewMapControl);
+    this.overviewMapControl.setRotateWithView(true);
+  };
+
+  /**
+   * Set the layer to be displayed in the overview map.
+   * Remarks:
+   * As of OpenLayers 6 re-using the same layer instance between different map controls is no
+   * longer supported. The workaround used here is to create a shallow clone if the layer is a
+   * TileLayer by reusing the same source. This will cover most of the cases for background layers.
+   * For other layer types fallback to an OSM layer.
+   * @param {ol.layer.Base} layer The currently displayed layer.
+   */
+  setLayer (layer) {
+    this.layer = (layer instanceof TileLayer)
+      ? new TileLayer({
+        extent: layer.getExtent(),
+        source: layer.getSource()
+      })
+      : new TileLayer({
+        source: new OSM()
+      });
+
+    const overviewMap = this.overviewMapControl.getOverviewMap();
+    overviewMap.getLayers().clear();
+    overviewMap.addLayer(this.layer);
+  }
+}

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -9,6 +9,7 @@ import ColorUtil from '../../util/Color';
 export default class OverviewMapController {
   overviewMapControl = null;
   map = null;
+  layer = null;
 
   /**
    * Construction
@@ -31,6 +32,22 @@ export default class OverviewMapController {
     this.map.addControl(this.overviewMapControl);
     this.setOlStyle(this.conf.color);
   };
+
+  /**
+   * Unregister the OpenLayers overview map.
+   */
+  destroy () {
+    if (this.layer) {
+      const overviewMap = this.overviewMapControl.getOverviewMap();
+      overviewMap.getLayers().clear();
+    }
+    if (this.map) {
+      this.map.removeControl(this.overviewMapControl);
+    }
+    this.layer = null;
+    this.map = null;
+    this.overviewMapControl = null;
+  }
 
   /**
    * Sets the background color of the OL expand button to the given color and applies a

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -1,6 +1,7 @@
 import { OverviewMap } from 'ol/control';
 import TileLayer from 'ol/layer/Tile';
 import OSM from 'ol/source/OSM';
+import ColorUtil from '../../util/Color';
 
 /**
  * Implementation of an OpenLayers based overview map.
@@ -12,20 +13,46 @@ export default class OverviewMapController {
   /**
    * Construction
    * @param {ol.Map} map OpenLayers map.
-   * @param {Object} overviewMapConf The overview map configuration object.
+   * @param {Object} config The overview map configuration object.
    */
-  constructor (map, overviewMapConf) {
+  constructor (map, config) {
     this.map = map;
-    this.conf = overviewMapConf || {};
+    this.conf = config || {};
 
     this.overviewMapControl = new OverviewMap({
       className: 'ol-overviewmap wgu-overviewmap',
-      collapsed: false
+      collapsed: false,
+      collapsible: true
     });
 
     this.map.addControl(this.overviewMapControl);
     this.overviewMapControl.setRotateWithView(true);
+    this.setOlStyle(this.conf.color);
   };
+
+  /**
+   * Sets the background color of the OL expand button to the given color and applies a
+   * vuetify card like style to the inner overview map .
+   * @param {String} color The color to set.
+   */
+  setOlStyle (color) {
+    document.querySelector('.ol-overviewmap-map').classList.add('v-card');
+
+    if (color) {
+      if (ColorUtil.isCssColor(color)) {
+        if (document.querySelector('.ol-overviewmap')) {
+          document.querySelector('.ol-overviewmap button').style.backgroundColor = color;
+          document.querySelector('.ol-overviewmap').style.borderColor = color;
+        }
+      } else {
+        const [colorName, colorModifier] = color.toString().trim().split(' ', 2);
+        if (document.querySelector('.ol-overviewmap')) {
+          document.querySelector('.ol-overviewmap button').classList.add(colorName);
+          document.querySelector('.ol-overviewmap button').classList.add(colorModifier);
+        }
+      }
+    }
+  }
 
   /**
    * Set the layer to be displayed in the overview map.

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -1,7 +1,6 @@
 import { OverviewMap } from 'ol/control';
 import TileLayer from 'ol/layer/Tile';
 import OSM from 'ol/source/OSM';
-import ColorUtil from '../../util/Color';
 
 /**
  * Implementation of an OpenLayers based overview map.
@@ -14,23 +13,28 @@ export default class OverviewMapController {
   /**
    * Construction
    * @param {ol.Map} map OpenLayers map.
+   * @param {HTMLElement} target The target container to render the control.
    * @param {Object} config The overview map configuration object.
    */
-  constructor (map, config) {
+  constructor (map, target, config) {
     this.map = map;
     this.conf = config || {};
 
     this.overviewMapControl = new OverviewMap({
-      className: 'ol-overviewmap wgu-overviewmap',
-      collapsed: this.conf.collapsed,
-      collapsible: this.conf.collapsible,
-      label: this.conf.label,
-      collapseLabel: this.conf.collapseLabel,
+      className: 'ol-overviewmap wgu-overviewmap-ctrl',
+      target: target,
+      collapsible: false,
       rotateWithView: this.conf.rotateWithView
     });
 
-    this.map.addControl(this.overviewMapControl);
-    this.setOlStyle(this.conf.color);
+    // TODO:
+    // Workaround because without defering the following operation, OL will fail to render
+    // the overview map control. Presumably because no sizes have been computed yet on the
+    // target DOM element. Currently the selection box is also displaced initially.
+    setTimeout(() => {
+      this.map.addControl(this.overviewMapControl);
+      this.setOlStyle(this.conf.color);
+    }, 100);
   };
 
   /**
@@ -50,27 +54,11 @@ export default class OverviewMapController {
   }
 
   /**
-   * Sets the background color of the OL expand button to the given color and applies a
-   * vuetify card like style to the inner overview map .
+   * Applies a vuetify card like style to the inner overview map.
    * @param {String} color The color to set.
    */
   setOlStyle (color) {
     document.querySelector('.ol-overviewmap-map').classList.add('v-card', 'ma-1');
-
-    if (color) {
-      if (ColorUtil.isCssColor(color)) {
-        if (document.querySelector('.ol-overviewmap')) {
-          document.querySelector('.ol-overviewmap button').style.backgroundColor = color;
-          document.querySelector('.ol-overviewmap').style.borderColor = color;
-        }
-      } else {
-        const [colorName, colorModifier] = color.toString().trim().split(' ', 2);
-        if (document.querySelector('.ol-overviewmap')) {
-          document.querySelector('.ol-overviewmap button').classList.add(colorName);
-          document.querySelector('.ol-overviewmap button').classList.add(colorModifier);
-        }
-      }
-    }
   }
 
   /**

--- a/src/components/overviewmap/OverviewMapController.js
+++ b/src/components/overviewmap/OverviewMapController.js
@@ -64,7 +64,7 @@ export default class OverviewMapController {
    * @param {String} color The color to set.
    */
   setOlStyle (color) {
-    document.querySelector('.ol-overviewmap-map').classList.add('v-card', 'ma-1');
+    document.querySelector('.ol-overviewmap-map').classList.add('v-card', 'ma-0');
   }
 
   /**

--- a/src/components/overviewmap/OverviewMapPanel.vue
+++ b/src/components/overviewmap/OverviewMapPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-sheet :color="color" :dark="dark" :width="width" :height="height"
+  <v-sheet :width="width" :height="height"
     elevation="8" class="pa-1" ref="overviewmapPanel">
   </v-sheet>
 </template>
@@ -11,8 +11,6 @@
     name: 'wgu-overviewmap-panel',
     mixins: [Mapable],
     props: {
-      dark: { type: Boolean, required: true },
-      color: { type: String, required: true },
       rotateWithView: { type: Boolean, required: true },
       width: { type: Number, required: true },
       height: { type: Number, required: true }

--- a/src/components/overviewmap/OverviewMapPanel.vue
+++ b/src/components/overviewmap/OverviewMapPanel.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-sheet :color="color" :dark="dark" elevation="8" ref="overviewmapPanel">
+  <v-sheet :color="color" :dark="dark" :width="width" :height="height"
+    elevation="8" class="pa-1" ref="overviewmapPanel">
   </v-sheet>
 </template>
 
@@ -11,8 +12,10 @@
     mixins: [Mapable],
     props: {
       dark: { type: Boolean, required: true },
-      color: { type: String, required: false, default: 'white' },
-      rotateWithView: { type: Boolean, required: false, default: true }
+      color: { type: String, required: true },
+      rotateWithView: { type: Boolean, required: true },
+      width: { type: Number, required: true },
+      height: { type: Number, required: true }
     },
     data () {
       return {

--- a/src/components/overviewmap/OverviewMapPanel.vue
+++ b/src/components/overviewmap/OverviewMapPanel.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-sheet :color="color" :dark="dark" elevation="8" ref="overviewmapPanel">
+  </v-sheet>
+</template>
+
+<script>
+  import { Mapable } from '../../mixins/Mapable';
+  import OverviewMapController from './OverviewMapController';
+  export default {
+    name: 'wgu-overviewmap-panel',
+    mixins: [Mapable],
+    props: {
+      dark: { type: Boolean, required: true },
+      color: { type: String, required: false, default: 'white' },
+      rotateWithView: { type: Boolean, required: false, default: true }
+    },
+    data () {
+      return {
+        layers: []
+      }
+    },
+    mounted () {
+      this.createOverviewMapCtrl();
+    },
+    destroyed () {
+      this.destroyOverviewMapCtrl();
+    },
+    methods: {
+      /**
+       * This function is executed, after the map is bound (see mixins/Mapable).
+       * Bind to the layers from the OpenLayers map.
+       */
+      onMapBound () {
+        this.layers = this.map.getLayers().getArray();
+        this.createOverviewMapCtrl();
+      },
+      /**
+       * This function is executed, before the map is unbound (see mixins/Mapable)
+       */
+      onMapUnbound () {
+        this.destroyOverviewMapCtrl();
+      },
+      /**
+       * Creates the OpenLayers overview map control.
+       */
+      createOverviewMapCtrl () {
+        const panel = this.$refs.overviewmapPanel;
+        if (this.map && panel && !this.overviewMap) {
+          this.overviewMap = new OverviewMapController(this.map, panel.$el, this.$props);
+        }
+      },
+      /**
+       * Tears down the OpenLayers overview map control.
+       */
+      destroyOverviewMapCtrl () {
+        if (this.overviewMap) {
+          this.overviewMap.destroy();
+          this.overviewMap = undefined;
+        }
+      }
+    },
+    computed: {
+      /**
+       * Reactive property to return the currently visible OpenLayers background layer.
+       * To disambiguate multiple selected background layers - which may occur programmatically -
+       * this returns the first in the list of background layers.
+       */
+      selectedBgLayer () {
+        return this.layers
+          .filter(layer => layer.get('isBaseLayer'))
+          .reverse()
+          .find(layer => layer.getVisible());
+      }
+    },
+    watch: {
+      /**
+       * Watch for background layer selection change.
+       */
+      selectedBgLayer () {
+        this.overviewMap.setLayer(this.selectedBgLayer);
+      }
+    }
+  }
+</script>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -33,6 +33,10 @@
     "title": "Hintergrundkarte auswählen"
   },
 
+  "wgu-overviewmap": {
+    "title": "Übersichtskarte anzeigen"
+  },
+
   "wgu-geocoder": {
     "title": "Adress-Suche",
     "placeHolder": "Adresse suchen"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,6 +33,10 @@
     "title": "Change background map"
   },
 
+  "wgu-overviewmap": {
+    "title": "Show overview map"
+  },
+
   "wgu-geocoder": {
     "title": "Address Search",
     "placeHolder": "Search for an address"

--- a/src/util/ViewAnimation.js
+++ b/src/util/ViewAnimation.js
@@ -23,7 +23,7 @@ const ViewAnimationUtil = {
     };
 
     const appConfig = Vue.prototype.$appConfig;
-    const animType = appConfig.viewAnimation?.type;
+    const animType = appConfig?.viewAnimation?.type;
     return animations[animType] || animations['default'];
   },
 
@@ -37,7 +37,7 @@ const ViewAnimationUtil = {
    */
   getOptions (options) {
     const appConfig = Vue.prototype.$appConfig;
-    return options || appConfig.viewAnimation?.options || {};
+    return options || appConfig?.viewAnimation?.options || {};
   },
 
   /**

--- a/test/unit/specs/components/overviewmap/OverviewMap.spec.js
+++ b/test/unit/specs/components/overviewmap/OverviewMap.spec.js
@@ -1,0 +1,89 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+import OverviewMap from '@/components/overviewmap/OverviewMap';
+
+describe('overviewmap/OverviewMap.vue', () => {
+  const vuetify = new Vuetify();
+
+  it('is defined', () => {
+    expect(OverviewMap).to.not.be.an('undefined');
+  });
+
+  describe('props', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(OverviewMap, {
+        vuetify
+      });
+      vm = comp.vm
+    });
+
+    it('has correct default props', () => {
+      expect(vm.icon).to.equal('zoom_out_map');
+      expect(vm.visible).to.equal(true);
+      expect(vm.rotateWithView).to.equal(true);
+      expect(vm.width).to.equal(164);
+      expect(vm.height).to.equal(178);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('data', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(OverviewMap, {
+        vuetify
+      });
+      vm = comp.vm;
+    });
+
+    it('has correct default data', () => {
+      expect(vm.open).to.equal(true);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('user interactions', () => {
+    let comp;
+    let vm;
+
+    // Remarks: The following is necessary to avoid warnings.
+    //  For reasons not fully understood the test utils will fail to attach
+    //  the v-menu to the wgu-overviewmap-wrapper div element created
+    //  in the component.
+    const div = document.createElement('div');
+    div.id = 'wgu-overviewmap-wrapper';
+    document.body.appendChild(div);
+
+    beforeEach(() => {
+      comp = mount(OverviewMap, {
+        vuetify
+      });
+      vm = comp.vm;
+    });
+
+    it('button click switches open', done => {
+      expect(vm.open).to.equal(true);
+
+      const button = comp.findComponent({ name: 'v-btn' });
+      button.trigger('click');
+
+      vm.$nextTick(() => {
+        expect(vm.open).to.equal(false);
+        done();
+      });
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+});

--- a/test/unit/specs/components/overviewmap/OverviewMapPanel.spec.js
+++ b/test/unit/specs/components/overviewmap/OverviewMapPanel.spec.js
@@ -1,0 +1,146 @@
+
+import { shallowMount } from '@vue/test-utils';
+import OverviewMapPanel from '@/components/overviewmap/OverviewMapPanel';
+import OlMap from 'ol/Map';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+
+const moduleProps = {
+  'rotateWithView': true,
+  'width': 164,
+  'height': 178
+};
+
+describe('overviewmap/OverviewMapPanel.vue', () => {
+  it('is defined', () => {
+    expect(OverviewMapPanel).to.not.be.an('undefined');
+  });
+
+  it('has a mounted hook', () => {
+    expect(OverviewMapPanel.mounted).to.be.a('function');
+  });
+
+  describe('props', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(OverviewMapPanel, {
+        propsData: moduleProps
+      });
+      vm = comp.vm;
+    });
+
+    it('has correct props', () => {
+      expect(vm.rotateWithView).to.equal(true);
+      expect(vm.width).to.equal(164);
+      expect(vm.height).to.equal(178);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('data', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(OverviewMapPanel, {
+        propsData: moduleProps
+      });
+      vm = comp.vm;
+    });
+
+    it('has correct default data', () => {
+      expect(typeof OverviewMapPanel.data).to.equal('function');
+      expect(vm.layers).to.be.an('array');
+      expect(vm.layers.length).to.eql(0);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('computed properties', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(OverviewMapPanel, {
+        propsData: moduleProps
+      });
+      vm = comp.vm;
+    });
+
+    it('detects selected base layer', () => {
+      const layerIn = new VectorLayer({
+        visible: true,
+        isBaseLayer: true,
+        source: new VectorSource()
+      });
+      const layerOut = new VectorLayer({
+        visible: true,
+        isBaseLayer: false,
+        source: new VectorSource()
+      });
+      const map = new OlMap({
+        layers: [layerIn, layerOut]
+      });
+      vm.map = map;
+      vm.onMapBound();
+
+      expect(vm.selectedBgLayer).to.equal(layerIn);
+    });
+
+    it('selectedBgLayer is synced with the layer stack', () => {
+      const layerIn = new VectorLayer({
+        visible: true,
+        isBaseLayer: true,
+        source: new VectorSource()
+      });
+      const layerOut = new VectorLayer({
+        visible: true,
+        isBaseLayer: true,
+        source: new VectorSource()
+      });
+      const map = new OlMap({
+        layers: [layerIn]
+      });
+      vm.map = map;
+      vm.onMapBound();
+
+      expect(vm.selectedBgLayer).to.equal(layerIn);
+
+      layerIn.setVisible(false);
+      map.addLayer(layerOut);
+
+      expect(vm.selectedBgLayer).to.equal(layerOut);
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+
+  describe('methods', () => {
+    let comp;
+    let vm;
+    beforeEach(() => {
+      comp = shallowMount(OverviewMapPanel, {
+        propsData: moduleProps
+      });
+      vm = comp.vm;
+    });
+
+    it('are implemented', () => {
+      expect(typeof vm.onMapBound).to.equal('function');
+      expect(typeof vm.onMapUnbound).to.equal('function');
+      expect(typeof vm.createOverviewMapCtrl).to.equal('function');
+      expect(typeof vm.destroyOverviewMapCtrl).to.equal('function');
+    });
+
+    afterEach(() => {
+      comp.destroy();
+    });
+  });
+});


### PR DESCRIPTION
This branch adds OpenLayers overview maps as a configurable component (closes #204).
![wegue_overview_map](https://user-images.githubusercontent.com/46027124/142389241-e5a859aa-f5ef-4772-86b0-62d855b22199.png)

The control will be added to the map, when a top level `overviewMap` configuration option is declared.
I added an example to various app templates, e.g.

```JSON
 "overviewMap" : {
    "collapsible": true,
    "collapsed": false
  }
```



