### PR TITLE
Fix parameter to define FeatureType in WFS 2.0.0

### DIFF
--- a/src/factory/Layer.js
+++ b/src/factory/Layer.js
@@ -232,14 +232,14 @@ export const LayerFactory = {
           version: lConf.version,
           request: 'GetFeature',
           outputFormat,
-          srsname: lConf.projection
+          srsName: lConf.projection
         };
 
         // add WFS version dependent feature limitation
         if (Number.isInteger(parseInt(lConf.maxFeatures))) {
           if (lConf.version.startsWith('1.')) {
             params.maxFeatures = lConf.maxFeatures;
-            params.typename = lConf.typeName;
+            params.typeName = lConf.typeName;
           } else {
             params.count = lConf.maxFeatures;
             params.typeNames = lConf.typeName;


### PR DESCRIPTION
This ensures that in WFS 2.0.0 `GetFeature` requests the parameter `typesNames` is used. `typename` is only valid for WFS 1. A lot of implementations seem also to accept `typename` for WFS 2. That is why we did not stumble over this earlier. 