### PR TITLE
Add a sample module

### DIFF
--- a/app-starter/WguAppTemplate.vue
+++ b/app-starter/WguAppTemplate.vue
@@ -81,6 +81,7 @@
   import MapLoadingStatus from '../src/components/progress/MapLoadingStatus'
   import AttributeTableWin from '../src/components/attributeTable/AttributeTableWin.vue'
   import MapRecorderWin from '../src/components/maprecorder/MapRecorderWin'
+  import SampleModuleWin from './components/SampleModule.vue'
 
   export default {
     name: 'wgu-app-tpl',
@@ -99,7 +100,8 @@
       'wgu-infoclick-win': InfoClickWin,
       'wgu-maploading-status': MapLoadingStatus,
       'wgu-attributetable-win': AttributeTableWin,
-      'wgu-maprecorder-win': MapRecorderWin
+      'wgu-maprecorder-win': MapRecorderWin,
+      'sample-module-win': SampleModuleWin
     },
     data () {
       return {

--- a/app-starter/components/SampleModule.vue
+++ b/app-starter/components/SampleModule.vue
@@ -1,0 +1,53 @@
+<!-- This is a minimal module that helps getting started building custom modules -->
+
+<!-- The template contains the HTML of our module  -->
+<template>
+  <!--
+  Our module builds upon the 'wgu-module-card' and handles the integration into Wegue
+  -->
+  <wgu-module-card v-bind="$attrs"
+      moduleName="sample-module"
+      class="sample-module"
+      :icon="icon">
+    <!--
+    Here goes the actual content of the module
+    We use a the component 'v-card-text' from the Vuetify library
+    in which we write a simple text
+    -->
+    <v-card-text>
+      <!-- The text itself is located in the language specific translation files -->
+      {{ $t('sample-module.text') }}
+    </v-card-text>
+  </wgu-module-card>
+</template>
+
+<!-- This part contains the logic of our module and is written in JavaScript -->
+<script>
+  // the module card is a the template for a typical Wegue module
+  import ModuleCard from '../../src/components/modulecore/ModuleCard';
+
+  /**
+   * The part below is specific to the Vue.js framework
+   * and is reduced to a minimum for the moment
+   */
+  export default {
+    name: 'sample-module',
+    inheritAttrs: false,
+    components: {
+      'wgu-module-card': ModuleCard
+    },
+    props: {
+      icon: { type: String, required: false, default: 'star' }
+    }
+  }
+</script>
+
+<!-- Here we do the styling of our module -->
+<style scoped>
+  /* our module has the class '.sample-module' and we reference it here */
+  .sample-module {
+    left: auto !important;
+    top:300px !important;
+    right: 10px;
+  }
+</style>

--- a/app-starter/components/SampleModule.vue
+++ b/app-starter/components/SampleModule.vue
@@ -1,53 +1,111 @@
-<!-- This is a minimal module that helps getting started building custom modules -->
-
 <!-- The template contains the HTML of our module  -->
 <template>
   <!--
-  Our module builds upon the 'wgu-module-card' and handles the integration into Wegue
+  Our module builds upon the 'wgu-module-card'
+  it handles the integration into Wegue
+  like adding a button in the toolbar
   -->
-  <wgu-module-card v-bind="$attrs"
-      moduleName="sample-module"
-      class="sample-module"
-      :icon="icon">
+  <wgu-module-card
+    v-bind="$attrs"
+    moduleName="sample-module"
+    class="sample-module"
+    :icon="icon"
+  >
     <!--
     Here goes the actual content of the module
     We use a the component 'v-card-text' from the Vuetify library
-    in which we write a simple text
     -->
     <v-card-text>
-      <!-- The text itself is located in the language specific translation files -->
-      {{ $t('sample-module.text') }}
+      <!--
+      Note the double curly brackets.
+      They contain variables that dynamically change.
+      The way how they change is done in the <script> part
+      -->
+      <b>Zoom:</b> {{ zoom }} <br />
+      <b>Center:</b> {{ center }}
     </v-card-text>
   </wgu-module-card>
 </template>
-
-<!-- This part contains the logic of our module and is written in JavaScript -->
 <script>
-  // the module card is a the template for a typical Wegue module
-  import ModuleCard from '../../src/components/modulecore/ModuleCard';
+// the module card is a the template for a typical Wegue module
+import ModuleCard from '../../src/components/modulecore/ModuleCard';
+// we import a so called "mixin" that helps us to interact with the map
+import { Mapable } from '../../src/mixins/Mapable';
+// an OpenLayers helper function to display coordinates
+import { toStringXY } from 'ol/coordinate';
+// an OpenLayer helper function to transform coordinate reference systems
+import { transform } from 'ol/proj.js';
 
-  /**
-   * The part below is specific to the Vue.js framework
-   * and is reduced to a minimum for the moment
-   */
-  export default {
-    name: 'sample-module',
-    inheritAttrs: false,
-    components: {
-      'wgu-module-card': ModuleCard
+export default {
+  name: 'sample-module',
+  // make sure to register the 'Mapable' mixin
+  mixins: [Mapable],
+  inheritAttrs: false,
+  components: {
+    'wgu-module-card': ModuleCard
+  },
+  props: {
+    icon: { type: String, required: false, default: 'star' }
+  },
+  // here we define variables that are used in the HTML above
+  data () {
+    return {
+      zoom: '',
+      center: ''
+    };
+  },
+  methods: {
+    /**
+     * This function is called once the map is bound to the application
+     */
+    onMapBound () {
+      // the mixin 'Mapable' provides access to our OpenLayer map
+      // via the variable 'this.map'
+      // here we get the 'view' from the map
+      const view = this.map.getView();
+      // we call the function to extract zoom and center from the map
+      // once it is initially created
+      this.extractMapViewProperties(view);
+      // to ensure that we react on updates of the map,
+      // we need to register a listener
+      view.on('change', () => {
+        // always when the map view is changing we extract
+        // the current zoom and center from it
+        this.extractMapViewProperties(view);
+      });
     },
-    props: {
-      icon: { type: String, required: false, default: 'star' }
+
+    /**
+     * We extract the current zoom and center coordinates
+     * from the OpenLayers view and store the values
+     * to our module's 'zoom' and 'center' variables
+     *
+     * @param {ol.View} view The OpenLayers view
+     */
+    extractMapViewProperties (view) {
+      this.zoom = Math.round(view.getZoom());
+
+      const sourceCrs = view.getProjection();
+      const targetCrs = 'EPSG:4326';
+
+      // we transform the coordinates from the map projection to WGS84 (EPSG:3857)
+      const centerTargetCrs = transform(view.getCenter(), sourceCrs, targetCrs);
+
+      // create a readable string from the coordinates
+      this.center = toStringXY(
+        centerTargetCrs,
+        4 // <-- number of digits after comma
+      );
     }
   }
+};
 </script>
-
 <!-- Here we do the styling of our module -->
 <style scoped>
-  /* our module has the class '.sample-module' and we reference it here */
-  .sample-module {
-    left: auto !important;
-    top:300px !important;
-    right: 10px;
-  }
+/* our module has the class '.sample-module' and we reference it here */
+.sample-module {
+  left: auto !important;
+  top: 300px !important;
+  right: 10px;
+}
 </style>

--- a/app-starter/locales/de.json
+++ b/app-starter/locales/de.json
@@ -63,5 +63,10 @@
     "htmlContent": "<b>WebGIS basierend auf OpenLayers und Vue.js</b></br>Vorlagen und wiederverwertbare Komponenten für Web-Kartenanwendungen mit OpenLayers und Vue.js",
     "infoLinkUrl": "http://wegue.org/",
     "infoLinkText": "Mehr Informationen"
+  },
+
+  "sample-module": {
+    "title": "Beispiel Modul",
+    "text": "Hallo Wegue"
   }
 }

--- a/app-starter/locales/en.json
+++ b/app-starter/locales/en.json
@@ -63,5 +63,10 @@
     "htmlContent": "<b>WebGIS with OpenLayers and Vue.js</b> Template and re-usable components for webmapping applications with OpenLayers and Vue.js",
     "infoLinkUrl": "http://wegue.org/",
     "infoLinkText": "More info"
+  },
+
+  "sample-module": {
+    "title": "Sample Module",
+    "text": "Hello Wegue"
   }
 }

--- a/app-starter/static/app-conf.json
+++ b/app-starter/static/app-conf.json
@@ -266,6 +266,11 @@
     },
     "wgu-localeswitcher": {
       "target": "toolbar"
+    },
+    "sample-module": {
+      "target": "toolbar",
+      "win": "floating",
+      "icon": "star"
     }
   }
 }


### PR DESCRIPTION
fixes #265 

- This PR adds a minimal module to `app-starter` that should help new users to create their custom modules. 
- This new `SampleModule.vue` is extensively commented to explain the basic anatomy of a module
- It contains a simple access of the OpenLayers map to make creating custom map-related modules easier

![image](https://user-images.githubusercontent.com/15704517/153872321-891845b2-1d4e-42c3-b508-c91722b15f60.png)
