### PR TITLE
Enable online development using Gitpod

### DIFF
--- a/.gitpod
+++ b/.gitpod
@@ -8,4 +8,3 @@ tasks:
 vscode:
   extensions:
     - dbaeumer.vscode-eslint
-    

--- a/.gitpod
+++ b/.gitpod
@@ -1,0 +1,11 @@
+# This is a configuration for working with the gitpod.io online IDE
+ports:
+  - port: 8081
+    onOpen: open-preview
+tasks:
+  - init: npm install && npm run init:app
+    command: npm run dev
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint
+    

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ Build a Wegue Docker Image as follows:
 docker build -t meggsimum/wegue:latest .
 ```
 
+## Developing online using Gitpod.io
+
+Gitpod.io is an online IDE using VS Code that also provides a terminal and enables live preview. A registration is required but can be done with a GitHub account. 
+
+Open [gitpod.io/#https://github.com/meggsimum/wegue/](https://gitpod.io/#https://github.com/meggsimum/wegue/) to get started. 
+
+Wegue will automatically be initiated and your Wegue application can be previewed in a pane of the online IDE. The live preview of Wegue can also be seen in another browser tab by prefixing your workspace sub-URL with `8081-`. For example  `https://8081-YOUR-WORKSPACE-NAME.ws-eu25.gitpod.io`.
+
 ## Who do I talk to?
 You need more information or support? Please contact us at:
 


### PR DESCRIPTION
[Gitpod](https://gitpod.io) is an online IDE that also provides live preview of the web application. This PR makes Wegue ready for that.

You can try it now with: **https://gitpod.io/#https://github.com/JakobMiksch/wegue/tree/gitpod**

It will automatically do the setup steps and will launch a Wegue application that can be seen in your browser. 

This is useful for workshops, because no dev setup needs to be prepared. 

![image](https://user-images.githubusercontent.com/15704517/148574849-08ce5829-928b-42ba-a512-9d72810e3176.png)
