### PR TITLE
Backport #455: Restrict the measure tool draw interaction to the left mouse button

### DIFF
--- a/src/components/measuretool/OlMeasureController.js
+++ b/src/components/measuretool/OlMeasureController.js
@@ -74,8 +74,11 @@ export default class OlMeasureController {
     }
 
     const type = (measureType === 'area' ? 'Polygon' : 'LineString');
+    const leftClickOnly = (event) => event.originalEvent.button === 0;
+
     const draw = new DrawInteraction({
       source: me.source,
+      condition: leftClickOnly,
       type,
       maxPoints: measureType === 'angle' ? 2 : undefined,
       style: new Style({


### PR DESCRIPTION
This PR backports #455 fix on the `v2` branch as suggested in #438.