### PR TITLE
Add more rules to weaken linter in dev mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,9 @@ module.exports = {
 
     // weaken some rules in development mode
     'no-multiple-empty-lines': process.env.NODE_ENV  === 'development' ? 'warn' : 'error',
-    'no-unused-vars': process.env.NODE_ENV  === 'development' ? 'warn' : 'error'
+    'no-unused-vars': process.env.NODE_ENV  === 'development' ? 'warn' : 'error',
+    'space-before-blocks': process.env.NODE_ENV  === 'development' ? 'warn' : 'error',
+    'space-before-function-paren': process.env.NODE_ENV  === 'development' ? 'warn' : 'error',
+    'object-curly-spacing': process.env.NODE_ENV  === 'development' ? 'warn' : 'error',
   }
 }


### PR DESCRIPTION
This pull request weakens more eslint rules when using dev-mode:

- `space-before-blocks`
- `space-before-function-paren`
- `object-curly-spacing`

This helps to be more productive while making prototypes in Wegue. But of course, this does not affect the proper checking of rules when running `npm run build`.
    