### PR TITLE
Add .eslintcache to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,14 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Build related
 node_modules
 .DS_Store
 dist
 dist-ssr
 coverage
 *.local
+.eslintcache
 
 /cypress/videos/
 /cypress/screenshots/


### PR DESCRIPTION
Ignores .eslintcache - which is created by ESLint after recent dependency updates.