### PR TITLE
Refactor map recorder tests to avoid Chrome-specific MIME type checks

### DIFF
--- a/tests/unit/specs/components/maprecorder/MapRecorderWin.spec.js
+++ b/tests/unit/specs/components/maprecorder/MapRecorderWin.spec.js
@@ -54,8 +54,8 @@ describe('maprecorder/MapRecorderWin.vue', () => {
       expect(vm.timerHandle).to.be.null;
       expect(vm.error).to.be.false;
       // Supported codecs under chrome.
-      expect(vm.mimeType).to.equal('video/webm');
-      expect(vm.mimeTypes).to.have.lengthOf(3);
+      expect(vm.mimeType).to.be.a('string');
+      expect(vm.mimeTypes).to.be.an('array');
     });
 
     afterEach(() => {
@@ -71,12 +71,9 @@ describe('maprecorder/MapRecorderWin.vue', () => {
       vm = comp.vm;
     });
 
-    it('correct supported mime types under chrome', () => {
+    it('supports at least one mime type under chrome', () => {
       const mimeTypes = vm.getSupportedMimeTypes();
-      expect(mimeTypes).to.have.lengthOf(3);
-      expect(mimeTypes[0]).to.equal('video/webm');
-      expect(mimeTypes[1]).to.equal('video/mp4');
-      expect(mimeTypes[2]).to.equal('video/x-matroska');
+      expect(mimeTypes).to.be.an('array').that.is.not.empty;
     });
 
     it('start / stop recording sets correct states', () => {


### PR DESCRIPTION
This PR improves the maintainability of the map recorder tests by removing Chrome-dependent MIME type assertions - as suggested in #407.