### PR TITLE
Infoclick vuetify tables

### DIFF
--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -1,31 +1,19 @@
 <template>
 
-  <table 
-    :class="{
-      'wgu-coordstable': true,
-      'light-theme': !isDarkTheme,
-      'dark-theme': isDarkTheme
-    }"
-    v-if="coordRows"
-    style="border: 2px solid var(--v-secondary-base);"
-  >
-    <thead>
-      <tr>
-        <th v-for="(entry, key) in coordRows" :key="key">
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="(value, key) in coordRows" :key="key">
-        <td class="key-td">
-          {{key}}
-        </td>
-        <td class="val-td">
-          {{value}}
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <v-card-text class="px-0" v-if="coordRows">
+    <v-simple-table class="wgu-coordstable">
+      <tbody>
+        <tr v-for="(value, key) in coordRows" :key="key">
+          <td class="key-td">
+            {{key}}
+          </td>
+          <td class="val-td">
+            {{value}}
+          </td>
+        </tr>
+      </tbody>
+    </v-simple-table>
+  </v-card-text>
 
 </template>
 
@@ -33,11 +21,9 @@
 
 import { transform } from 'ol/proj.js';
 import { toStringHDMS } from 'ol/coordinate';
-import { ColorTheme } from '../../mixins/ColorTheme';
 
 export default {
   name: 'wgu-coords-table',
-  mixins: [ColorTheme],
   props: {
     coordsData: { type: Object },
     showMapPos: { type: Boolean, required: false, default: true },
@@ -84,36 +70,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-
-table.wgu-coordstable {
-  margin-top: 12px;
-  width: 100%;
-}
-
-.wgu-coordstable table {
-  border-radius: 3px;
-}
-
-.wgu-coordstable.dark-theme td {
-  background-color: hsla(0, 0%, 98%, 0.03);
-}
-
-.wgu-coordstable.light-theme td {
-  background-color: hsla(0, 0%, 98%, 1);
-}
-
-.wgu-coordstable tr {
-  font-size: 16px;
-}
-
-.wgu-coordstable th, .wgu-coordstable td {
-  width: 200px;
-  padding: 5px 5px;
-}
-
 .wgu-coordstable td.key-td {
-  width: 160px;
-  padding: 5px 5px;
+  width: 40%;
 }
-
 </style>

--- a/src/components/infoclick/CoordsTable.vue
+++ b/src/components/infoclick/CoordsTable.vue
@@ -70,6 +70,10 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
+.wgu-coordstable {
+  word-break: break-word;
+}
+
 .wgu-coordstable td.key-td {
   width: 40%;
 }

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -1,40 +1,24 @@
 <template>
 
-  <table 
-  :class="{
-      'wgu-proptable': true,
-      'light-theme': !isDarkTheme,
-      'dark-theme': isDarkTheme
-    }"
-    v-if="show"
-    style="border: 2px solid var(--v-secondary-base);"
-  >
-    <thead>
-      <tr>
-        <th v-for="(entry, key) in properties" :key="key">
-        </th>
-      </tr>
-    </thead>
-    <tbody class="attr-tbody">
-      <tr v-for="(value, key) in properties" :key="key">
-        <td class="key-td">
-          {{key}}
-        </td>
-        <td class="val-td">
-          {{value}}
-        </td>
-      </tr>
-    </tbody>
-  </table>
-
+  <v-card-text class="px-0" v-if="show">
+    <v-simple-table class="wgu-proptable">
+      <tbody class="attr-tbody">
+        <tr v-for="(value, key) in properties" :key="key">
+          <td class="key-td">
+            {{key}}
+          </td>
+          <td class="val-td">
+            {{value}}
+          </td>
+        </tr>
+      </tbody>
+    </v-simple-table>
+  </v-card-text>
 </template>
 
 <script>
-import { ColorTheme } from '../../mixins/ColorTheme';
-
 export default {
   name: 'wgu-property-table',
-  mixins: [ColorTheme],
   props: {
     properties: { type: Object }
   },
@@ -51,33 +35,7 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-
-table.wgu-proptable {
- border-radius: 3px;
- /* background-color: #fff; */
- width: 100%;
-}
-
-.wgu-proptable.dark-theme td {
-  background-color: hsla(0, 0%, 98%, 0.03);
-}
-
-.wgu-proptable.light-theme td {
-  background-color: hsla(0, 0%, 98%, 1);
-}
-
-.wgu-proptable tr {
-  font-size: 16px;
-}
-
-.wgu-proptable th, .wgu-proptable td {
- width: 200px;
- padding: 5px 5px;
-}
-
 .wgu-proptable td.key-td {
-  width: 160px;
-  padding: 5px 5px;
+  width: 40%;
 }
-
 </style>

--- a/src/components/infoclick/PropertyTable.vue
+++ b/src/components/infoclick/PropertyTable.vue
@@ -35,6 +35,10 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
+.wgu-proptable {
+  word-break: break-word;
+}
+
 .wgu-proptable td.key-td {
   width: 40%;
 }


### PR DESCRIPTION
This pull request changes the plain html tables of the infoclick module into a vuetify based v-simple-table. The idea is to get rid of a lot of custom css formatting and use a control that is already theming compliant. 
This is a follow up task to #262 and was previously mentioned there.

Here's a screenshot of the result:
![wegue_map_click_info](https://user-images.githubusercontent.com/46027124/143911856-1a6d2c37-7255-4dac-af0f-44b0eceb54b0.png)