### PR TITLE
Do not reverse the list of map layers.

### DIFF
--- a/src/components/attributeTable/AttributeTableWin.vue
+++ b/src/components/attributeTable/AttributeTableWin.vue
@@ -72,8 +72,7 @@ export default {
           layer instanceof VectorLayer &&
           layer.get('lid') !== 'wgu-measure-layer' &&
           layer.get('lid') !== 'wgu-geolocator-layer'
-        )
-        .reverse();
+        );
     },
     /**
      * Reactive property to return the items object to bind to the selection menu.

--- a/src/components/bglayerswitcher/BgLayerList.vue
+++ b/src/components/bglayerswitcher/BgLayerList.vue
@@ -79,8 +79,7 @@ export default {
      */
     displayedLayers () {
       return this.layers
-        .filter(layer => layer.get('isBaseLayer'))
-        .reverse();
+        .filter(layer => layer.get('isBaseLayer'));
     },
     /**
      * Reactive property to return the currently visible OpenLayers background layer ID.

--- a/src/components/layerlist/LayerList.vue
+++ b/src/components/layerlist/LayerList.vue
@@ -41,8 +41,7 @@ export default {
      */
     displayedLayers () {
       return this.layers
-        .filter(layer => layer.get('displayInLayerList') !== false && !layer.get('isBaseLayer'))
-        .reverse();
+        .filter(layer => layer.get('displayInLayerList') !== false && !layer.get('isBaseLayer'));
     }
   }
 };

--- a/src/components/ol/Map.vue
+++ b/src/components/ol/Map.vue
@@ -203,7 +203,7 @@ export default {
       const layers = [];
       const appConfig = this.$appConfig;
       const mapLayersConfig = appConfig.mapLayers || [];
-      mapLayersConfig.reverse().forEach(function (lConf) {
+      mapLayersConfig.forEach(function (lConf) {
         // Some Layers may require a TileGrid object
         // Remarks: Passing null instead of undefined as parameters into the
         //  constructor of OpenLayers sources overwrites OpenLayers defaults.

--- a/src/components/overviewmap/OverviewMapPanel.vue
+++ b/src/components/overviewmap/OverviewMapPanel.vue
@@ -66,7 +66,6 @@ export default {
     selectedBgLayer () {
       return this.layers
         .filter(layer => layer.get('isBaseLayer'))
-        .reverse()
         .find(layer => layer.getVisible());
     }
   },

--- a/tests/unit/specs/components/ol/PermalinkController.spec.js
+++ b/tests/unit/specs/components/ol/PermalinkController.spec.js
@@ -172,7 +172,7 @@ describe('ol/Map.vue', () => {
         }
       });
 
-      expect(vm.permalinkController.getParamStr()).to.equal('#z=' + newZoom + '&c=8.9832%2C17.6789&r=0&l=ahocevar-imagewms%2Cahocevar-wms%2Cosm-bg');
+      expect(vm.permalinkController.getParamStr()).to.equal('#z=' + newZoom + '&c=8.9832%2C17.6789&r=0&l=osm-bg%2Cahocevar-wms%2Cahocevar-imagewms');
     });
 
     afterEach(() => {


### PR DESCRIPTION
This PR removes reversing of layer collections during both OpenLayers map initialization and layer list rendering. Layer order is now preserved consistently as declared in configuration files and runtime additions. This has the following practical consequences:
* Rendering z-order now follows native OpenLayers behavior (later layers render above earlier ones when sharing the same z-index)
* Dynamically added layers during runtime (e.g. DragDrop) now appear at the end of layer selection and management controls instead of at the top.