### PR TITLE
Upgrade vite dependency to 7.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "sass-embedded": "^1.93.2",
         "sinon": "^21.0.0",
         "sinon-chai": "^3.7.0",
-        "vite": "^7.3.0",
+        "vite": "^7.3.2",
         "vite-plugin-vue-devtools": "^8.0.2",
         "vite-plugin-vuetify": "^2.1.2"
       },
@@ -9665,9 +9665,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
     "sass-embedded": "^1.93.2",
     "sinon": "^21.0.0",
     "sinon-chai": "^3.7.0",
-    "vite": "^7.3.0",
+    "vite": "^7.3.2",
     "vite-plugin-vue-devtools": "^8.0.2",
     "vite-plugin-vuetify": "^2.1.2"
   },
   "overrides": {
     "karma-vite": {
-      "vite": "^7.1.9"
+      "vite": "^7.3.2"
     }
   },
   "engines": {


### PR DESCRIPTION
Upgrades `vite` to version `7.3.2`, which adds a vulnerability patch, see [here](https://github.com/vitejs/vite/security/advisories/GHSA-p9ff-h696-f583).  